### PR TITLE
Fix logging and pipeline failure during init

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/PipelineParser.java
@@ -37,7 +37,7 @@ public class PipelineParser {
     private static final String PIPELINE_TYPE = "pipeline";
     private static final String ATTRIBUTE_NAME = "name";
     private final String configurationFileLocation;
-    private final Map<String, PipelineConnector> sourceConnectorMap = new HashMap<>();
+    private final Map<String, PipelineConnector> sourceConnectorMap = new HashMap<>(); //TODO Remove this and rely only on pipelineMap
 
     public PipelineParser(final String configurationFileLocation) {
         this.configurationFileLocation = configurationFileLocation;
@@ -57,7 +57,7 @@ public class PipelineParser {
             pipelineConfigurationMap.forEach((pipelineName, configuration) ->
                     configuration.updateCommonPipelineConfiguration(pipelineName));
             for (String pipelineName : allPipelineNames) {
-                if (!pipelineMap.containsKey(pipelineName)) {
+                if (!pipelineMap.containsKey(pipelineName) && pipelineConfigurationMap.containsKey(pipelineName)) {
                     buildPipelineFromConfiguration(pipelineName, pipelineConfigurationMap, pipelineMap);
                 }
             }
@@ -98,7 +98,9 @@ public class PipelineParser {
             pipelineMap.put(pipelineName, pipeline);
         } catch (Exception ex) {
             //If pipeline construction errors out, we will skip that pipeline and proceed
-            LOG.error("Construction of pipeline components failed, skipping building of pipeline [{}]", pipelineName, ex);
+            LOG.error("Construction of pipeline components failed, skipping building of pipeline [{}] and its connected " +
+                    "pipelines", pipelineName, ex);
+            processRemoveIfRequired(pipelineName, pipelineConfigurationMap, pipelineMap);
         }
 
     }
@@ -111,11 +113,19 @@ public class PipelineParser {
         LOG.info("Building [{}] as source component for the pipeline [{}]", pluginSetting.getName(), sourcePipelineName);
         final Optional<String> pipelineNameOptional = getPipelineNameIfPipelineType(pluginSetting);
         if (pipelineNameOptional.isPresent()) { //update to ifPresentOrElse when using JDK9
+            final String connectedPipeline = pipelineNameOptional.get();
             if (!sourceConnectorMap.containsKey(sourcePipelineName)) {
                 LOG.info("Source of pipeline [{}] requires building of pipeline [{}]", sourcePipelineName,
-                        pipelineNameOptional.get());
+                        connectedPipeline);
                 //Build connected pipeline for the pipeline connector to be available
+                //Building like below sometimes yields multiple runs if the pipeline building fails before sink
+                //creation. except for running the creation again, it will not harm anything - TODO Fix this
                 buildPipelineFromConfiguration(pipelineNameOptional.get(), pipelineConfigurationMap, pipelineMap);
+            }
+            if (!pipelineMap.containsKey(connectedPipeline)) {
+                LOG.info("Connected Pipeline [{}] failed to build, Failing building source for [{}]",
+                        connectedPipeline, sourcePipelineName);
+                throw new RuntimeException(format("Failed building source for %s, exiting", sourcePipelineName));
             }
             final PipelineConnector pipelineConnector = sourceConnectorMap.get(sourcePipelineName);
             pipelineConnector.setSourcePipelineName(pipelineNameOptional.get());
@@ -144,5 +154,40 @@ public class PipelineParser {
             return Optional.of((String) pluginSetting.getAttributeFromSettings(ATTRIBUTE_NAME));
         }
         return Optional.empty();
+    }
+
+    /**
+     * This removes all built connected pipelines of given pipeline from pipelineMap.
+     * TODO Update this to be more elegant and trigger destroy of plugins
+     */
+    private void removeConnectedPipelines(
+            final String failedPipeline,
+            final Map<String, PipelineConfiguration> pipelineConfigurationMap,
+            final Map<String, Pipeline> pipelineMap) {
+        final PipelineConfiguration failedPipelineConfiguration = pipelineConfigurationMap.remove(failedPipeline);
+
+        //remove source connected pipelines
+        final Optional<String> sourcePipelineOptional = getPipelineNameIfPipelineType(
+                failedPipelineConfiguration.getSourcePluginSetting());
+        sourcePipelineOptional.ifPresent(sourcePipeline -> processRemoveIfRequired(
+                sourcePipeline, pipelineConfigurationMap, pipelineMap));
+
+        //remove sink connected pipelines
+        final List<PluginSetting> sinkPluginSettings = failedPipelineConfiguration.getSinkPluginSettings();
+        sinkPluginSettings.forEach(sinkPluginSetting -> {
+            getPipelineNameIfPipelineType(sinkPluginSetting).ifPresent(sinkPipeline -> processRemoveIfRequired(
+                    sinkPipeline, pipelineConfigurationMap, pipelineMap));
+        });
+    }
+
+    private void processRemoveIfRequired(
+            final String pipelineName,
+            final Map<String, PipelineConfiguration> pipelineConfigurationMap,
+            final Map<String, Pipeline> pipelineMap) {
+        if (pipelineConfigurationMap.containsKey(pipelineName)) {
+            pipelineMap.remove(pipelineName);
+            sourceConnectorMap.remove(pipelineName);
+            removeConnectedPipelines(pipelineName, pipelineConfigurationMap, pipelineMap);
+        }
     }
 }

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/TestDataProvider.java
@@ -27,6 +27,8 @@ public class TestDataProvider {
     public static final Integer TEST_DELAY = 3_000;
     public static final String VALID_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/valid_multiple_pipeline_configuration.yml";
     public static final String VALID_SINGLE_PIPELINE_EMPTY_SOURCE_PLUGIN_FILE = "src/test/resources/single_pipeline_valid_empty_source_plugin_settings.yml";
+    public static final String CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT = "src/test/resources/connected_pipeline_incorrect_root_source.yml";
+    public static final String CONNECTED_PIPELINE_CHILD_PIPELINE_INCORRECT = "src/test/resources/connected_pipeline_incorrect_child_pipeline.yml";
     public static final String CYCLE_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/cyclic_multiple_pipeline_configuration.yml";
     public static final String INCORRECT_SOURCE_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/incorrect_source_multiple_pipeline_configuration.yml";
     public static final String MISSING_NAME_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/missing_name_multiple_pipeline_configuration.yml";

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/PipelineParserTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/PipelineParserTests.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static com.amazon.dataprepper.TestDataProvider.CONNECTED_PIPELINE_CHILD_PIPELINE_INCORRECT;
+import static com.amazon.dataprepper.TestDataProvider.CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT;
 import static com.amazon.dataprepper.TestDataProvider.CYCLE_MULTIPLE_PIPELINE_CONFIG_FILE;
 import static com.amazon.dataprepper.TestDataProvider.INCORRECT_SOURCE_MULTIPLE_PIPELINE_CONFIG_FILE;
 import static com.amazon.dataprepper.TestDataProvider.MISSING_NAME_MULTIPLE_PIPELINE_CONFIG_FILE;
@@ -26,6 +28,20 @@ public class PipelineParserTests {
         final PipelineParser pipelineParser = new PipelineParser(VALID_MULTIPLE_PIPELINE_CONFIG_FILE);
         final Map<String, Pipeline> actualPipelineMap = pipelineParser.parseConfiguration();
         assertThat(actualPipelineMap.keySet(), is(VALID_MULTIPLE_PIPELINE_NAMES));
+    }
+
+    @Test
+    public void testConnectedPipelineCreationWhenRootPipelineFails() {
+        final PipelineParser pipelineParser = new PipelineParser(CONNECTED_PIPELINE_ROOT_SOURCE_INCORRECT);
+        final Map<String, Pipeline> connectedPipelines = pipelineParser.parseConfiguration();
+        assertThat(connectedPipelines.size(), is(equalTo(0)));
+    }
+
+    @Test
+    public void testConnectedPipelineCreationWhenChildPipelineFails() {
+        final PipelineParser pipelineParser = new PipelineParser(CONNECTED_PIPELINE_CHILD_PIPELINE_INCORRECT);
+        final Map<String, Pipeline> connectedPipelines = pipelineParser.parseConfiguration();
+        assertThat(connectedPipelines.size(), is(equalTo(0)));
     }
 
     @Test

--- a/data-prepper-core/src/test/resources/connected_pipeline_incorrect_child_pipeline.yml
+++ b/data-prepper-core/src/test/resources/connected_pipeline_incorrect_child_pipeline.yml
@@ -1,0 +1,25 @@
+# this configuration file is solely for testing formatting
+test-pipeline-1:
+  source:
+    file:
+      path: "/tmp/file-source.tmp"
+  buffer:
+    bounded_blocking:
+  sink:
+    - pipeline:
+        name: "test-pipeline-2"
+test-pipeline-2:
+  source:
+    pipeline:
+      name: "test-pipeline-1"
+  sink:
+    - pipeline:
+        name: "test-pipeline-3"
+    - file1: #this will fail file plugin creation.
+test-pipeline-3:
+  source:
+    pipeline:
+      name: "test-pipeline-2"
+  sink:
+    - file:
+        path: "/tmp/todelete.txt"

--- a/data-prepper-core/src/test/resources/connected_pipeline_incorrect_root_source.yml
+++ b/data-prepper-core/src/test/resources/connected_pipeline_incorrect_root_source.yml
@@ -1,0 +1,23 @@
+# this configuration file is solely for testing formatting
+test-pipeline-1:
+  source:
+    file: #this plugin fails as it requires path attribute
+  buffer:
+    bounded_blocking:
+  sink:
+    - pipeline:
+        name: "test-pipeline-2"
+test-pipeline-2:
+  source:
+    pipeline:
+      name: "test-pipeline-1"
+  sink:
+    - pipeline:
+        name: "test-pipeline-3"
+test-pipeline-3:
+  source:
+    pipeline:
+      name: "test-pipeline-2"
+  sink:
+    - file:
+        path: "/tmp/todelete.txt"


### PR DESCRIPTION
*Description of changes:*

Cherry-pick commit of the [fix](https://github.com/opendistro-for-elasticsearch/Data-Prepper/pull/197) applied on the release. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
