### PR TITLE
Remove the doc count from the default policy

### DIFF
--- a/situp-plugins/elasticsearch/src/main/resources/raw-span-policy.json
+++ b/situp-plugins/elasticsearch/src/main/resources/raw-span-policy.json
@@ -9,7 +9,6 @@
           {
             "rollover": {
               "min_size": "50gb",
-              "min_doc_count": 50000,
               "min_index_age": "24h"
             }
           }


### PR DESCRIPTION
*Description of changes:*

 50K document is really low from query perspective for spans so we decided to remove the count from the policy. We can look into this in the future if scale comes as bottleneck.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
