### PR TITLE
Fail creation of connected pipelines if root pipeline fails

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/PipelineParser.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/ProcessWorker.java
@@ -40,9 +40,11 @@ public class ProcessWorker implements Runnable {
             do {
                 Collection records = readBuffer.read(pipeline.getReadBatchTimeoutInMillis());
                 //TODO Hacky way to avoid logging continuously - Will be removed as part of metrics implementation
-                if (records.isEmpty() && !isEmptyRecordsLogged) {
-                    LOG.info(" {} Worker: No records received from buffer", pipeline.getName());
-                    isEmptyRecordsLogged = true;
+                if (records.isEmpty()) {
+                    if(!isEmptyRecordsLogged) {
+                        LOG.info(" {} Worker: No records received from buffer", pipeline.getName());
+                        isEmptyRecordsLogged = true;
+                    }
                 } else {
                     LOG.info(" {} Worker: Processing {} records from buffer", pipeline.getName(), records.size());
                 }

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/ProcessWorker.java
@@ -21,7 +21,7 @@ public class ProcessWorker implements Runnable {
     private final List<Processor> processors;
     private final Collection<Sink> sinks;
     private final Pipeline pipeline;
-    private boolean isQueueEmpty = false;
+    private boolean isEmptyRecordsLogged = false;
 
     public ProcessWorker(
             final Buffer readBuffer,
@@ -39,7 +39,13 @@ public class ProcessWorker implements Runnable {
         try {
             do {
                 Collection records = readBuffer.read(pipeline.getReadBatchTimeoutInMillis());
-                LOG.info(" {} Worker: Processing {} records from buffer", pipeline.getName(), records.size());
+                //TODO Hacky way to avoid logging continuously - Will be removed as part of metrics implementation
+                if (records.isEmpty() && !isEmptyRecordsLogged) {
+                    LOG.info(" {} Worker: No records received from buffer", pipeline.getName());
+                    isEmptyRecordsLogged = true;
+                } else {
+                    LOG.info(" {} Worker: Processing {} records from buffer", pipeline.getName(), records.size());
+                }
                 //Should Empty list from buffer should be sent to the processors? For now sending as the Stateful processors expects it.
                 for (final Processor processor : processors) {
                     records = processor.execute(records);

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/TestDataProvider.java
@@ -28,6 +28,7 @@ public class TestDataProvider {
     public static final String VALID_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/valid_multiple_pipeline_configuration.yml";
     public static final String VALID_SINGLE_PIPELINE_EMPTY_SOURCE_PLUGIN_FILE = "src/test/resources/single_pipeline_valid_empty_source_plugin_settings.yml";
     public static final String CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT = "src/test/resources/connected_pipeline_incorrect_root_source.yml";
+    public static final String CONNECTED_PIPELINE_CHILD_PIPELINE_INCORRECT = "src/test/resources/connected_pipeline_incorrect_child_pipeline.yml";
     public static final String CYCLE_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/cyclic_multiple_pipeline_configuration.yml";
     public static final String INCORRECT_SOURCE_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/incorrect_source_multiple_pipeline_configuration.yml";
     public static final String MISSING_NAME_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/missing_name_multiple_pipeline_configuration.yml";

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/TestDataProvider.java
@@ -27,6 +27,7 @@ public class TestDataProvider {
     public static final Integer TEST_DELAY = 3_000;
     public static final String VALID_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/valid_multiple_pipeline_configuration.yml";
     public static final String VALID_SINGLE_PIPELINE_EMPTY_SOURCE_PLUGIN_FILE = "src/test/resources/single_pipeline_valid_empty_source_plugin_settings.yml";
+    public static final String CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT = "src/test/resources/connected_pipeline_incorrect_root_source.yml";
     public static final String CYCLE_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/cyclic_multiple_pipeline_configuration.yml";
     public static final String INCORRECT_SOURCE_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/incorrect_source_multiple_pipeline_configuration.yml";
     public static final String MISSING_NAME_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/missing_name_multiple_pipeline_configuration.yml";

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/PipelineParserTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/PipelineParserTests.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static com.amazon.dataprepper.TestDataProvider.CONNECTED_PIPELINE_CHILD_PIPELINE_INCORRECT;
 import static com.amazon.dataprepper.TestDataProvider.CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT;
 import static com.amazon.dataprepper.TestDataProvider.CYCLE_MULTIPLE_PIPELINE_CONFIG_FILE;
 import static com.amazon.dataprepper.TestDataProvider.INCORRECT_SOURCE_MULTIPLE_PIPELINE_CONFIG_FILE;
@@ -30,8 +31,15 @@ public class PipelineParserTests {
     }
 
     @Test
-    public void testConnectedPipelineCreationWhenRootPipelineFails(){
+    public void testConnectedPipelineCreationWhenRootPipelineFails() {
         final PipelineParser pipelineParser = new PipelineParser(CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT);
+        final Map<String, Pipeline> connectedPipelines = pipelineParser.parseConfiguration();
+        assertThat(connectedPipelines.size(), is(equalTo(0)));
+    }
+
+    @Test
+    public void testConnectedPipelineCreationWhenChildPipelineFails() {
+        final PipelineParser pipelineParser = new PipelineParser(CONNECTED_PIPELINE_CHILD_PIPELINE_INCORRECT);
         final Map<String, Pipeline> connectedPipelines = pipelineParser.parseConfiguration();
         assertThat(connectedPipelines.size(), is(equalTo(0)));
     }

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/PipelineParserTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/PipelineParserTests.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static com.amazon.dataprepper.TestDataProvider.CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT;
 import static com.amazon.dataprepper.TestDataProvider.CYCLE_MULTIPLE_PIPELINE_CONFIG_FILE;
 import static com.amazon.dataprepper.TestDataProvider.INCORRECT_SOURCE_MULTIPLE_PIPELINE_CONFIG_FILE;
 import static com.amazon.dataprepper.TestDataProvider.MISSING_NAME_MULTIPLE_PIPELINE_CONFIG_FILE;
@@ -26,6 +27,13 @@ public class PipelineParserTests {
         final PipelineParser pipelineParser = new PipelineParser(VALID_MULTIPLE_PIPELINE_CONFIG_FILE);
         final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
         assertThat(actualPipelineMap.keySet(), is(VALID_MULTIPLE_PIPELINE_NAMES));
+    }
+
+    @Test
+    public void testConnectedPipelineCreationWhenRootPipelineFails(){
+        final PipelineParser pipelineParser = new PipelineParser(CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT);
+        final Map<String, Pipeline> connectedPipelines = pipelineParser.parseConfiguration();
+        assertThat(connectedPipelines.size(), is(equalTo(0)));
     }
 
     @Test

--- a/data-prepper-core/src/test/resources/connected_pipeline_incorrect_child_pipeline.yml
+++ b/data-prepper-core/src/test/resources/connected_pipeline_incorrect_child_pipeline.yml
@@ -1,0 +1,25 @@
+# this configuration file is solely for testing formatting
+test-pipeline-1:
+  source:
+    file:
+      path: "/tmp/file-source.tmp"
+  buffer:
+    bounded_blocking:
+  sink:
+    - pipeline:
+        name: "test-pipeline-2"
+test-pipeline-2:
+  source:
+    pipeline:
+      name: "test-pipeline-1"
+  sink:
+    - pipeline:
+        name: "test-pipeline-3"
+    - file1: #this will fail file plugin creation.
+test-pipeline-3:
+  source:
+    pipeline:
+      name: "test-pipeline-2"
+  sink:
+    - file:
+        path: "/tmp/todelete.txt"

--- a/data-prepper-core/src/test/resources/connected_pipeline_incorrect_root_source.yml
+++ b/data-prepper-core/src/test/resources/connected_pipeline_incorrect_root_source.yml
@@ -1,0 +1,23 @@
+# this configuration file is solely for testing formatting
+test-pipeline-1:
+  source:
+    file: #this plugin fails as it requires path attribute
+  buffer:
+    bounded_blocking:
+  sink:
+    - pipeline:
+        name: "test-pipeline-2"
+test-pipeline-2:
+  source:
+    pipeline:
+      name: "test-pipeline-1"
+  sink:
+    - pipeline:
+        name: "test-pipeline-3"
+test-pipeline-3:
+  source:
+    pipeline:
+      name: "test-pipeline-2"
+  sink:
+    - file:
+        path: "/tmp/todelete.txt"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The changes will fail building of connected child pipelines if the connected root pipeline failed. Below is the pictorial representation of what the flow does

```
                   --> childPipeline1
                 /
rootPipeline ---
                 \
                   --> childPipeline2
```
Case: `rootPipeline` building fails for any reason
Result: It skips `rootPipeline` and proceeds building of `childPipeline1` (or `childPipeline2`) -> As part of building source where it requires a `PipelineConnector` (connector to `rootPipeline`) and attempts to retrieve from `sourceConnectorMap` but as r`ootPipeline` failed, there will not be any `PipelineConnector`. It assumes the `rootPipeline` building hasn't started and attempts to build and checks if the `Pipeline` was created, failing to find a `Pipeline` - It will fail the source creation and effectively `childPipeline1` (or `childPipeline2`) creation.


```
                         -> p6
                       /
                  -> p5
                /      \
  p1 -> p2 -> p3        -> p7
 /
R 
 \
  s1 -> s2 -> s3

```

Case: if p5 fails
Result: We will kill all connected pipelines - recursively going through all connected pipelines and removing them if Pipeline is already created.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
