### PR TITLE
Adding abstract implementations of Sink and Buffer

### DIFF
--- a/situp-api/src/main/java/com/amazon/situp/model/buffer/AbstractBuffer.java
+++ b/situp-api/src/main/java/com/amazon/situp/model/buffer/AbstractBuffer.java
@@ -1,0 +1,87 @@
+package com.amazon.situp.model.buffer;
+
+import com.amazon.situp.model.configuration.PluginSetting;
+import com.amazon.situp.model.metrics.MetricNames;
+import com.amazon.situp.model.metrics.PluginMetrics;
+import com.amazon.situp.model.record.Record;
+import java.util.Collection;
+import java.util.concurrent.TimeoutException;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
+
+/**
+ * Abstract implementation of the Buffer interface to record boilerplate metrics
+ */
+public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
+    protected final PluginMetrics pluginMetrics;
+    private final Counter recordsWrittenCounter;
+    private final Counter recordsReadCounter;
+    private final Counter writeTimeoutCounter;
+    private final Timer writeTimer;
+    private final Timer readTimer;
+
+    public AbstractBuffer(final PluginSetting pluginSetting) {
+        this.pluginMetrics = PluginMetrics.fromPluginSetting(pluginSetting);
+        this.recordsWrittenCounter = pluginMetrics.counter(MetricNames.RECORDS_WRITTEN);
+        this.recordsReadCounter = pluginMetrics.counter(MetricNames.RECORDS_READ);
+        this.writeTimeoutCounter = pluginMetrics.counter(MetricNames.WRITE_TIMEOUTS);
+        this.writeTimer = pluginMetrics.timer(MetricNames.WRITE_TIME_ELAPSED);
+        this.readTimer = pluginMetrics.timer(MetricNames.READ_TIME_ELAPSED);
+    }
+
+    /**
+     * Records metrics for ingress, time elapsed, and timeouts, while calling the doWrite method
+     * to perform the actual write
+     * @param record the Record to add
+     * @param timeoutInMillis how long to wait before giving up
+     * @throws TimeoutException
+     */
+    @Override
+    public void write(T record, int timeoutInMillis) throws TimeoutException {
+        try {
+            writeTimer.record(() -> {
+                try {
+                    doWrite(record, timeoutInMillis);
+                } catch (TimeoutException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            recordsWrittenCounter.increment();
+        } catch (RuntimeException e) {
+            if(e.getCause() instanceof TimeoutException) {
+                writeTimeoutCounter.increment();
+                throw (TimeoutException) e.getCause();
+            } else  {
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Records egress and time elapsed metrics, while calling the doRead function to
+     * do the actual read
+     * @param timeoutInMillis how long to wait before giving up
+     * @return Collection<Records> read
+     */
+    @Override
+    public Collection<T> read(int timeoutInMillis) {
+        Collection<T> records = readTimer.record(() -> doRead(timeoutInMillis));
+        recordsReadCounter.increment(records.size()*1.0);
+        return records;
+    }
+
+    /**
+     * This method should implement the logic for writing to the  buffer
+     * @param record Record to write to buffer
+     * @param timeoutInMillis Timeout for write operation in millis
+     * @throws TimeoutException
+     */
+    public abstract void doWrite(T record, int timeoutInMillis) throws TimeoutException;
+
+    /**
+     * This method should implement the logic for reading from the buffer
+     * @param timeoutInMillis Timeout in millis
+     * @return Records read from the buffer
+     */
+    public abstract Collection<T> doRead(int timeoutInMillis);
+}

--- a/situp-api/src/main/java/com/amazon/situp/model/buffer/AbstractBuffer.java
+++ b/situp-api/src/main/java/com/amazon/situp/model/buffer/AbstractBuffer.java
@@ -43,13 +43,13 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
                 try {
                     doWrite(record, timeoutInMillis);
                 } catch (TimeoutException e) {
+                    writeTimeoutCounter.increment();
                     throw new RuntimeException(e);
                 }
             });
             recordsWrittenCounter.increment();
         } catch (RuntimeException e) {
             if(e.getCause() instanceof TimeoutException) {
-                writeTimeoutCounter.increment();
                 throw (TimeoutException) e.getCause();
             } else  {
                 throw e;

--- a/situp-api/src/main/java/com/amazon/situp/model/metrics/MetricNames.java
+++ b/situp-api/src/main/java/com/amazon/situp/model/metrics/MetricNames.java
@@ -20,6 +20,31 @@ public class MetricNames {
     public static final String TIME_ELAPSED = "timeElapsed";
 
     /**
+     * Metric representing the numebr of records written to a Buffer
+     */
+    public static final String RECORDS_WRITTEN = "recordsWritten";
+
+    /**
+     * Metric representing the number of records read from a buffer
+     */
+    public static final String RECORDS_READ = "recordsRead";
+
+    /**
+     * Metric representing the time elapsed while writing to a Buffer
+     */
+    public static final String WRITE_TIME_ELAPSED = "writeTimeElapsed";
+
+    /**
+     * Metric representing the time elapsed while reading from a buffer
+     */
+    public static final String READ_TIME_ELAPSED = "readTimeElapsed";
+
+    /**
+     * Metric representing the count of write timeouts to a Buffer
+     */
+    public static final String WRITE_TIMEOUTS = "writeTimeouts";
+
+    /**
      * Delimiter used to separate path components in metric names.
      */
     public static final String DELIMITER = ".";

--- a/situp-api/src/main/java/com/amazon/situp/model/sink/AbstractSink.java
+++ b/situp-api/src/main/java/com/amazon/situp/model/sink/AbstractSink.java
@@ -1,0 +1,41 @@
+package com.amazon.situp.model.sink;
+
+import com.amazon.situp.model.configuration.PluginSetting;
+import com.amazon.situp.model.metrics.MetricNames;
+import com.amazon.situp.model.metrics.PluginMetrics;
+import com.amazon.situp.model.record.Record;
+import java.util.Collection;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
+
+/**
+ * This class implements the Sink interface and records boilerplate metrics
+ */
+public abstract class AbstractSink<T extends Record<?>> implements Sink<T> {
+    protected final PluginMetrics pluginMetrics;
+    private final Counter recordsInCounter;
+    private final Timer timeElapsedTimer;
+
+    public AbstractSink(final PluginSetting pluginSetting) {
+        this.pluginMetrics = PluginMetrics.fromPluginSetting(pluginSetting);
+        recordsInCounter = pluginMetrics.counter(MetricNames.RECORDS_IN);
+        timeElapsedTimer = pluginMetrics.timer(MetricNames.TIME_ELAPSED);
+    }
+
+    /**
+     * Records metrics for ingress and time elapsed, while calling
+     * doOutput to perform the actual output logic
+     * @param records the records to write to the sink.
+     */
+    @Override
+    public void output(Collection<T> records) {
+        recordsInCounter.increment(records.size()*1.0);
+        timeElapsedTimer.record(() -> doOutput(records));
+    }
+
+    /**
+     * This method should implement the output logic
+     * @param records Records to be output
+     */
+    public abstract void doOutput(Collection<T> records);
+}

--- a/situp-api/src/test/java/com/amazon/situp/model/buffer/AbstractBufferTest.java
+++ b/situp-api/src/test/java/com/amazon/situp/model/buffer/AbstractBufferTest.java
@@ -1,0 +1,123 @@
+package com.amazon.situp.model.buffer;
+
+import com.amazon.situp.model.configuration.PluginSetting;
+import com.amazon.situp.model.metrics.MetricNames;
+import com.amazon.situp.model.metrics.MetricsTestUtil;
+import com.amazon.situp.model.metrics.MetricsTestUtil.*;
+import com.amazon.situp.model.record.Record;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringJoiner;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Statistic;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AbstractBufferTest {
+
+    @Test
+    public void testReadAndWriteMetrics() throws TimeoutException {
+        final String bufferName = "testBuffer";
+        final String pipelineName = "pipelineName";
+        MetricsTestUtil.initMetrics();
+
+        PluginSetting pluginSetting = new PluginSetting(bufferName, Collections.emptyMap());
+        pluginSetting.setPipelineName(pipelineName);
+        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferImpl(pluginSetting);
+        for(int i=0; i<5; i++) {
+            abstractBuffer.write(new Record<>(UUID.randomUUID().toString()), 1000);
+        }
+        abstractBuffer.read(1000);
+
+        final List<Measurement> recordsWrittenMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_WRITTEN).toString());
+        final List<Measurement> recordsReadMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_READ).toString());
+        final List<Measurement> writeTimeMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.WRITE_TIME_ELAPSED).toString());
+        final List<Measurement> readTimeMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.READ_TIME_ELAPSED).toString());
+        Assert.assertEquals(1, recordsWrittenMeasurements.size());
+        Assert.assertEquals(5.0, recordsWrittenMeasurements.get(0).getValue(), 0);
+        Assert.assertEquals(1, recordsReadMeasurements.size());
+        Assert.assertEquals(5.0, recordsReadMeasurements.get(0).getValue(), 0);
+        Assert.assertEquals(5.0, MetricsTestUtil.getMeasurementFromList(writeTimeMeasurements, Statistic.COUNT).getValue(), 0);
+        Assert.assertTrue(
+                MetricsTestUtil.isBetween(
+                        MetricsTestUtil.getMeasurementFromList(writeTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
+                        0.5,
+                        0.6));
+        Assert.assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(readTimeMeasurements, Statistic.COUNT).getValue(), 0);
+        Assert.assertTrue(MetricsTestUtil.isBetween(
+                MetricsTestUtil.getMeasurementFromList(readTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
+                0.1,
+                0.2));
+    }
+
+    @Test
+    public void testTimeoutMetric() throws TimeoutException {
+        final String bufferName = "testBuffer";
+        final String pipelineName = "pipelineName";
+        MetricsTestUtil.initMetrics();
+        PluginSetting pluginSetting = new PluginSetting(bufferName, Collections.emptyMap());
+        pluginSetting.setPipelineName(pipelineName);
+        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferTimeoutImpl(pluginSetting);
+        Assert.assertThrows(TimeoutException.class, () -> abstractBuffer.write(new Record<>(UUID.randomUUID().toString()), 1000));
+
+        final List<Measurement> timeoutMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.WRITE_TIMEOUTS).toString());
+        Assert.assertEquals(1, timeoutMeasurements.size());
+        Assert.assertEquals(1.0, timeoutMeasurements.get(0).getValue(), 0);
+    }
+
+    public static class AbstractBufferImpl extends AbstractBuffer<Record<String>> {
+        private final Queue<Record<String>> queue;
+        public AbstractBufferImpl(PluginSetting pluginSetting) {
+            super(pluginSetting);
+            queue = new LinkedList<>();
+        }
+
+        @Override
+        public void doWrite(Record<String> record, int timeoutInMillis) throws TimeoutException {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+
+            }
+            queue.add(record);
+        }
+
+        @Override
+        public Collection<Record<String>> doRead(int timeoutInMillis) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+
+            }
+            final Collection<Record<String>> records = new HashSet<>();
+            for(int i=0; i<5; i++) {
+                if(!queue.isEmpty()) {
+                    records.add(queue.remove());
+                }
+            }
+            return records;
+        }
+    }
+
+    public static class AbstractBufferTimeoutImpl extends AbstractBufferImpl {
+        public AbstractBufferTimeoutImpl(PluginSetting pluginSetting) {
+            super(pluginSetting);
+        }
+
+        @Override
+        public void doWrite(Record<String> record, int timeoutInMillis) throws TimeoutException {
+            throw new TimeoutException();
+        }
+    }
+}

--- a/situp-api/src/test/java/com/amazon/situp/model/metrics/MetricsTestUtil.java
+++ b/situp-api/src/test/java/com/amazon/situp/model/metrics/MetricsTestUtil.java
@@ -1,0 +1,36 @@
+package com.amazon.situp.model.metrics;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Statistic;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+public class MetricsTestUtil {
+
+    public static void initMetrics() {
+        Metrics.globalRegistry.getRegistries().forEach(meterRegistry -> Metrics.globalRegistry.remove(meterRegistry));
+        Metrics.addRegistry(new SimpleMeterRegistry());
+    }
+
+    public static List<Measurement> getMeasurementList(final String meterName) {
+        return StreamSupport.stream(getRegistry().find(meterName).meter().measure().spliterator(), false)
+                .collect(Collectors.toList());
+    }
+
+    public static Measurement getMeasurementFromList(final List<Measurement> measurements, final Statistic statistic) {
+        return measurements.stream().filter(measurement -> measurement.getStatistic() == statistic).findAny().get();
+    }
+
+    private static MeterRegistry getRegistry() {
+        return Metrics.globalRegistry.getRegistries().iterator().next();
+    }
+
+    public static boolean isBetween(double value, double low, double high) {
+        return value > low && value < high;
+    }
+
+}

--- a/situp-api/src/test/java/com/amazon/situp/model/processor/AbstractPrepperTest.java
+++ b/situp-api/src/test/java/com/amazon/situp/model/processor/AbstractPrepperTest.java
@@ -2,6 +2,7 @@ package com.amazon.situp.model.processor;
 
 import com.amazon.situp.model.configuration.PluginSetting;
 import com.amazon.situp.model.metrics.MetricNames;
+import com.amazon.situp.model.metrics.MetricsTestUtil;
 import com.amazon.situp.model.record.Record;
 import java.util.Arrays;
 import java.util.Collection;
@@ -9,16 +10,47 @@ import java.util.Collections;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import io.micrometer.core.instrument.Measurement;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Statistic;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class AbstractPrepperTest {
+
+    @Test
+    public void testMetrics() {
+        final String processorName = "testProcessor";
+        final String pipelineName = "pipelineName";
+        MetricsTestUtil.initMetrics();
+
+        PluginSetting pluginSetting = new PluginSetting(processorName, Collections.emptyMap());
+        pluginSetting.setPipelineName(pipelineName);
+        AbstractPrepper<Record<String>, Record<String>> processor = new ProcessorImpl(pluginSetting);
+
+        processor.execute(Arrays.asList(
+                new Record<>("Value1"),
+                new Record<>("Value2"),
+                new Record<>("Value3")
+        ));
+
+        final List<Measurement> recordsInMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(processorName).add(MetricNames.RECORDS_IN).toString());
+        final List<Measurement> recordsOutMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(processorName).add(MetricNames.RECORDS_OUT).toString());
+        final List<Measurement> elapsedTimeMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(processorName).add(MetricNames.TIME_ELAPSED).toString());
+
+        Assert.assertEquals(1, recordsInMeasurements.size());
+        Assert.assertEquals(3.0, recordsInMeasurements.get(0).getValue(), 0);
+        Assert.assertEquals(1, recordsOutMeasurements.size());
+        Assert.assertEquals(6.0, recordsOutMeasurements.get(0).getValue(), 0);
+        Assert.assertEquals(3, elapsedTimeMeasurements.size());
+        Assert.assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(elapsedTimeMeasurements, Statistic.COUNT).getValue(), 0);
+        Assert.assertTrue(MetricsTestUtil.isBetween(
+                MetricsTestUtil.getMeasurementFromList(elapsedTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
+                0.1,
+                0.2));
+    }
 
     public static class ProcessorImpl extends AbstractPrepper<Record<String>, Record<String>> {
         public ProcessorImpl(PluginSetting pluginSetting) {
@@ -36,51 +68,4 @@ public class AbstractPrepperTest {
                     .collect(Collectors.toList());
         }
     }
-
-    @Test
-    public void testMetrics() {
-        final String processorName = "testProcessor";
-        final String pipelineName = "pipelineName";
-        final SimpleMeterRegistry simple = new SimpleMeterRegistry();
-        Metrics.addRegistry(simple);
-
-        PluginSetting pluginSetting = new PluginSetting(processorName, Collections.emptyMap());
-        pluginSetting.setPipelineName(pipelineName);
-        AbstractPrepper<Record<String>, Record<String>> processor = new ProcessorImpl(pluginSetting);
-
-        processor.execute(Arrays.asList(
-                new Record<>("Value1"),
-                new Record<>("Value2"),
-                new Record<>("Value3")
-        ));
-
-        final List<Measurement> recordsInMeasurements = getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(processorName).add(MetricNames.RECORDS_IN).toString(),
-                simple);
-        final List<Measurement> recordsOutMeasurements = getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(processorName).add(MetricNames.RECORDS_OUT).toString(),
-                simple);
-        final List<Measurement> elapsedTimeMeasurements = getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(processorName).add(MetricNames.TIME_ELAPSED).toString(),
-                simple);
-
-        Assert.assertEquals(1, recordsInMeasurements.size());
-        Assert.assertEquals(3.0, recordsInMeasurements.get(0).getValue(), 0);
-        Assert.assertEquals(1, recordsOutMeasurements.size());
-        Assert.assertEquals(6.0, recordsOutMeasurements.get(0).getValue(), 0);
-        Assert.assertEquals(3, elapsedTimeMeasurements.size());
-        Assert.assertEquals(1.0, getMeasurementFromList(elapsedTimeMeasurements, Statistic.COUNT).getValue(), 0);
-        Assert.assertTrue(0.1 < getMeasurementFromList(elapsedTimeMeasurements, Statistic.TOTAL_TIME).getValue());
-        Assert.assertTrue(0.1 < getMeasurementFromList(elapsedTimeMeasurements, Statistic.MAX).getValue());
-    }
-
-    private List<Measurement> getMeasurementList(final String meterName, final MeterRegistry registry) {
-        return StreamSupport.stream(registry.find(meterName).meter().measure().spliterator(), false)
-                .collect(Collectors.toList());
-    }
-
-    private Measurement getMeasurementFromList(final List<Measurement> measurements, final Statistic statistic) {
-        return measurements.stream().filter(measurement -> measurement.getStatistic() == statistic).findAny().get();
-    }
-
 }

--- a/situp-api/src/test/java/com/amazon/situp/model/sink/AbstractSinkTest.java
+++ b/situp-api/src/test/java/com/amazon/situp/model/sink/AbstractSinkTest.java
@@ -1,0 +1,65 @@
+package com.amazon.situp.model.sink;
+
+import com.amazon.situp.model.configuration.PluginSetting;
+import com.amazon.situp.model.metrics.MetricNames;
+import com.amazon.situp.model.metrics.MetricsTestUtil;
+import com.amazon.situp.model.record.Record;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.UUID;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Statistic;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AbstractSinkTest {
+    @Test
+    public void testMetrics() {
+        final String sinkName = "testSink";
+        final String pipelineName = "pipelineName";
+        MetricsTestUtil.initMetrics();
+        PluginSetting pluginSetting = new PluginSetting(sinkName, Collections.emptyMap());
+        pluginSetting.setPipelineName(pipelineName);
+        AbstractSink<Record<String>> abstractSink = new AbstractSinkImpl(pluginSetting);
+        abstractSink.output(Arrays.asList(
+                new Record<>(UUID.randomUUID().toString()),
+                new Record<>(UUID.randomUUID().toString()),
+                new Record<>(UUID.randomUUID().toString()),
+                new Record<>(UUID.randomUUID().toString()),
+                new Record<>(UUID.randomUUID().toString())
+        ));
+
+        final List<Measurement> recordsInMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(sinkName).add(MetricNames.RECORDS_IN).toString());
+        final List<Measurement> elapsedTimeMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(sinkName).add(MetricNames.TIME_ELAPSED).toString());
+
+        Assert.assertEquals(1, recordsInMeasurements.size());
+        Assert.assertEquals(5.0, recordsInMeasurements.get(0).getValue(), 0);
+        Assert.assertEquals(3, elapsedTimeMeasurements.size());
+        Assert.assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(elapsedTimeMeasurements, Statistic.COUNT).getValue(), 0);
+        Assert.assertTrue(MetricsTestUtil.isBetween(
+                MetricsTestUtil.getMeasurementFromList(elapsedTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
+                0.5,
+                0.6));
+    }
+
+    private static class AbstractSinkImpl extends AbstractSink<Record<String>> {
+
+        public AbstractSinkImpl(PluginSetting pluginSetting) {
+            super(pluginSetting);
+        }
+
+        @Override
+        public void doOutput(Collection<Record<String>> records) {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding Abstract implementations of Buffer and Sink for testing.

Note: The checked exception in Buffer.write() required a little bit of extra code to handle in the abstract class. The other method for doing this would be to time the method, and use the Timer.record(Duration duration) to record the time. Both implementations required a little extra code, so I did not see a huge difference between the two.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
