### PR TITLE
Updating OtelTraceSourceTests

### DIFF
--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -84,7 +84,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    void testHttpFullJson() throws InvalidProtocolBufferException {
+    void testHttpn() throws InvalidProtocolBufferException {
         WebClient.of().execute(RequestHeaders.builder()
                         .scheme(SessionProtocol.HTTP)
                         .authority("127.0.0.1:21890")
@@ -95,51 +95,9 @@ public class OTelTraceSourceTest {
                 HttpData.copyOf(JsonFormat.printer().print(SUCCESS_REQUEST).getBytes()))
                 .aggregate()
                 .whenComplete((i, ex) -> {
-                    assertThat(i.status().code()).isEqualTo(200);
-                });
-        WebClient.of().execute(RequestHeaders.builder()
-                        .scheme(SessionProtocol.HTTP)
-                        .authority("127.0.0.1:21890")
-                        .method(HttpMethod.POST)
-                        .path("/opentelemetry.proto.collector.trace.v1.TraceService/Export")
-                        .contentType(MediaType.JSON_UTF_8)
-                        .build(),
-                HttpData.copyOf(JsonFormat.printer().print(FAILURE_REQUEST).getBytes()))
-                .aggregate()
-                .whenComplete((i, ex) -> {
-                    assertThat(i.status().code()).isEqualTo(503);
-                    validateBuffer();
-                });
+                    assertThat(i.status().code()).isEqualTo(415);
+                }).join();
 
-    }
-
-    @Test
-    void testHttpFullBytes() {
-        WebClient.of().execute(RequestHeaders.builder()
-                        .scheme(SessionProtocol.HTTP)
-                        .authority("127.0.0.1:21890")
-                        .method(HttpMethod.POST)
-                        .path("/opentelemetry.proto.collector.trace.v1.TraceService/Export")
-                        .contentType(MediaType.PROTOBUF)
-                        .build(),
-                HttpData.copyOf(SUCCESS_REQUEST.toByteArray()))
-                .aggregate()
-                .whenComplete((i, ex) -> {
-                    assertThat(i.status().code()).isEqualTo(200);
-                });
-        WebClient.of().execute(RequestHeaders.builder()
-                        .scheme(SessionProtocol.HTTP)
-                        .authority("127.0.0.1:21890")
-                        .method(HttpMethod.POST)
-                        .path("/opentelemetry.proto.collector.trace.v1.TraceService/Export")
-                        .contentType(MediaType.PROTOBUF)
-                        .build(),
-                HttpData.copyOf(FAILURE_REQUEST.toByteArray()))
-                .aggregate()
-                .whenComplete((i, ex) -> {
-                    assertThat(i.status().code()).isEqualTo(503);
-                    validateBuffer();
-                });
     }
 
     @Test

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -84,7 +84,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    void testHttp() throws InvalidProtocolBufferException {
+    void testHttpFullJson() throws InvalidProtocolBufferException {
         WebClient.of().execute(RequestHeaders.builder()
                         .scheme(SessionProtocol.HTTP)
                         .authority("127.0.0.1:21890")
@@ -95,10 +95,51 @@ public class OTelTraceSourceTest {
                 HttpData.copyOf(JsonFormat.printer().print(SUCCESS_REQUEST).getBytes()))
                 .aggregate()
                 .whenComplete((i, ex) -> {
-                    //Http is not allowed, so 415 is expected
                     assertThat(i.status().code()).isEqualTo(415);
                 }).join();
+        WebClient.of().execute(RequestHeaders.builder()
+                        .scheme(SessionProtocol.HTTP)
+                        .authority("127.0.0.1:21890")
+                        .method(HttpMethod.POST)
+                        .path("/opentelemetry.proto.collector.trace.v1.TraceService/Export")
+                        .contentType(MediaType.JSON_UTF_8)
+                        .build(),
+                HttpData.copyOf(JsonFormat.printer().print(FAILURE_REQUEST).getBytes()))
+                .aggregate()
+                .whenComplete((i, ex) -> {
+                    assertThat(i.status().code()).isEqualTo(415);
+                    //validateBuffer();
+                }).join();
 
+    }
+
+    @Test
+    void testHttpFullBytes() {
+        WebClient.of().execute(RequestHeaders.builder()
+                        .scheme(SessionProtocol.HTTP)
+                        .authority("127.0.0.1:21890")
+                        .method(HttpMethod.POST)
+                        .path("/opentelemetry.proto.collector.trace.v1.TraceService/Export")
+                        .contentType(MediaType.PROTOBUF)
+                        .build(),
+                HttpData.copyOf(SUCCESS_REQUEST.toByteArray()))
+                .aggregate()
+                .whenComplete((i, ex) -> {
+                    assertThat(i.status().code()).isEqualTo(415);
+                }).join();
+        WebClient.of().execute(RequestHeaders.builder()
+                        .scheme(SessionProtocol.HTTP)
+                        .authority("127.0.0.1:21890")
+                        .method(HttpMethod.POST)
+                        .path("/opentelemetry.proto.collector.trace.v1.TraceService/Export")
+                        .contentType(MediaType.PROTOBUF)
+                        .build(),
+                HttpData.copyOf(FAILURE_REQUEST.toByteArray()))
+                .aggregate()
+                .whenComplete((i, ex) -> {
+                    assertThat(i.status().code()).isEqualTo(415);
+                    //validateBuffer();
+                }).join();
     }
 
     @Test

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -84,7 +84,7 @@ public class OTelTraceSourceTest {
     }
 
     @Test
-    void testHttpn() throws InvalidProtocolBufferException {
+    void testHttp() throws InvalidProtocolBufferException {
         WebClient.of().execute(RequestHeaders.builder()
                         .scheme(SessionProtocol.HTTP)
                         .authority("127.0.0.1:21890")
@@ -95,6 +95,7 @@ public class OTelTraceSourceTest {
                 HttpData.copyOf(JsonFormat.printer().print(SUCCESS_REQUEST).getBytes()))
                 .aggregate()
                 .whenComplete((i, ex) -> {
+                    //Http is not allowed, so 415 is expected
                     assertThat(i.status().code()).isEqualTo(415);
                 }).join();
 


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/opendistro-for-elasticsearch/Data-Prepper/issues/214

*Description of changes:*

- Updating armeria WebClient.execute() call to call join(), so that the future is run
- Updating test to assert a 415 (media type unsupported) error, which is what is expected
- Removing extra test for http, since this is no longer needed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
