### PR TITLE
#200: Added PeerListProvider interface and static implementation.

### DIFF
--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerClientPool.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerClientPool.java
@@ -1,0 +1,39 @@
+package com.amazon.dataprepper.plugins.processor.peerforwarder;
+
+import com.linecorp.armeria.client.Clients;
+import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class PeerClientPool {
+    private static final PeerClientPool INSTANCE = new PeerClientPool();
+    private final Map<String, TraceServiceGrpc.TraceServiceBlockingStub> peerClients;
+
+    private int clientTimeoutSeconds = 3;
+
+    private PeerClientPool() {
+        peerClients = new ConcurrentHashMap<>();
+    }
+
+    public static PeerClientPool getInstance() {
+        return INSTANCE;
+    }
+
+    public void setClientTimeoutSeconds(int clientTimeoutSeconds) {
+        this.clientTimeoutSeconds = clientTimeoutSeconds;
+    }
+
+    public TraceServiceGrpc.TraceServiceBlockingStub getClient(final String address) {
+        // TODO: Resolve to IP first, or is hostname good enough?
+        return peerClients.computeIfAbsent(address, addr -> createGRPCClient(addr));
+    }
+
+    private TraceServiceGrpc.TraceServiceBlockingStub createGRPCClient(final String ipAddress) {
+        // TODO: replace hardcoded port with customization
+        return Clients.builder(String.format("gproto+http://%s:21890/", ipAddress))
+                .writeTimeout(Duration.ofSeconds(clientTimeoutSeconds))
+                .build(TraceServiceGrpc.TraceServiceBlockingStub.class);
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderConfig.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderConfig.java
@@ -1,26 +1,56 @@
 package com.amazon.dataprepper.plugins.processor.peerforwarder;
 
 import com.amazon.dataprepper.model.configuration.PluginSetting;
-
-import java.util.ArrayList;
-import java.util.List;
+import com.amazon.dataprepper.plugins.processor.peerforwarder.discovery.PeerListProvider;
+import com.amazon.dataprepper.plugins.processor.peerforwarder.discovery.PeerListProviderFactory;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class PeerForwarderConfig {
-    public static final String DATA_PREPPER_IPS = "data_prepper_ips";
     public static final String TIME_OUT = "time_out";
     public static final String MAX_NUM_SPANS_PER_REQUEST = "span_agg_count";
     public static final int NUM_VIRTUAL_NODES = 10;
+    public static final String DISCOVERY_MODE = "discovery_mode";
+    public static final String CLUSTER_HOSTNAME = "cluster_hostname";
+    public static final String DATA_PREPPER_IPS = "data_prepper_ips";
 
-    private final List<String> dataPrepperIps;
-
+    private final HashRing hashRing;
+    private final PeerClientPool peerClientPool;
     private final int timeOut;
-
     private final int maxNumSpansPerRequest;
 
-    public List<String> getDataPrepperIps() {
-        return dataPrepperIps;
+    private PeerForwarderConfig(final PeerClientPool peerClientPool,
+                                final HashRing hashRing,
+                                final int timeOut,
+                                final int maxNumSpansPerRequest) {
+        checkNotNull(peerClientPool);
+        checkNotNull(hashRing);
+
+        this.peerClientPool = peerClientPool;
+        this.hashRing = hashRing;
+        this.timeOut = timeOut;
+        this.maxNumSpansPerRequest = maxNumSpansPerRequest;
+    }
+
+    public static PeerForwarderConfig buildConfig(final PluginSetting pluginSetting) {
+        final PeerListProvider peerListProvider = new PeerListProviderFactory().createProvider(pluginSetting);
+        final HashRing hashRing = new HashRing(peerListProvider, NUM_VIRTUAL_NODES);
+        final PeerClientPool peerClientPool = PeerClientPool.getInstance();
+        peerClientPool.setClientTimeoutSeconds(3);
+
+        return new PeerForwarderConfig(
+                peerClientPool,
+                hashRing,
+                pluginSetting.getIntegerOrDefault(TIME_OUT, 3),
+                pluginSetting.getIntegerOrDefault(MAX_NUM_SPANS_PER_REQUEST, 48));
+    }
+
+    public HashRing getHashRing() {
+        return hashRing;
+    }
+
+    public PeerClientPool getPeerClientPool() {
+        return peerClientPool;
     }
 
     public int getTimeOut() {
@@ -29,20 +59,5 @@ public class PeerForwarderConfig {
 
     public int getMaxNumSpansPerRequest() {
         return maxNumSpansPerRequest;
-    }
-
-    private PeerForwarderConfig(final List<String> dataPrepperIps, final int timeOut, final int maxNumSpansPerRequest) {
-        checkNotNull(dataPrepperIps, "peerIps cannot be null");
-        this.dataPrepperIps = dataPrepperIps;
-        this.timeOut = timeOut;
-        this.maxNumSpansPerRequest = maxNumSpansPerRequest;
-    }
-
-    @SuppressWarnings("unchecked")
-    public static PeerForwarderConfig buildConfig(final PluginSetting pluginSetting) {
-        return new PeerForwarderConfig(
-                (List<String>) pluginSetting.getAttributeOrDefault(DATA_PREPPER_IPS, new ArrayList<>()),
-                pluginSetting.getIntegerOrDefault(TIME_OUT, 300),
-                pluginSetting.getIntegerOrDefault(MAX_NUM_SPANS_PER_REQUEST, 48));
     }
 }

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/DiscoveryMode.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/DiscoveryMode.java
@@ -1,0 +1,5 @@
+package com.amazon.dataprepper.plugins.processor.peerforwarder.discovery;
+
+public enum DiscoveryMode {
+    STATIC,
+}

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/PeerListProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/PeerListProvider.java
@@ -1,0 +1,10 @@
+package com.amazon.dataprepper.plugins.processor.peerforwarder.discovery;
+
+import java.util.List;
+
+/**
+ * Provides a list other Data Prepper instance endpoints within the same cluster.
+ */
+public interface PeerListProvider {
+    List<String> getPeerList();
+}

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/PeerListProviderFactory.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/PeerListProviderFactory.java
@@ -1,0 +1,27 @@
+package com.amazon.dataprepper.plugins.processor.peerforwarder.discovery;
+
+import com.amazon.dataprepper.model.configuration.PluginSetting;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import static com.amazon.dataprepper.plugins.processor.peerforwarder.PeerForwarderConfig.DATA_PREPPER_IPS;
+import static com.amazon.dataprepper.plugins.processor.peerforwarder.PeerForwarderConfig.DISCOVERY_MODE;
+
+public class PeerListProviderFactory {
+    public PeerListProvider createProvider(final PluginSetting pluginSetting) {
+        Objects.requireNonNull(pluginSetting);
+
+        final String discoveryModeString = pluginSetting.getStringOrDefault(DISCOVERY_MODE, DiscoveryMode.STATIC.toString()).toUpperCase();
+        final DiscoveryMode discoveryMode = DiscoveryMode.valueOf(discoveryModeString);
+
+        switch (discoveryMode) {
+            case STATIC:
+                final List<String> endpoints = (List<String>) pluginSetting.getAttributeOrDefault(DATA_PREPPER_IPS, Collections.emptyList());
+                return new StaticPeerListProvider(endpoints);
+            default:
+                return new StaticPeerListProvider();
+        }
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/StaticPeerListProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/StaticPeerListProvider.java
@@ -1,0 +1,36 @@
+package com.amazon.dataprepper.plugins.processor.peerforwarder.discovery;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+
+public class StaticPeerListProvider implements PeerListProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(StaticPeerListProvider.class);
+
+    public static final String LOCAL_ENDPOINT = "127.0.0.1";
+    public static final List<String> DEFAULT_LIST = Collections.singletonList(LOCAL_ENDPOINT);
+
+    private final List<String> endpoints;
+
+    public StaticPeerListProvider(final List<String> dataPrepperEndpoints) {
+        if (dataPrepperEndpoints != null && dataPrepperEndpoints.size() > 0) {
+            endpoints = Collections.unmodifiableList(dataPrepperEndpoints);
+        } else {
+            LOG.warn("No endpoints provided, defaulting to localhost only.");
+            endpoints = DEFAULT_LIST;
+        }
+
+        LOG.info("Found endpoints: {}", String.join(",", endpoints));
+    }
+
+    public StaticPeerListProvider() {
+        this(Collections.emptyList());
+    }
+
+    @Override
+    public List<String> getPeerList() {
+        return endpoints;
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerClientPoolTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerClientPoolTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertNotNull;
 
 public class PeerClientPoolTest {
     private static final String VALID_ADDRESS = "10.10.10.5";
-    private static final String INVALID_ADDRESS = "10.10::99.99";
 
     @Test
     public void testGetClientValidAddress() {
@@ -16,12 +15,5 @@ public class PeerClientPoolTest {
         TraceServiceGrpc.TraceServiceBlockingStub client = pool.getClient(VALID_ADDRESS);
 
         assertNotNull(client);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testGetClientInvalidAddress() {
-        PeerClientPool pool = PeerClientPool.getInstance();
-
-        pool.getClient(INVALID_ADDRESS);
     }
 }

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerClientPoolTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerClientPoolTest.java
@@ -1,0 +1,27 @@
+package com.amazon.dataprepper.plugins.processor.peerforwarder;
+
+import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class PeerClientPoolTest {
+    private static final String VALID_ADDRESS = "10.10.10.5";
+    private static final String INVALID_ADDRESS = "10.10::99.99";
+
+    @Test
+    public void testGetClientValidAddress() {
+        PeerClientPool pool = PeerClientPool.getInstance();
+
+        TraceServiceGrpc.TraceServiceBlockingStub client = pool.getClient(VALID_ADDRESS);
+
+        assertNotNull(client);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetClientInvalidAddress() {
+        PeerClientPool pool = PeerClientPool.getInstance();
+
+        pool.getClient(INVALID_ADDRESS);
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderConfigTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderConfigTest.java
@@ -23,7 +23,6 @@ public class PeerForwarderConfigTest {
         final PeerForwarderConfig peerForwarderConfig = PeerForwarderConfig.buildConfig(
                 new PluginSetting("peer_forwarder", settings));
 
-        Assert.assertEquals(testPeerIps, peerForwarderConfig.getDataPrepperIps());
         Assert.assertEquals(testNumSpansPerRequest, peerForwarderConfig.getMaxNumSpansPerRequest());
         Assert.assertEquals(testTimeout, peerForwarderConfig.getTimeOut());
     }

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderTest.java
@@ -239,6 +239,7 @@ public class PeerForwarderTest {
 
     private PeerForwarder generatePeerForwarder(final List<String> dataPrepperIps, final int spansPerRequest) {
         final HashMap<String, Object> settings = new HashMap<>();
+        settings.put(PeerForwarderConfig.DISCOVERY_MODE, "STATIC");
         settings.put(PeerForwarderConfig.DATA_PREPPER_IPS, dataPrepperIps);
         settings.put(PeerForwarderConfig.MAX_NUM_SPANS_PER_REQUEST, spansPerRequest);
         settings.put(PeerForwarderConfig.TIME_OUT, 300);

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/PeerListProviderFactoryTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/PeerListProviderFactoryTest.java
@@ -5,23 +5,20 @@ import com.amazon.dataprepper.plugins.processor.peerforwarder.PeerForwarderConfi
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
+import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PeerListProviderFactoryTest {
+    private static final String PLUGIN_NAME = "PLUGIN_NAME";
     private static final String ENDPOINT = "ENDPOINT";
 
-    @Mock
     private PluginSetting pluginSetting;
 
     private PeerListProviderFactory factory;
@@ -29,11 +26,12 @@ public class PeerListProviderFactoryTest {
     @Before
     public void setup() {
         factory = new PeerListProviderFactory();
+        pluginSetting = new PluginSetting(PLUGIN_NAME, new HashMap<>());
     }
 
     @Test
     public void testCreateProviderStaticInstanceNoEndpoints() {
-        when(pluginSetting.getStringOrDefault(eq(PeerForwarderConfig.DISCOVERY_MODE), any())).thenReturn(DiscoveryMode.STATIC.toString());
+        pluginSetting.getSettings().put(PeerForwarderConfig.DISCOVERY_MODE, DiscoveryMode.STATIC.toString());
 
         PeerListProvider result = factory.createProvider(pluginSetting);
 
@@ -44,8 +42,8 @@ public class PeerListProviderFactoryTest {
 
     @Test
     public void testCreateProviderStaticInstanceWithEndpoints() {
-        when(pluginSetting.getStringOrDefault(eq(PeerForwarderConfig.DISCOVERY_MODE), any())).thenReturn(DiscoveryMode.STATIC.toString());
-        when(pluginSetting.getAttributeOrDefault(eq(PeerForwarderConfig.DATA_PREPPER_IPS), any())).thenReturn(Collections.singletonList(ENDPOINT));
+        pluginSetting.getSettings().put(PeerForwarderConfig.DISCOVERY_MODE, DiscoveryMode.STATIC.toString());
+        pluginSetting.getSettings().put(PeerForwarderConfig.DATA_PREPPER_IPS, Collections.singletonList(ENDPOINT));
 
         PeerListProvider result = factory.createProvider(pluginSetting);
 

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/PeerListProviderFactoryTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/PeerListProviderFactoryTest.java
@@ -1,0 +1,56 @@
+package com.amazon.dataprepper.plugins.processor.peerforwarder.discovery;
+
+import com.amazon.dataprepper.model.configuration.PluginSetting;
+import com.amazon.dataprepper.plugins.processor.peerforwarder.PeerForwarderConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PeerListProviderFactoryTest {
+    private static final String ENDPOINT = "ENDPOINT";
+
+    @Mock
+    private PluginSetting pluginSetting;
+
+    private PeerListProviderFactory factory;
+
+    @Before
+    public void setup() {
+        factory = new PeerListProviderFactory();
+    }
+
+    @Test
+    public void testCreateProviderStaticInstanceNoEndpoints() {
+        when(pluginSetting.getStringOrDefault(eq(PeerForwarderConfig.DISCOVERY_MODE), any())).thenReturn(DiscoveryMode.STATIC.toString());
+
+        PeerListProvider result = factory.createProvider(pluginSetting);
+
+        assertTrue(result instanceof StaticPeerListProvider);
+        assertEquals(1, result.getPeerList().size());
+        assertFalse(result.getPeerList().contains(ENDPOINT));
+    }
+
+    @Test
+    public void testCreateProviderStaticInstanceWithEndpoints() {
+        when(pluginSetting.getStringOrDefault(eq(PeerForwarderConfig.DISCOVERY_MODE), any())).thenReturn(DiscoveryMode.STATIC.toString());
+        when(pluginSetting.getAttributeOrDefault(eq(PeerForwarderConfig.DATA_PREPPER_IPS), any())).thenReturn(Collections.singletonList(ENDPOINT));
+
+        PeerListProvider result = factory.createProvider(pluginSetting);
+
+        assertTrue(result instanceof StaticPeerListProvider);
+        assertEquals(1, result.getPeerList().size());
+        assertTrue(result.getPeerList().contains(ENDPOINT));
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/StaticPeerListProviderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/StaticPeerListProviderTest.java
@@ -1,0 +1,30 @@
+package com.amazon.dataprepper.plugins.processor.peerforwarder.discovery;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class StaticPeerListProviderTest {
+    private static final String ENDPOINT_1 = "10.10.0.1";
+    private static final String ENDPOINT_2 = "10.10.0.2";
+    private static final List<String> ENDPOINT_LIST = Arrays.asList(ENDPOINT_1, ENDPOINT_2);
+
+    @Test
+    public void testDefaultListProvider() {
+        StaticPeerListProvider listProvider = new StaticPeerListProvider();
+
+        assertEquals(1, listProvider.getPeerList().size());
+        assertEquals(StaticPeerListProvider.LOCAL_ENDPOINT, listProvider.getPeerList().get(0));
+    }
+
+    @Test
+    public void testListProviderWithGivenList() {
+        StaticPeerListProvider listProvider = new StaticPeerListProvider(ENDPOINT_LIST);
+
+        assertEquals(ENDPOINT_LIST.size(), listProvider.getPeerList().size());
+        assertEquals(ENDPOINT_LIST, listProvider.getPeerList());
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* #200 

*Description of changes:*
* Defined PeerListProvider interface and static implementation (w/ factory)
* Factored out PeerClientPool for managing GRPC clients
* Starting to invert dependencies in PeerForwarder class so it's not responsible for building/managing its dependencies

Manually tested with 2 Prepper instances and the following entry-pipeline:
```
entry-pipeline:
  delay: "100"
  source:
    otel_trace_source:
  processor:
    - peer_forwarder:
        discovery_mode: "static"
        data_prepper_ips:
          - "data-prepper"
          - "data-prepper2"
  sink:
    - pipeline:
        name: "raw-pipeline"
    - pipeline:
        name: "service-map-pipeline"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
