### PR TITLE
TST: including peer forwarder in e2e servicemap test

### DIFF
--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -82,7 +82,7 @@ task createDataPrepper2DockerContainer(type: DockerCreateContainer) {
     dependsOn buildDataPrepperDockerImage
     dependsOn createDataPrepperNetwork
     containerName = "data-prepper2"
-    hostConfig.portBindings = ['21891:21890', '4900:4900']
+    hostConfig.portBindings = ['21891:21890', '4901:4900']
     hostConfig.network = createDataPrepperNetwork.getNetworkName()
     targetImageId buildDataPrepperDockerImage.getImageId()
 }

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -110,6 +110,14 @@ task stopDataPrepperDockerContainer2(type: DockerStopContainer) {
     targetContainerId createDataPrepperDockerContainer2.getContainerId()
 }
 
+task removeDataPrepperDockerContainer(type: DockerRemoveContainer) {
+    targetContainerId stopDataPrepperDockerContainer.getContainerId()
+}
+
+task removeDataPrepperDockerContainer2(type: DockerRemoveContainer) {
+    targetContainerId stopDataPrepperDockerContainer2.getContainerId()
+}
+
 /**
  * ODFE Docker tasks
  */
@@ -162,6 +170,7 @@ task rawSpanEndToEndTest(type: Test) {
 
     finalizedBy stopOdfeDockerContainer
     finalizedBy stopDataPrepperDockerContainer
+    finalizedBy removeDataPrepperDockerContainer
     finalizedBy removeDataPrepperNetwork
 }
 
@@ -185,5 +194,7 @@ task serviceMapEndToEndTest(type: Test) {
     finalizedBy stopOdfeDockerContainer
     finalizedBy stopDataPrepperDockerContainer
     finalizedBy stopDataPrepperDockerContainer2
+    finalizedBy removeDataPrepperDockerContainer
+    finalizedBy removeDataPrepperDockerContainer2
     finalizedBy removeDataPrepperNetwork
 }

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -68,7 +68,7 @@ task buildDataPrepperDockerImage(type: DockerBuildImage) {
     images.add("integ-test-pipeline-image")
 }
 
-task createDataPrepperDockerContainer(type: DockerCreateContainer) {
+task createDataPrepper1DockerContainer(type: DockerCreateContainer) {
     dependsOn buildDataPrepperDockerImage
     dependsOn createDataPrepperNetwork
     containerName = "data-prepper1"
@@ -77,7 +77,7 @@ task createDataPrepperDockerContainer(type: DockerCreateContainer) {
     targetImageId buildDataPrepperDockerImage.getImageId()
 }
 
-task createDataPrepperDockerContainer2(type: DockerCreateContainer) {
+task createDataPrepper2DockerContainer(type: DockerCreateContainer) {
     dependsOn buildDataPrepperDockerImage
     dependsOn createDataPrepperNetwork
     containerName = "data-prepper2"
@@ -86,36 +86,36 @@ task createDataPrepperDockerContainer2(type: DockerCreateContainer) {
     targetImageId buildDataPrepperDockerImage.getImageId()
 }
 
-task startDataPrepperDockerContainer(type: DockerStartContainer) {
-    dependsOn createDataPrepperDockerContainer
-    targetContainerId createDataPrepperDockerContainer.getContainerId()
+task startDataPrepper1DockerContainer(type: DockerStartContainer) {
+    dependsOn createDataPrepper1DockerContainer
+    targetContainerId createDataPrepper1DockerContainer.getContainerId()
     doLast {
         sleep(10*1000)
     }
 }
 
-task startDataPrepperDockerContainer2(type: DockerStartContainer) {
-    dependsOn createDataPrepperDockerContainer2
-    targetContainerId createDataPrepperDockerContainer2.getContainerId()
+task startDataPrepper2DockerContainer(type: DockerStartContainer) {
+    dependsOn createDataPrepper2DockerContainer
+    targetContainerId createDataPrepper2DockerContainer.getContainerId()
     doLast {
         sleep(10*1000)
     }
 }
 
-task stopDataPrepperDockerContainer(type: DockerStopContainer) {
-    targetContainerId createDataPrepperDockerContainer.getContainerId()
+task stopDataPrepper1DockerContainer(type: DockerStopContainer) {
+    targetContainerId createDataPrepper1DockerContainer.getContainerId()
 }
 
-task stopDataPrepperDockerContainer2(type: DockerStopContainer) {
-    targetContainerId createDataPrepperDockerContainer2.getContainerId()
+task stopDataPrepper2DockerContainer(type: DockerStopContainer) {
+    targetContainerId createDataPrepper2DockerContainer.getContainerId()
 }
 
-task removeDataPrepperDockerContainer(type: DockerRemoveContainer) {
-    targetContainerId stopDataPrepperDockerContainer.getContainerId()
+task removeDataPrepper1DockerContainer(type: DockerRemoveContainer) {
+    targetContainerId stopDataPrepper1DockerContainer.getContainerId()
 }
 
-task removeDataPrepperDockerContainer2(type: DockerRemoveContainer) {
-    targetContainerId stopDataPrepperDockerContainer2.getContainerId()
+task removeDataPrepper2DockerContainer(type: DockerRemoveContainer) {
+    targetContainerId stopDataPrepper2DockerContainer.getContainerId()
 }
 
 /**
@@ -156,8 +156,8 @@ task stopOdfeDockerContainer(type: DockerStopContainer) {
 task rawSpanEndToEndTest(type: Test) {
     dependsOn build
     dependsOn startOdfeDockerContainer
-    dependsOn startDataPrepperDockerContainer
-    startDataPrepperDockerContainer.mustRunAfter 'startOdfeDockerContainer'
+    dependsOn startDataPrepper1DockerContainer
+    startDataPrepper1DockerContainer.mustRunAfter 'startOdfeDockerContainer'
 
     description = 'Runs the raw span integration tests.'
     group = 'verification'
@@ -169,18 +169,18 @@ task rawSpanEndToEndTest(type: Test) {
     }
 
     finalizedBy stopOdfeDockerContainer
-    finalizedBy stopDataPrepperDockerContainer
-    finalizedBy removeDataPrepperDockerContainer
+    finalizedBy stopDataPrepper1DockerContainer
+    finalizedBy removeDataPrepper1DockerContainer
     finalizedBy removeDataPrepperNetwork
 }
 
 task serviceMapEndToEndTest(type: Test) {
     dependsOn build
     dependsOn startOdfeDockerContainer
-    dependsOn startDataPrepperDockerContainer
-    dependsOn startDataPrepperDockerContainer2
-    startDataPrepperDockerContainer.mustRunAfter 'startOdfeDockerContainer'
-    startDataPrepperDockerContainer2.mustRunAfter 'startOdfeDockerContainer'
+    dependsOn startDataPrepper1DockerContainer
+    dependsOn startDataPrepper2DockerContainer
+    startDataPrepper1DockerContainer.mustRunAfter 'startOdfeDockerContainer'
+    startDataPrepper2DockerContainer.mustRunAfter 'startOdfeDockerContainer'
 
     description = 'Runs the raw span integration tests.'
     group = 'verification'
@@ -192,9 +192,9 @@ task serviceMapEndToEndTest(type: Test) {
     }
 
     finalizedBy stopOdfeDockerContainer
-    finalizedBy stopDataPrepperDockerContainer
-    finalizedBy stopDataPrepperDockerContainer2
-    finalizedBy removeDataPrepperDockerContainer
-    finalizedBy removeDataPrepperDockerContainer2
+    finalizedBy stopDataPrepper1DockerContainer
+    finalizedBy stopDataPrepper2DockerContainer
+    finalizedBy removeDataPrepper1DockerContainer
+    finalizedBy removeDataPrepper2DockerContainer
     finalizedBy removeDataPrepperNetwork
 }

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -71,7 +71,17 @@ task buildDataPrepperDockerImage(type: DockerBuildImage) {
 task createDataPrepperDockerContainer(type: DockerCreateContainer) {
     dependsOn buildDataPrepperDockerImage
     dependsOn createDataPrepperNetwork
+    containerName = "data-prepper1"
     hostConfig.portBindings = ['21890:21890']
+    hostConfig.network = createDataPrepperNetwork.getNetworkName()
+    targetImageId buildDataPrepperDockerImage.getImageId()
+}
+
+task createDataPrepperDockerContainer2(type: DockerCreateContainer) {
+    dependsOn buildDataPrepperDockerImage
+    dependsOn createDataPrepperNetwork
+    containerName = "data-prepper2"
+    hostConfig.portBindings = ['21891:21890']
     hostConfig.network = createDataPrepperNetwork.getNetworkName()
     targetImageId buildDataPrepperDockerImage.getImageId()
 }
@@ -84,8 +94,20 @@ task startDataPrepperDockerContainer(type: DockerStartContainer) {
     }
 }
 
+task startDataPrepperDockerContainer2(type: DockerStartContainer) {
+    dependsOn createDataPrepperDockerContainer2
+    targetContainerId createDataPrepperDockerContainer2.getContainerId()
+    doLast {
+        sleep(10*1000)
+    }
+}
+
 task stopDataPrepperDockerContainer(type: DockerStopContainer) {
     targetContainerId createDataPrepperDockerContainer.getContainerId()
+}
+
+task stopDataPrepperDockerContainer2(type: DockerStopContainer) {
+    targetContainerId createDataPrepperDockerContainer2.getContainerId()
 }
 
 /**
@@ -147,7 +169,9 @@ task serviceMapEndToEndTest(type: Test) {
     dependsOn build
     dependsOn startOdfeDockerContainer
     dependsOn startDataPrepperDockerContainer
+    dependsOn startDataPrepperDockerContainer2
     startDataPrepperDockerContainer.mustRunAfter 'startOdfeDockerContainer'
+    startDataPrepperDockerContainer2.mustRunAfter 'startOdfeDockerContainer'
 
     description = 'Runs the raw span integration tests.'
     group = 'verification'
@@ -160,5 +184,6 @@ task serviceMapEndToEndTest(type: Test) {
 
     finalizedBy stopOdfeDockerContainer
     finalizedBy stopDataPrepperDockerContainer
+    finalizedBy stopDataPrepperDockerContainer2
     finalizedBy removeDataPrepperNetwork
 }

--- a/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndServiceMapTest.java
+++ b/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndServiceMapTest.java
@@ -208,25 +208,7 @@ public class EndToEndServiceMapTest {
                 final ServiceMapTestData parentData = spanIdToServiceMapTestData.get(parentId);
                 if (parentData != null && !parentData.serviceName.equals(currData.serviceName)) {
                     String rootSpanName = getRootSpanName(parentId, spanIdToServiceMapTestData);
-                    Map<String, Object> destination = new HashMap<>();
-                    destination.put("resource", currData.name);
-                    destination.put("domain", currData.serviceName);
-                    Map<String, Object> edge = new HashMap<>();
-                    edge.put("serviceName", parentData.serviceName);
-                    edge.put("kind", parentData.spanKind.name());
-                    edge.put("traceGroupName", rootSpanName);
-                    edge.put("destination", destination);
-                    edge.put("target", null);
-                    possibleEdges.add(edge);
-
-                    Map<String, Object> target = new HashMap<>(destination);
-                    edge = new HashMap<>();
-                    edge.put("serviceName", currData.serviceName);
-                    edge.put("kind", currData.spanKind.name());
-                    edge.put("traceGroupName", rootSpanName);
-                    edge.put("destination", null);
-                    edge.put("target", target);
-                    possibleEdges.add(edge);
+                    possibleEdges.addAll(getEdgeMaps(rootSpanName, currData, parentData));
                 }
             }
         }
@@ -240,5 +222,32 @@ public class EndToEndServiceMapTest {
             rootServiceMapTestData = spanIdToServiceMapTestData.get(rootServiceMapTestData.parentId);
         }
         return rootServiceMapTestData.name;
+    }
+
+    private List<Map<String, Object>> getEdgeMaps(
+            final String rootSpanName, final ServiceMapTestData currData, final ServiceMapTestData parentData) {
+        final List<Map<String, Object>> edges = new ArrayList<>();
+
+        Map<String, Object> destination = new HashMap<>();
+        destination.put("resource", currData.name);
+        destination.put("domain", currData.serviceName);
+        Map<String, Object> edge = new HashMap<>();
+        edge.put("serviceName", parentData.serviceName);
+        edge.put("kind", parentData.spanKind.name());
+        edge.put("traceGroupName", rootSpanName);
+        edge.put("destination", destination);
+        edge.put("target", null);
+        edges.add(edge);
+
+        Map<String, Object> target = new HashMap<>(destination);
+        edge = new HashMap<>();
+        edge.put("serviceName", currData.serviceName);
+        edge.put("kind", currData.spanKind.name());
+        edge.put("traceGroupName", rootSpanName);
+        edge.put("destination", null);
+        edge.put("target", target);
+        edges.add(edge);
+
+        return edges;
     }
 }

--- a/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndServiceMapTest.java
+++ b/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndServiceMapTest.java
@@ -100,7 +100,7 @@ public class EndToEndServiceMapTest {
 
     private void sendExportTraceServiceRequestToSource(final ExportTraceServiceRequest request) {
         Clients.newClient(
-                "gproto+http://127.0.0.1:21890/", TraceServiceGrpc.TraceServiceBlockingStub.class).export(request);
+                "gproto+http://127.0.0.1:21891/", TraceServiceGrpc.TraceServiceBlockingStub.class).export(request);
     }
 
     private List<Map<String, Object>> getSourcesFromIndex(final RestHighLevelClient restHighLevelClient, final String index) throws IOException {

--- a/data-prepper-core/src/integrationTest/resources/pipeline.yml
+++ b/data-prepper-core/src/integrationTest/resources/pipeline.yml
@@ -3,6 +3,7 @@ entry-pipeline:
     otel_trace_source:
   processor:
     - peer_forwarder:
+        discovery_mode: "static"
         data_prepper_ips: ["data-prepper1", "data-prepper2"]
   sink:
     - pipeline:

--- a/data-prepper-core/src/integrationTest/resources/pipeline.yml
+++ b/data-prepper-core/src/integrationTest/resources/pipeline.yml
@@ -1,6 +1,9 @@
 entry-pipeline:
   source:
     otel_trace_source:
+  processor:
+    - peer_forwarder:
+        data_prepper_ips: ["data-prepper1", "data-prepper2"]
   sink:
     - pipeline:
         name: "raw-pipeline"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Refactors some setup functions in endToEndServiceMapTest
- Add an additional instance of data-prepper in gradle docker
- Included peerforwarder in the data-prepper pipeline.yml

Note: not sure how to handle create arbitrary number of data prepper containers in gradle task w/o hardcoding. Since it is not blocking, will leave it to future if necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
