### PR TITLE
Adding DNS container to trace-analytics-sample-app.

### DIFF
--- a/examples/dns/Dockerfile
+++ b/examples/dns/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.12
+RUN apk --no-cache add dnsmasq-dnssec
+EXPOSE 53 53/udp
+ENTRYPOINT ["dnsmasq", "-k"]

--- a/examples/dns/dnsmasq.conf
+++ b/examples/dns/dnsmasq.conf
@@ -1,0 +1,3 @@
+log-queries
+server=127.0.0.11
+addn-hosts=/etc/hosts.prepper

--- a/examples/dns/dnsmasq.conf
+++ b/examples/dns/dnsmasq.conf
@@ -1,3 +1,2 @@
-log-queries
-server=127.0.0.11
+server=127.0.0.11 # Embedded Docker DNS
 addn-hosts=/etc/hosts.prepper

--- a/examples/dns/hosts.prepper
+++ b/examples/dns/hosts.prepper
@@ -1,0 +1,1 @@
+10.10.2.1 prepper-cluster

--- a/examples/trace-analytics-sample-app/README.md
+++ b/examples/trace-analytics-sample-app/README.md
@@ -64,6 +64,8 @@ Correspondingly, on the server side, the API calls are as follows
 
 Each API call in the chains above calls `/logs (analytics-service:8087)` in the analytics service.
 
+Trace data is sent to the OpenTelemetry Collector which then exports traces to an instance of Data Prepper. This sample app contains a lightweight DNS server to handle custom hostname resolution, enabling multiple Prepper instances to be found under the same hostname. Any hostnames not resolvable by the DNS server are forwarded to Docker's embedded DNS at 127.0.0.11.
+
 ## Run
 
 To run this application together with client:

--- a/examples/trace-analytics-sample-app/docker-compose.yml
+++ b/examples/trace-analytics-sample-app/docker-compose.yml
@@ -1,5 +1,29 @@
 version: "3.7"
+networks:
+  my_network:
+    driver: bridge
+    ipam:
+     config:
+       - subnet: 10.10.0.0/16
+         gateway: 10.10.0.1
+
 services:
+  dnsmasq:
+    restart: always
+    build:
+      context: ../dns
+      dockerfile: Dockerfile
+    volumes:
+      - ../dns/dnsmasq.conf:/etc/dnsmasq.conf
+      - ../dns/hosts.prepper:/etc/hosts.prepper
+    ports:
+      - "5300:53/udp"
+    cap_add:
+      - NET_ADMIN
+    networks:
+      my_network:
+        ipv4_address: 10.10.1.1
+
   data-prepper:
     restart: unless-stopped
     container_name: data-prepper
@@ -15,9 +39,11 @@ services:
     ports:
       - "21890:21890"
     networks:
-      - my_network
+      my_network:
+        ipv4_address: 10.10.2.1
     depends_on:
       - opendistro-for-elasticsearch
+
   opendistro-for-elasticsearch:
     container_name: node-0.example.com
     image: 'amazon/opendistro-for-elasticsearch:1.10.1'
@@ -28,6 +54,7 @@ services:
       - discovery.type=single-node
     networks:
       - my_network
+
   kibana:
     build:
       context: ../..
@@ -42,12 +69,14 @@ services:
       ELASTICSEARCH_HOSTS: https://node-0.example.com:9200
     networks:
       - my_network
+
   otel-collector:
     restart: unless-stopped
+    dns: 10.10.1.1
     image: otel/opentelemetry-collector:0.14.0
     command: ["--config=/etc/otel-collector-config.yml"]
     volumes:
-      - ./opentelemetry-collector/otel-collector-config.yml:/etc/otel-collector-config.yml
+      - ./opentelemetry-collector/otel-collector-dns-config.yml:/etc/otel-collector-config.yml
       - ../demo/demo-data-prepper.crt:/etc/demo-data-prepper.crt
     ports:
       - "55680:55680"
@@ -55,6 +84,7 @@ services:
       - data-prepper
     networks:
       - my_network
+
   mysql:
     restart: unless-stopped
     image: mysql:latest
@@ -64,6 +94,7 @@ services:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
     networks:
       - my_network
+
   sample-app:
     restart: unless-stopped
     build:
@@ -91,5 +122,3 @@ services:
       - mysql
     networks:
       - my_network
-networks:
-  my_network:

--- a/examples/trace-analytics-sample-app/opentelemetry-collector/otel-collector-dns-config.yml
+++ b/examples/trace-analytics-sample-app/opentelemetry-collector/otel-collector-dns-config.yml
@@ -1,0 +1,17 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:55680
+
+exporters:
+  otlp/2:
+    endpoint: prepper-cluster:21890
+    insecure: true
+  logging:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [logging, otlp/2]


### PR DESCRIPTION
*Issue #, if available:* #200 

*Description of changes:*
Adding a small DNS service to the docker-compose example, to be used in the multi-host DNS discovery example.

Tested with `docker compose up -d` and confirming data still propagates all the way to ES:
>15846 [raw-pipeline-process-worker-3-thread-1] INFO  com.amazon.dataprepper.pipeline.ProcessWorker  –  raw-pipeline Worker: Processing 7 records from buffer


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
