### PR TITLE
Add sinks to processor execution queue

### DIFF
--- a/situp-core/src/main/java/com/amazon/situp/Situp.java
+++ b/situp-core/src/main/java/com/amazon/situp/Situp.java
@@ -108,7 +108,7 @@ public class Situp {
                 .collect(Collectors.toList());
 
         final List<PluginSetting> sinkPluginSettings = pipelineConfiguration.getSink().getPluginSettings();
-        final Collection<Sink> sinks = sinkPluginSettings.stream().map(SinkFactory::newSink).collect(Collectors.toList());
+        final List<Sink> sinks = sinkPluginSettings.stream().map(SinkFactory::newSink).collect(Collectors.toList());
 
         final int processorThreads = getConfiguredThreadsOrDefault(processorConfiguration);
 

--- a/situp-core/src/main/java/com/amazon/situp/pipeline/ProcessWorker.java
+++ b/situp-core/src/main/java/com/amazon/situp/pipeline/ProcessWorker.java
@@ -4,15 +4,18 @@ import com.amazon.situp.model.record.Record;
 import com.amazon.situp.model.buffer.Buffer;
 import com.amazon.situp.model.processor.Processor;
 import com.amazon.situp.model.sink.Sink;
+import com.amazon.situp.pipeline.common.FutureHelper;
+import com.amazon.situp.pipeline.common.FutureHelperResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.Future;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ProcessWorker implements Runnable {
-    private static final Logger LOG = LoggerFactory.getLogger(Pipeline.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ProcessWorker.class);
 
     private final Buffer readBuffer;
     private final List<Processor> processors;
@@ -44,13 +47,13 @@ public class ProcessWorker implements Runnable {
                     for (final Processor processor : processors) {
                         records = processor.execute(records);
                     }
-                    postToSink(records);
+                    postToSink(records); //TODO use the response to ack the buffer
                 } else {
                     isQueueEmpty = true;
                 }
             } while (!isHalted || !isBufferEmpty()); //If pipeline is stopped, we try to empty the already buffered records ?
         } catch (final Exception ex) {
-            throw new IllegalStateException(ex);
+            LOG.error("Encountered exception during pipeline processing", ex); //do not halt the execution
         }
     }
 
@@ -65,10 +68,20 @@ public class ProcessWorker implements Runnable {
 
     /**
      * TODO Add isolator pattern - Fail if one of the Sink fails [isolator Pattern]
+     * Uses the pipeline method to publish to sinks, waits for each of the sink result to be true before attempting to
+     * process more records from buffer.
      */
-    private boolean postToSink(Collection<Record> records) {
-        LOG.debug("Pipeline Worker: Submitting {} processed records to sink", records.size());
-        sinks.forEach(sink -> sink.output(records));
-        return true;
+    private boolean postToSink(final Collection<Record> records) {
+        LOG.debug("Pipeline Worker: Submitting {} processed records to sinks", records.size());
+        boolean someSinksFailed;
+        final List<Future<Boolean>> sinkFutures = pipeline.publishToSinks(records);
+        final FutureHelperResult<Boolean> futureResults = FutureHelper.awaitFuturesIndefinitely(sinkFutures);
+        someSinksFailed = futureResults.getFailedReasons().size() != 0;
+        for(Boolean sinkResult : futureResults.getSuccessfulResults()) {
+            if(!sinkResult) {
+                return false;
+            }
+        }
+        return !someSinksFailed;
     }
 }

--- a/situp-core/src/main/java/com/amazon/situp/pipeline/common/FutureHelper.java
+++ b/situp-core/src/main/java/com/amazon/situp/pipeline/common/FutureHelper.java
@@ -1,0 +1,104 @@
+package com.amazon.situp.pipeline.common;
+
+import com.google.common.base.Stopwatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class FutureHelper {
+    private static final Logger LOG = LoggerFactory.getLogger(FutureHelper.class);
+
+    /**
+     * Helper method to handle the return of multiple futures. The method will return
+     * as soon as all the futures are complete or until the specified timeout duration.
+     * @param futureList
+     * @param duration
+     * @param timeUnit
+     * @param stopwatch
+     * @param <A>
+     * @return A list of completed, errored, and uncompleted future tasks.
+     */
+    public static <A> FutureHelperResult<A> awaitFutures(
+            final List<Future<A>> futureList,
+            long duration, TimeUnit timeUnit,
+            final Stopwatch stopwatch) {
+        final List<A> completedFutureResults = new ArrayList<>(futureList.size());
+        final List<Future<A>> uncompletedFutures = new ArrayList<>();
+        final List<Integer> uncompletedIndexes = new ArrayList<>();
+        final List<ExecutionException> failedExceptionList = new ArrayList<>();
+        final List<Integer> failedIndexes = new ArrayList<>();
+
+        final Queue<Future<A>> futureQueue = new LinkedList<>(futureList);
+        long totalMillisRemaining = timeUnit.toMillis(duration);
+
+        int index = -1;
+        while (!futureQueue.isEmpty()) {
+            stopwatch.reset();
+            stopwatch.start();
+            final Future<A> firstFuture = futureQueue.remove();
+            index++;
+            try {
+                if (totalMillisRemaining > 0) {
+
+                    final A value = firstFuture.get(totalMillisRemaining, TimeUnit.MILLISECONDS);
+                    completedFutureResults.add(value);
+
+                } else {
+                    if (firstFuture.isDone()) {
+                        //at this point the future should return immediately
+                        completedFutureResults.add(firstFuture.get(1, TimeUnit.MILLISECONDS));
+                    } else {
+                        uncompletedFutures.add(firstFuture);
+                        uncompletedIndexes.add(index);
+                    }
+                }
+            } catch (ExecutionException e) {
+                //There is some problem with the request
+                failedExceptionList.add(e);
+                failedIndexes.add(index);
+                LOG.error("FutureTask failed due to: ", e);
+            } catch (InterruptedException | TimeoutException t) {
+                //Out of time
+                uncompletedFutures.add(firstFuture);
+                uncompletedIndexes.add(index);
+            }
+            totalMillisRemaining -= stopwatch.elapsed(TimeUnit.MILLISECONDS);
+
+        }
+
+        return new FutureHelperResult<>(completedFutureResults, uncompletedFutures, uncompletedIndexes
+                ,failedExceptionList, failedIndexes);
+
+    }
+
+    public static <A> FutureHelperResult<A> awaitFuturesIndefinitely(final List<Future<A>> futureList) {
+        final List<A> completedFutureResults = new ArrayList<>(futureList.size());
+        final List<ExecutionException> failedExceptionList = new ArrayList<>();
+
+        final Queue<Future<A>> futureQueue = new LinkedList<>(futureList);
+        while(!futureQueue.isEmpty()) {
+            final Future<A> future = futureQueue.remove();
+            try{
+                if(future.isDone()) {
+                    completedFutureResults.add(future.get(1, TimeUnit.MILLISECONDS));
+                } else {
+                    futureQueue.add(future); //add it back to queue
+                }
+            } catch (ExecutionException e) {
+                failedExceptionList.add(e);
+                LOG.error("FutureTask failed due to: ", e);
+            } catch (InterruptedException | TimeoutException e) {
+                LOG.error("FutureTask is interrupted or timed out");
+            }
+        }
+        return new FutureHelperResult<>(completedFutureResults, failedExceptionList);
+    }
+}

--- a/situp-core/src/main/java/com/amazon/situp/pipeline/common/FutureHelperResult.java
+++ b/situp-core/src/main/java/com/amazon/situp/pipeline/common/FutureHelperResult.java
@@ -1,0 +1,52 @@
+package com.amazon.situp.pipeline.common;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+public class FutureHelperResult<T> {
+    private final List<T> successfulResults;
+    private final List<Future<T>> uncompletedFutures;
+    private final List<Integer> uncompletedIndexes;
+    private final List<ExecutionException> failedReasons;
+    private final List<Integer> failedIndexes;
+
+    public FutureHelperResult(
+            List<T> successfulResults,
+            List<Future<T>> uncompletedFutures,
+            List<Integer> uncompletedIndexes,
+            List<ExecutionException> failedReasons,
+            List<Integer> failedIndexes) {
+        this.successfulResults = successfulResults;
+        this.uncompletedFutures = uncompletedFutures;
+        this.uncompletedIndexes = uncompletedIndexes;
+        this.failedReasons = failedReasons;
+        this.failedIndexes = failedIndexes;
+    }
+
+    public FutureHelperResult(List<T> successfulResults, List<ExecutionException> failedReasons) {
+        this(successfulResults, Collections.emptyList(), Collections.emptyList(), failedReasons,
+                Collections.emptyList());
+    }
+
+    public List<T> getSuccessfulResults() {
+        return successfulResults;
+    }
+
+    public List<Future<T>> getUncompletedFutures() {
+        return uncompletedFutures;
+    }
+
+    public List<Integer> getUncompletedIndexes() {
+        return uncompletedIndexes;
+    }
+
+    public List<ExecutionException> getFailedReasons() {
+        return failedReasons;
+    }
+
+    public List<Integer> getFailedIndexes() {
+        return failedIndexes;
+    }
+}

--- a/situp-core/src/test/java/com/amazon/situp/pipeline/PipelineTests.java
+++ b/situp-core/src/test/java/com/amazon/situp/pipeline/PipelineTests.java
@@ -22,6 +22,7 @@ public class PipelineTests {
         List<Record<String>> preRun = testSink.getCollectedRecords();
         assertThat("Sink records are not empty before Pipeline execution", preRun.isEmpty());
         testPipeline.execute();
+        Thread.sleep(1000);
         testPipeline.stop();
         List<Record<String>> postRun = testSink.getCollectedRecords();
         assertThat("Pipeline sink has records different from expected", postRun, is(TestSource.TEST_DATA));


### PR DESCRIPTION
*Issue #, if available:* #12 

*Description of changes:*
1. Adds sinks output to processorExecutorService - _At the time of this writing, we are defaulting the minimum and maximum threads to no of sinks + processorThreads, We will be updating this at a later point. Also we are not leveraging the Future results to add back pressure to source but it will be addressed in changes for BlockingQueue or AckedQueue_



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
