### PR TITLE
Use HashRing in Peerforwarder

### DIFF
--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
@@ -18,7 +19,8 @@ public class HashRing {
     private final int numVirtualNodes;
     private final TreeMap<Long, String> virtualNodes = new TreeMap<>();
 
-    public HashRing(@Nonnull final List<String> serverIps, final int numVirtualNodes) {
+    public HashRing(final List<String> serverIps, final int numVirtualNodes) {
+        Objects.requireNonNull(serverIps);
         this.numVirtualNodes = numVirtualNodes;
         final List<String> sortedServerIps = new ArrayList<>(new HashSet<>(serverIps));
         Collections.sort(sortedServerIps);
@@ -31,7 +33,7 @@ public class HashRing {
         return serverIps;
     }
 
-    private void addServerIp(@Nonnull final String serverIp) {
+    private void addServerIp(final String serverIp) {
         serverIps.add(serverIp);
         final byte[] serverIpInBytes = serverIp.getBytes();
         final Checksum crc32 = new CRC32();
@@ -46,7 +48,7 @@ public class HashRing {
         }
     }
 
-    public String getServerIp(@Nonnull final byte[] traceId) {
+    public String getServerIp(final byte[] traceId) {
         if (virtualNodes.isEmpty()) {
             return null;
         }

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
@@ -23,9 +23,7 @@ public class HashRing {
     public HashRing(final List<String> serverIps, final int numVirtualNodes) {
         Objects.requireNonNull(serverIps);
         this.numVirtualNodes = numVirtualNodes;
-        final List<String> sortedServerIps = new ArrayList<>(new HashSet<>(serverIps));
-        Collections.sort(sortedServerIps);
-        for (final String serverIp: sortedServerIps) {
+        for (final String serverIp: serverIps) {
             addServerIp(serverIp);
         }
     }

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
@@ -47,12 +47,13 @@ public class HashRing {
         }
     }
 
-    public Optional<String> getServerIp(final byte[] traceId) {
+    public Optional<String> getServerIp(final String traceId) {
         if (virtualNodes.isEmpty()) {
             return Optional.empty();
         }
+        final byte[] traceIdInBytes = traceId.getBytes();
         final Checksum crc32 = new CRC32();
-        crc32.update(traceId, 0, traceId.length);
+        crc32.update(traceIdInBytes, 0, traceIdInBytes.length);
         final long hashcode = crc32.getValue();
         // obtain Map.Entry with key greater than the hashcode
         final Map.Entry<Long, String> entry = virtualNodes.higherEntry(hashcode);

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
@@ -5,6 +5,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
@@ -48,13 +49,13 @@ public class HashRing {
         final Checksum crc32 = new CRC32();
         crc32.update(traceId, 0, traceId.length);
         final long hashcode = crc32.getValue();
-        // obtain key greater than the hashcode
-        final Long key = virtualNodes.higherKey(hashcode);
-        if (key == null) {
+        // obtain Map.Entry with key greater than the hashcode
+        final Map.Entry<Long, String> entry = virtualNodes.higherEntry(hashcode);
+        if (entry == null) {
             // return first node if no key is greater than the hashcode
-            return virtualNodes.get(virtualNodes.firstKey());
+            return virtualNodes.firstEntry().getValue();
         } else {
-            return virtualNodes.get(key);
+            return entry.getValue();
         }
     }
 }

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
@@ -48,9 +49,9 @@ public class HashRing {
         }
     }
 
-    public String getServerIp(final byte[] traceId) {
+    public Optional<String> getServerIp(final byte[] traceId) {
         if (virtualNodes.isEmpty()) {
-            return null;
+            return Optional.empty();
         }
         final Checksum crc32 = new CRC32();
         crc32.update(traceId, 0, traceId.length);
@@ -59,9 +60,9 @@ public class HashRing {
         final Map.Entry<Long, String> entry = virtualNodes.higherEntry(hashcode);
         if (entry == null) {
             // return first node if no key is greater than the hashcode
-            return virtualNodes.firstEntry().getValue();
+            return Optional.of(virtualNodes.firstEntry().getValue());
         } else {
-            return entry.getValue();
+            return Optional.of(entry.getValue());
         }
     }
 }

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
@@ -1,0 +1,60 @@
+package com.amazon.dataprepper.plugins.processor.peerforwarder;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.zip.CRC32;
+import java.util.zip.Checksum;
+
+@NotThreadSafe
+public class HashRing {
+    private final List<String> serverIps = new ArrayList<>();
+    private final int numVirtualNodes;
+    private final TreeMap<Long, String> virtualNodes = new TreeMap<>();
+
+    public HashRing(@Nonnull final List<String> serverIps, final int numVirtualNodes) {
+        this.numVirtualNodes = numVirtualNodes;
+        for (final String serverIp: serverIps) {
+            addServerIp(serverIp);
+        }
+    }
+
+    public List<String> getServerIps() {
+        return serverIps;
+    }
+
+    public void addServerIp(@Nonnull final String serverIp) {
+        serverIps.add(serverIp);
+        final byte[] serverIpInBytes = serverIp.getBytes();
+        final Checksum crc32 = new CRC32();
+        final ByteBuffer intBuffer = ByteBuffer.allocate(4);
+        for (int i = 0; i < numVirtualNodes; i++) {
+            crc32.update(serverIpInBytes, 0, serverIpInBytes.length);
+            intBuffer.putInt(i);
+            crc32.update(intBuffer.array(), 0, intBuffer.array().length);
+            virtualNodes.put(crc32.getValue(), serverIp);
+            crc32.reset();
+            intBuffer.clear();
+        }
+    }
+
+    public String getServerIp(@Nonnull final byte[] traceId) {
+        if (virtualNodes.isEmpty()) {
+            return null;
+        }
+        final Checksum crc32 = new CRC32();
+        crc32.update(traceId, 0, traceId.length);
+        final long hashcode = crc32.getValue();
+        // obtain key greater than the hashcode
+        final Long key = virtualNodes.higherKey(hashcode);
+        if (key == null) {
+            // return first node if no key is greater than the hashcode
+            return virtualNodes.get(virtualNodes.firstKey());
+        } else {
+            return virtualNodes.get(key);
+        }
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
@@ -5,6 +5,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -19,7 +20,7 @@ public class HashRing {
 
     public HashRing(@Nonnull final List<String> serverIps, final int numVirtualNodes) {
         this.numVirtualNodes = numVirtualNodes;
-        final List<String> sortedServerIps = new ArrayList<>(serverIps);
+        final List<String> sortedServerIps = new ArrayList<>(new HashSet<>(serverIps));
         Collections.sort(sortedServerIps);
         for (final String serverIp: sortedServerIps) {
             addServerIp(serverIp);

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarder.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarder.java
@@ -88,8 +88,8 @@ public class PeerForwarder implements Processor<Record<ExportTraceServiceRequest
                 for (final Map.Entry<String, ResourceSpans> entry: rsBatch) {
                     final String traceId = entry.getKey();
                     final ResourceSpans newRS = entry.getValue();
-                    final String dataPrepperIp = hashRing.getServerIp(traceId.getBytes());
-                    groupedRS.get(dataPrepperIp).add(newRS);
+                    hashRing.getServerIp(traceId.getBytes()).ifPresent(
+                            dataPrepperIp -> groupedRS.get(dataPrepperIp).add(newRS));
                 }
             }
         }

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarder.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarder.java
@@ -88,8 +88,7 @@ public class PeerForwarder implements Processor<Record<ExportTraceServiceRequest
                 for (final Map.Entry<String, ResourceSpans> entry: rsBatch) {
                     final String traceId = entry.getKey();
                     final ResourceSpans newRS = entry.getValue();
-                    hashRing.getServerIp(traceId.getBytes()).ifPresent(
-                            dataPrepperIp -> groupedRS.get(dataPrepperIp).add(newRS));
+                    hashRing.getServerIp(traceId).ifPresent(dataPrepperIp -> groupedRS.get(dataPrepperIp).add(newRS));
                 }
             }
         }

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarder.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarder.java
@@ -74,6 +74,8 @@ public class PeerForwarder implements Processor<Record<ExportTraceServiceRequest
 
     @Override
     public List<Record<ExportTraceServiceRequest>> execute(final Collection<Record<ExportTraceServiceRequest>> records) {
+        // TODO: regenerate hashRing if there is a change in detected data_prepper_ips
+
         final Map<String, List<ResourceSpans>> groupedRS = new HashMap<>();
         for (final String dataPrepperIp: dataPrepperIps) {
             groupedRS.put(dataPrepperIp, new ArrayList<>());
@@ -86,7 +88,7 @@ public class PeerForwarder implements Processor<Record<ExportTraceServiceRequest
                 for (final Map.Entry<String, ResourceSpans> entry: rsBatch) {
                     final String traceId = entry.getKey();
                     final ResourceSpans newRS = entry.getValue();
-                    final String dataPrepperIp = getHostByConsistentHashing(traceId);
+                    final String dataPrepperIp = hashRing.getServerIp(traceId.getBytes());
                     groupedRS.get(dataPrepperIp).add(newRS);
                 }
             }
@@ -136,10 +138,5 @@ public class PeerForwarder implements Processor<Record<ExportTraceServiceRequest
         } else {
             localBuffer.add(new Record<>(request));
         }
-    }
-
-    private String getHostByConsistentHashing(final String traceId) {
-        // TODO: better consistent hashing algorithm, e.g. ring hashing
-        return hashRing.getServerIp(traceId.getBytes());
     }
 }

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderConfig.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderConfig.java
@@ -11,6 +11,7 @@ public class PeerForwarderConfig {
     public static final String DATA_PREPPER_IPS = "data_prepper_ips";
     public static final String TIME_OUT = "time_out";
     public static final String MAX_NUM_SPANS_PER_REQUEST = "span_agg_count";
+    public static final int NUM_VIRTUAL_NODES = 10;
 
     private final List<String> dataPrepperIps;
 

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
@@ -22,12 +22,20 @@ public class HashRingTest {
 
     @Test
     public void testGetServerIpSingleVirtualNode() {
-        final List<String> testServerIps = Arrays.asList("20", "30", "10");
-        final HashRing hashRing = new HashRing(testServerIps, 1);
+        List<String> testServerIps = Arrays.asList("20", "30", "10");
+        HashRing hashRing = new HashRing(testServerIps, 1);
         // Check indeed alternating serverIps for different inputs
         final String serverIp1 = hashRing.getServerIp(TEST_TRACE_ID_1).orElse("");
         final String serverIp2 = hashRing.getServerIp(TEST_TRACE_ID_2).orElse("");
         Assert.assertNotEquals(serverIp1, serverIp2);
+        // Duplicate and reorder the input serverIps
+        testServerIps = Arrays.asList("10", "10", "20", "30");
+        hashRing = new HashRing(testServerIps, 1);
+        // Check hash results do not depend on input order
+        final String serverIp3 = hashRing.getServerIp(TEST_TRACE_ID_1).orElse("");
+        final String serverIp4 = hashRing.getServerIp(TEST_TRACE_ID_2).orElse("");
+        Assert.assertEquals(serverIp1, serverIp3);
+        Assert.assertEquals(serverIp2, serverIp4);
     }
 
     @Test

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
@@ -25,8 +25,8 @@ public class HashRingTest {
         Assert.assertEquals(3, virtualNodes.size());
         Assert.assertTrue(virtualNodes.values().containsAll(expServerIps));
         // Check indeed alternating serverIps for different inputs
-        final String serverIp1 = hashRing.getServerIp(TEST_TRACE_ID_1);
-        final String serverIp2 = hashRing.getServerIp(TEST_TRACE_ID_2);
+        final String serverIp1 = hashRing.getServerIp(TEST_TRACE_ID_1).orElse("");
+        final String serverIp2 = hashRing.getServerIp(TEST_TRACE_ID_2).orElse("");
         Assert.assertNotEquals(serverIp1, serverIp2);
     }
 
@@ -37,7 +37,7 @@ public class HashRingTest {
         Assert.assertEquals(testServerIps, hashRing.getServerIps());
         final TreeMap<Long, String> virtualNodes = Whitebox.getInternalState(hashRing, "virtualNodes");
         Assert.assertEquals(3, virtualNodes.size());
-        final String serverIp = hashRing.getServerIp(TEST_TRACE_ID_1);
+        final String serverIp = hashRing.getServerIp(TEST_TRACE_ID_1).orElse("");
         Assert.assertEquals("127.0.0.1", serverIp);
     }
 }

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
@@ -16,9 +16,11 @@ public class HashRingTest {
 
     @Test
     public void testGetServerIpSingleVirtualNode() {
-        final List<String> testServerIps = Arrays.asList("10", "20", "30");
+        final List<String> testServerIps = Arrays.asList("20", "30", "10");
+        final List<String> expServerIps = new ArrayList<>(testServerIps);
+        Collections.sort(expServerIps);
         final HashRing hashRing = new HashRing(testServerIps, 1);
-        Assert.assertEquals(testServerIps, hashRing.getServerIps());
+        Assert.assertEquals(expServerIps, hashRing.getServerIps());
         // Check indeed alternating serverIps for different inputs
         final String serverIp1 = hashRing.getServerIp(TEST_TRACE_ID_1);
         final String serverIp2 = hashRing.getServerIp(TEST_TRACE_ID_2);
@@ -34,19 +36,5 @@ public class HashRingTest {
         Assert.assertEquals(3, virtualNodes.size());
         final String serverIp = hashRing.getServerIp(TEST_TRACE_ID_1);
         Assert.assertEquals("127.0.0.1", serverIp);
-    }
-
-    @Test
-    public void testAddAndGetServerIp() {
-        final HashRing hashRing = new HashRing(new ArrayList<>(), 1);
-        Assert.assertEquals(new ArrayList<>(), hashRing.getServerIps());
-        Assert.assertNull(hashRing.getServerIp(TEST_TRACE_ID_2));
-        // Check indeed alternating serverIps after adding new serverIp
-        hashRing.addServerIp("10");
-        final String serverIp1 = hashRing.getServerIp(TEST_TRACE_ID_2);
-        Assert.assertEquals("10", serverIp1);
-        hashRing.addServerIp("30");
-        final String serverIp2 = hashRing.getServerIp(TEST_TRACE_ID_2);
-        Assert.assertEquals("30", serverIp2);
     }
 }

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
@@ -14,10 +14,16 @@ public class HashRingTest {
     public static final String TEST_TRACE_ID_2 = "20";
 
     @Test
-    public void testGetServerIpSingleVirtualNode() {
+    public void testListServerIps() {
         final List<String> testServerIps = Arrays.asList("20", "30", "10");
         final HashRing hashRing = new HashRing(testServerIps, 1);
         Assert.assertEquals(testServerIps, hashRing.getServerIps());
+    }
+
+    @Test
+    public void testGetServerIpSingleVirtualNode() {
+        final List<String> testServerIps = Arrays.asList("20", "30", "10");
+        final HashRing hashRing = new HashRing(testServerIps, 1);
         // Check indeed alternating serverIps for different inputs
         final String serverIp1 = hashRing.getServerIp(TEST_TRACE_ID_1).orElse("");
         final String serverIp2 = hashRing.getServerIp(TEST_TRACE_ID_2).orElse("");

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
@@ -1,0 +1,52 @@
+package com.amazon.dataprepper.plugins.processor.peerforwarder;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeMap;
+
+public class HashRingTest {
+    public static final byte[] TEST_TRACE_ID_1 = "10".getBytes();
+    public static final byte[] TEST_TRACE_ID_2 = "20".getBytes();
+
+    @Test
+    public void testGetServerIpSingleVirtualNode() {
+        final List<String> testServerIps = Arrays.asList("10", "20", "30");
+        final HashRing hashRing = new HashRing(testServerIps, 1);
+        Assert.assertEquals(testServerIps, hashRing.getServerIps());
+        // Check indeed alternating serverIps for different inputs
+        final String serverIp1 = hashRing.getServerIp(TEST_TRACE_ID_1);
+        final String serverIp2 = hashRing.getServerIp(TEST_TRACE_ID_2);
+        Assert.assertNotEquals(serverIp1, serverIp2);
+    }
+
+    @Test
+    public void testGetServerIpMultipleVirtualNode() {
+        final List<String> testServerIps = Collections.singletonList("127.0.0.1");
+        final HashRing hashRing = new HashRing(testServerIps, 3);
+        Assert.assertEquals(testServerIps, hashRing.getServerIps());
+        final TreeMap<Long, String> virtualNodes = Whitebox.getInternalState(hashRing, "virtualNodes");
+        Assert.assertEquals(3, virtualNodes.size());
+        final String serverIp = hashRing.getServerIp(TEST_TRACE_ID_1);
+        Assert.assertEquals("127.0.0.1", serverIp);
+    }
+
+    @Test
+    public void testAddAndGetServerIp() {
+        final HashRing hashRing = new HashRing(new ArrayList<>(), 1);
+        Assert.assertEquals(new ArrayList<>(), hashRing.getServerIps());
+        Assert.assertNull(hashRing.getServerIp(TEST_TRACE_ID_2));
+        // Check indeed alternating serverIps after adding new serverIp
+        hashRing.addServerIp("10");
+        final String serverIp1 = hashRing.getServerIp(TEST_TRACE_ID_2);
+        Assert.assertEquals("10", serverIp1);
+        hashRing.addServerIp("30");
+        final String serverIp2 = hashRing.getServerIp(TEST_TRACE_ID_2);
+        Assert.assertEquals("30", serverIp2);
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
@@ -21,6 +21,9 @@ public class HashRingTest {
         Collections.sort(expServerIps);
         final HashRing hashRing = new HashRing(testServerIps, 1);
         Assert.assertEquals(expServerIps, hashRing.getServerIps());
+        final TreeMap<Long, String> virtualNodes = Whitebox.getInternalState(hashRing, "virtualNodes");
+        Assert.assertEquals(3, virtualNodes.size());
+        Assert.assertTrue(virtualNodes.values().containsAll(expServerIps));
         // Check indeed alternating serverIps for different inputs
         final String serverIp1 = hashRing.getServerIp(TEST_TRACE_ID_1);
         final String serverIp2 = hashRing.getServerIp(TEST_TRACE_ID_2);

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.TreeMap;
 
 public class HashRingTest {
-    public static final byte[] TEST_TRACE_ID_1 = "10".getBytes();
-    public static final byte[] TEST_TRACE_ID_2 = "20".getBytes();
+    public static final String TEST_TRACE_ID_1 = "10";
+    public static final String TEST_TRACE_ID_2 = "20";
 
     @Test
     public void testGetServerIpSingleVirtualNode() {

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
@@ -4,7 +4,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -17,13 +16,8 @@ public class HashRingTest {
     @Test
     public void testGetServerIpSingleVirtualNode() {
         final List<String> testServerIps = Arrays.asList("20", "30", "10");
-        final List<String> expServerIps = new ArrayList<>(testServerIps);
-        Collections.sort(expServerIps);
         final HashRing hashRing = new HashRing(testServerIps, 1);
-        Assert.assertEquals(expServerIps, hashRing.getServerIps());
-        final TreeMap<Long, String> virtualNodes = Whitebox.getInternalState(hashRing, "virtualNodes");
-        Assert.assertEquals(3, virtualNodes.size());
-        Assert.assertTrue(virtualNodes.values().containsAll(expServerIps));
+        Assert.assertEquals(testServerIps, hashRing.getServerIps());
         // Check indeed alternating serverIps for different inputs
         final String serverIp1 = hashRing.getServerIp(TEST_TRACE_ID_1).orElse("");
         final String serverIp2 = hashRing.getServerIp(TEST_TRACE_ID_2).orElse("");

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderTest.java
@@ -40,17 +40,17 @@ import static org.powermock.api.mockito.PowerMockito.spy;
 public class PeerForwarderTest {
     private static final String LOCAL_IP = "127.0.0.1";
     private static final Span SPAN_1 = Span.newBuilder()
-            .setTraceId(ByteString.copyFromUtf8("traceId1")).setSpanId(ByteString.copyFromUtf8("spanId1")).build();
+            .setTraceId(ByteString.copyFromUtf8("traceIdA")).setSpanId(ByteString.copyFromUtf8("spanId1")).build();
     private static final Span SPAN_2 = Span.newBuilder()
-            .setTraceId(ByteString.copyFromUtf8("traceId1")).setSpanId(ByteString.copyFromUtf8("spanId2")).build();
+            .setTraceId(ByteString.copyFromUtf8("traceIdA")).setSpanId(ByteString.copyFromUtf8("spanId2")).build();
     private static final Span SPAN_3 = Span.newBuilder()
-            .setTraceId(ByteString.copyFromUtf8("traceId1")).setSpanId(ByteString.copyFromUtf8("spanId3")).build();
+            .setTraceId(ByteString.copyFromUtf8("traceIdA")).setSpanId(ByteString.copyFromUtf8("spanId3")).build();
     private static final Span SPAN_4 = Span.newBuilder()
-            .setTraceId(ByteString.copyFromUtf8("traceId2")).setSpanId(ByteString.copyFromUtf8("spanId4")).build();
+            .setTraceId(ByteString.copyFromUtf8("traceIdB")).setSpanId(ByteString.copyFromUtf8("spanId4")).build();
     private static final Span SPAN_5 = Span.newBuilder()
-            .setTraceId(ByteString.copyFromUtf8("traceId2")).setSpanId(ByteString.copyFromUtf8("spanId5")).build();
+            .setTraceId(ByteString.copyFromUtf8("traceIdB")).setSpanId(ByteString.copyFromUtf8("spanId5")).build();
     private static final Span SPAN_6 = Span.newBuilder()
-            .setTraceId(ByteString.copyFromUtf8("traceId2")).setSpanId(ByteString.copyFromUtf8("spanId6")).build();
+            .setTraceId(ByteString.copyFromUtf8("traceIdB")).setSpanId(ByteString.copyFromUtf8("spanId6")).build();
 
     private static final ExportTraceServiceRequest REQUEST_1 = generateRequest(SPAN_1, SPAN_2, SPAN_4);
     private static final ExportTraceServiceRequest REQUEST_2 = generateRequest(SPAN_3, SPAN_5, SPAN_6);


### PR DESCRIPTION
*Issue #, if available:*
Contributes to #200 

*Description of changes:*
Replace consistent hashing algorithm of IP address and traceId in Peerforwarder with HashRing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
