### PR TITLE
Adding DataPrepperServer and PrometheusMetricsHandler

### DIFF
--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     implementation "org.apache.bval:bval-extras:${versionMap.bval_extras}"
     implementation "org.apache.bval:bval-jsr:${versionMap.bval_jsr}"
     implementation "org.reflections:reflections:${versionMap.reflections}"
+    implementation "io.micrometer:micrometer-core:1.5.1"
+    implementation "io.micrometer:micrometer-registry-prometheus:1.5.1"
     testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
 }
 

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
@@ -1,0 +1,36 @@
+package com.amazon.dataprepper.pipeline.server;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * Class to handle any serving that the data prepper instance needs to do.
+ * Currently, only serves metrics in prometheus format.
+ */
+public class DataPrepperServer {
+
+    private final HttpServer server;
+
+    public DataPrepperServer(final int port) throws IOException {
+        server = HttpServer.create(
+                new InetSocketAddress(port),
+                0
+        );
+        server.createContext("/metrics/prometheus", new PrometheusMetricsHandler());
+    }
+
+    /**
+     * Start the DataPrepperServer
+     */
+    public void start() {
+        server.start();
+    }
+
+    /**
+     * Stop the DataPrepperServer
+     */
+    public void stop() {
+        server.stop(0);
+    }
+}

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/PrometheusMetricsHandler.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/PrometheusMetricsHandler.java
@@ -1,0 +1,37 @@
+package com.amazon.dataprepper.pipeline.server;
+
+import java.io.IOException;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * HttpHandler to handle requests for Prometheus metrics
+ */
+public class PrometheusMetricsHandler implements HttpHandler {
+
+    private PrometheusMeterRegistry prometheusMeterRegistry;
+    private final Logger LOG = LoggerFactory.getLogger(PrometheusMetricsHandler.class);
+
+    public PrometheusMetricsHandler() {
+        prometheusMeterRegistry = (PrometheusMeterRegistry) Metrics.globalRegistry.getRegistries().iterator().next();
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        try {
+            byte response[] = prometheusMeterRegistry.scrape().getBytes("UTF-8");
+            exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.getResponseBody().close();
+        } catch (Exception e) {
+            LOG.error("Encountered exception scarping prometheus meter registry", e);
+            exchange.sendResponseHeaders(500, 0);
+            exchange.getResponseBody().close();
+        }
+    }
+}

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/server/DataPrepperServerTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/server/DataPrepperServerTest.java
@@ -1,0 +1,78 @@
+package com.amazon.dataprepper.server;
+
+import com.amazon.dataprepper.pipeline.server.DataPrepperServer;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.UUID;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DataPrepperServerTest {
+
+    private void setRegistry(PrometheusMeterRegistry prometheusMeterRegistry) {
+        Metrics.globalRegistry.getRegistries().iterator().forEachRemaining(meterRegistry -> Metrics.globalRegistry.remove(meterRegistry));
+        Metrics.addRegistry(prometheusMeterRegistry);
+    }
+
+    @Test
+    public void testGetMetrics() throws IOException, InterruptedException, URISyntaxException {
+        final String scrape = UUID.randomUUID().toString();
+        final PrometheusMeterRegistry prometheusMeterRegistry = new PrometheusRegistryMockScrape(PrometheusConfig.DEFAULT, scrape);
+        setRegistry(prometheusMeterRegistry);
+        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080);
+        dataPrepperServer.start();
+
+        HttpRequest request = HttpRequest.newBuilder(new URI("http://127.0.0.1:8080/metrics/prometheus"))
+                .GET().build();
+        HttpResponse response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        Assert.assertEquals(200, response.statusCode());
+        Assert.assertEquals(scrape, response.body());
+        dataPrepperServer.stop();
+    }
+
+    @Test
+    public void testScrapeFailure() throws IOException, InterruptedException, URISyntaxException {
+        setRegistry(new PrometheusRegistryThrowingScrape(PrometheusConfig.DEFAULT));
+        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080);
+        dataPrepperServer.start();
+
+        HttpRequest request = HttpRequest.newBuilder(new URI("http://127.0.0.1:8080/metrics/prometheus"))
+                .GET().build();
+        HttpResponse response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        Assert.assertEquals(500, response.statusCode());
+        dataPrepperServer.stop();
+    }
+
+    private static class PrometheusRegistryMockScrape extends PrometheusMeterRegistry {
+        final String scrape;
+        public PrometheusRegistryMockScrape(PrometheusConfig config, final String scrape) {
+            super(config);
+            this.scrape = scrape;
+        }
+
+        @Override
+        public String scrape() {
+            return scrape;
+        }
+    }
+
+    private static class PrometheusRegistryThrowingScrape extends PrometheusMeterRegistry {
+
+        public PrometheusRegistryThrowingScrape(PrometheusConfig config) {
+            super(config);
+        }
+
+        @Override
+        public String scrape() {
+            throw new RuntimeException("");
+        }
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/Data-Prepper/issues/201

*Description of changes:*
- Adding DataPrepperServer class to construct a server with the handlers we need to serve APIs for the DataPrepper
- Adding PrometheusMetricsHandler to serve the scrape of the Prometheus registry

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
