### PR TITLE
Extending Abstract classes for ServiceMapProcessor, BlockingBuffer, a…

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/PluginMetrics.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/PluginMetrics.java
@@ -12,7 +12,16 @@ public class PluginMetrics {
     private final String metricsPrefix;
 
     public static PluginMetrics fromPluginSetting(final PluginSetting pluginSetting) {
-        return new PluginMetrics(getPrefix(pluginSetting));
+        if(pluginSetting.getPipelineName() == null) {
+            throw new IllegalArgumentException("PluginSetting.pipelineName must not be null");
+        }
+        return PluginMetrics.fromNames(pluginSetting.getName(), pluginSetting.getPipelineName());
+    }
+
+    public static PluginMetrics fromNames(final String name, final String pipelineName) {
+        return new PluginMetrics(new StringJoiner(MetricNames.DELIMITER)
+                .add(pipelineName)
+                .add(name).toString());
     }
 
     private  PluginMetrics(final String metricsPrefix) {
@@ -33,15 +42,6 @@ public class PluginMetrics {
 
     public <T extends Number> T gauge(final String name, T number) {
         return Metrics.gauge(name, number);
-    }
-
-    private static String getPrefix(final PluginSetting pluginSetting) {
-        if(pluginSetting.getPipelineName() == null) {
-            throw new IllegalArgumentException("PluginSetting.pipelineName must not be null");
-        }
-        return new StringJoiner(MetricNames.DELIMITER)
-                .add(pluginSetting.getPipelineName())
-                .add(pluginSetting.getName()).toString();
     }
 
     private String getMeterName(final String name) {

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
@@ -21,7 +21,15 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
     private final Timer readTimer;
 
     public AbstractBuffer(final PluginSetting pluginSetting) {
-        this.pluginMetrics = PluginMetrics.fromPluginSetting(pluginSetting);
+        this(PluginMetrics.fromPluginSetting(pluginSetting));
+    }
+
+    public AbstractBuffer(final String bufferName, final String pipelineName) {
+        this(PluginMetrics.fromNames(bufferName, pipelineName));
+    }
+
+    private AbstractBuffer(final PluginMetrics pluginMetrics) {
+        this.pluginMetrics = pluginMetrics;
         this.recordsWrittenCounter = pluginMetrics.counter(MetricNames.RECORDS_WRITTEN);
         this.recordsReadCounter = pluginMetrics.counter(MetricNames.RECORDS_READ);
         this.writeTimeoutCounter = pluginMetrics.counter(MetricNames.WRITE_TIMEOUTS);

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractPrepper.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/processor/AbstractPrepper.java
@@ -46,5 +46,5 @@ public abstract class AbstractPrepper<InputRecord extends Record<?>, OutputRecor
      * @param records Input records
      * @return Processed records
      */
-    abstract Collection<OutputRecord> doExecute(Collection<InputRecord> records);
+    public abstract Collection<OutputRecord> doExecute(Collection<InputRecord> records);
 }

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
@@ -80,9 +80,7 @@ public class AbstractBufferTest {
         final String bufferName = "testBuffer";
         final String pipelineName = "pipelineName";
         MetricsTestUtil.initMetrics();
-        PluginSetting pluginSetting = new PluginSetting(bufferName, Collections.emptyMap());
-        pluginSetting.setPipelineName(pipelineName);
-        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferNpeImpl(pluginSetting);
+        final AbstractBuffer<Record<String>> abstractBuffer = new AbstractBufferNpeImpl(bufferName, pipelineName);
         Assert.assertThrows(NullPointerException.class, () -> abstractBuffer.write(new Record<>(UUID.randomUUID().toString()), 1000));
     }
 
@@ -90,6 +88,11 @@ public class AbstractBufferTest {
         private final Queue<Record<String>> queue;
         public AbstractBufferImpl(PluginSetting pluginSetting) {
             super(pluginSetting);
+            queue = new LinkedList<>();
+        }
+
+        public AbstractBufferImpl(final String name, final String pipelineName) {
+            super(name, pipelineName);
             queue = new LinkedList<>();
         }
 
@@ -132,8 +135,8 @@ public class AbstractBufferTest {
     }
 
     public static class AbstractBufferNpeImpl extends AbstractBufferImpl {
-        public AbstractBufferNpeImpl(PluginSetting pluginSetting) {
-            super(pluginSetting);
+        public AbstractBufferNpeImpl(final String name, final String pipelineName) {
+            super(name, pipelineName);
         }
 
         @Override

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/processor/AbstractPrepperTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/processor/AbstractPrepperTest.java
@@ -58,7 +58,7 @@ public class AbstractPrepperTest {
         }
 
         @Override
-        Collection<Record<String>> doExecute(Collection<Record<String>> records) {
+        public Collection<Record<String>> doExecute(Collection<Record<String>> records) {
             try {
                 Thread.sleep(100);
             } catch (InterruptedException e) {

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/buffer/BlockingBuffer.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/buffer/BlockingBuffer.java
@@ -2,6 +2,7 @@ package com.amazon.dataprepper.plugins.buffer;
 
 import com.amazon.dataprepper.model.PluginType;
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
+import com.amazon.dataprepper.model.buffer.AbstractBuffer;
 import com.amazon.dataprepper.model.buffer.Buffer;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
@@ -31,7 +32,7 @@ import static java.lang.String.format;
  * batch size is defined/determined by the configuration attribute {@link #ATTRIBUTE_BATCH_SIZE} or the timeout parameter
  */
 @DataPrepperPlugin(name = "bounded_blocking", type = PluginType.BUFFER)
-public class BlockingBuffer<T extends Record<?>> implements Buffer<T> {
+public class BlockingBuffer<T extends Record<?>> extends AbstractBuffer<T> {
     private static final Logger LOG = LoggerFactory.getLogger(BlockingBuffer.class);
     private static final int DEFAULT_BUFFER_CAPACITY = 512;
     private static final int DEFAULT_BATCH_SIZE = 8;
@@ -51,6 +52,7 @@ public class BlockingBuffer<T extends Record<?>> implements Buffer<T> {
      * @param pipelineName   the name of the associated Pipeline
      */
     public BlockingBuffer(final int bufferCapacity, final int batchSize, final String pipelineName) {
+        super("BlockingBuffer", pipelineName);
         this.batchSize = batchSize;
         this.blockingQueue = new LinkedBlockingQueue<>(bufferCapacity);
         this.pipelineName = pipelineName;
@@ -77,7 +79,7 @@ public class BlockingBuffer<T extends Record<?>> implements Buffer<T> {
     }
 
     @Override
-    public void write(T record, int timeoutInMillis) throws TimeoutException {
+    public void doWrite(T record, int timeoutInMillis) throws TimeoutException {
         try {
             boolean isSuccess = blockingQueue.offer(record, timeoutInMillis, TimeUnit.MILLISECONDS);
             if (!isSuccess) {
@@ -99,7 +101,7 @@ public class BlockingBuffer<T extends Record<?>> implements Buffer<T> {
      * @return The earliest batch of records in the buffer which are still not read.
      */
     @Override
-    public Collection<T> read(int timeoutInMillis) {
+    public Collection<T> doRead(int timeoutInMillis) {
         final List<T> records = new ArrayList<>();
         final Stopwatch stopwatch = Stopwatch.createStarted();
         try {

--- a/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSink.java
+++ b/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSink.java
@@ -4,6 +4,7 @@ import com.amazon.dataprepper.model.PluginType;
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.model.sink.AbstractSink;
 import com.amazon.dataprepper.model.sink.Sink;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.DocWriteRequest;
@@ -36,7 +37,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 @DataPrepperPlugin(name = "elasticsearch", type = PluginType.SINK)
-public class ElasticsearchSink implements Sink<Record<String>> {
+public class ElasticsearchSink extends AbstractSink<Record<String>> {
 
   private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchSink.class);
   // Pulled from BulkRequest to make estimation of bytes consistent
@@ -52,6 +53,7 @@ public class ElasticsearchSink implements Sink<Record<String>> {
   private final String documentIdField;
 
   public ElasticsearchSink(final PluginSetting pluginSetting) {
+    super(pluginSetting);
     this.esSinkConfig = ElasticsearchSinkConfiguration.readESConfig(pluginSetting);
     this.bulkSize = ByteSizeUnit.MB.toBytes(esSinkConfig.getIndexConfiguration().getBulkSize());
     this.indexType = esSinkConfig.getIndexConfiguration().getIndexType();
@@ -84,7 +86,7 @@ public class ElasticsearchSink implements Sink<Record<String>> {
   }
 
   @Override
-  public void output(final Collection<Record<String>> records) {
+  public void doOutput(final Collection<Record<String>> records) {
     if (records.isEmpty()) {
       return;
     }

--- a/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
+++ b/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
@@ -233,7 +233,9 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
       metadata.put(ConnectionConfiguration.PASSWORD, password);
     }
 
-    return new PluginSetting("elasticsearch", metadata);
+    final PluginSetting pluginSetting = new PluginSetting("elasticsearch", metadata);
+    pluginSetting.setPipelineName("integTestPipeline");
+    return pluginSetting;
   }
 
   private Record<String> generateCustomRecord(final String idField, final String documentId) throws IOException {

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/processor/ServiceMapStatefulProcessorTest.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/processor/ServiceMapStatefulProcessorTest.java
@@ -1,5 +1,6 @@
 package com.amazon.dataprepper.plugins.processor;
 
+import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.proto.trace.v1.Span;
@@ -35,6 +36,9 @@ public class ServiceMapStatefulProcessorTest {
     private static final String PASSWORD_DATABASE = "PASS";
     private static final String PAYMENT_SERVICE = "PAY";
     private static final String CART_SERVICE = "CART";
+    private static final PluginSetting PLUGIN_SETTING = new PluginSetting("testServiceMapProcessor", Collections.emptyMap()){{
+        setPipelineName("testPipelineName");
+    }};
 
     /**
      * This function mocks what the frontend will do to resolve the data in the service map index to find the edges
@@ -62,8 +66,8 @@ public class ServiceMapStatefulProcessorTest {
         Mockito.when(clock.instant()).thenReturn(Instant.now());
         ExecutorService threadpool = Executors.newCachedThreadPool();
         final File path = new File(ServiceMapProcessorConfig.DEFAULT_LMDB_PATH);
-        final ServiceMapStatefulProcessor serviceMapStateful1 = new ServiceMapStatefulProcessor(100, path, clock, 16);
-        final ServiceMapStatefulProcessor serviceMapStateful2 = new ServiceMapStatefulProcessor(100, path, clock, 16);
+        final ServiceMapStatefulProcessor serviceMapStateful1 = new ServiceMapStatefulProcessor(100, path, clock, 16, PLUGIN_SETTING);
+        final ServiceMapStatefulProcessor serviceMapStateful2 = new ServiceMapStatefulProcessor(100, path, clock, 16, PLUGIN_SETTING);
 
         final byte[] rootSpanId1 = ServiceMapTestUtils.getRandomBytes(8);
         final byte[] rootSpanId2 = ServiceMapTestUtils.getRandomBytes(8);


### PR DESCRIPTION
…nd ESSink

*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/Data-Prepper/issues/201

*Description of changes:*
- Extending AbstractPrepper for ServiceMapStatefulProcessor
  - Still todo: add custom metrics
- Extending AbstractSink for ElasticsearchSink
  - Still todo: custom metrics
- Extending AbstractBuffer for BlockingBuffer
- Adding new constructor in AbstractBuffer to support BlockingBuffer constructors
- Adding new static method to PluginMetrics to create an instance without a PluginSetting
- Adding pipeline name to PluginSetting in ES integration test



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
