### PR TITLE
Starting data prepper server when initializing the data prepper instance

### DIFF
--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -55,6 +55,7 @@ task createDataPrepperDockerFile(type: Dockerfile) {
     destFile = project.file('build/docker/Dockerfile')
     from("adoptopenjdk/openjdk14:jre-14.0.1_7-alpine")
     exposePort(21890)
+    exposePort(4900)
     workingDir("/app")
     copyFile("build/libs/${jar.archiveName}", "/app/data-prepper.jar")
     copyFile("src/integrationTest/resources/pipeline.yml", "/app/pipeline.yml")
@@ -71,7 +72,7 @@ task buildDataPrepperDockerImage(type: DockerBuildImage) {
 task createDataPrepperDockerContainer(type: DockerCreateContainer) {
     dependsOn buildDataPrepperDockerImage
     dependsOn createDataPrepperNetwork
-    hostConfig.portBindings = ['21890:21890']
+    hostConfig.portBindings = ['21890:21890', '4900:4900']
     hostConfig.network = createDataPrepperNetwork.getNetworkName()
     targetImageId buildDataPrepperDockerImage.getImageId()
 }

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
@@ -12,12 +12,16 @@ public class DataPrepperServer {
 
     private final HttpServer server;
 
-    public DataPrepperServer(final int port) throws IOException {
-        server = HttpServer.create(
-                new InetSocketAddress(port),
-                0
-        );
-        server.createContext("/metrics/prometheus", new PrometheusMetricsHandler());
+    public DataPrepperServer(final int port) {
+        try {
+            server = HttpServer.create(
+                    new InetSocketAddress(port),
+                    0
+            );
+            server.createContext("/metrics/prometheus", new PrometheusMetricsHandler());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create server", e);
+        }
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/Data-Prepper/issues/201

*Description of changes:*

- Starting a DataPrepperServer when instantiating DataPrepper instance
- Exposing metrics port on docker container for integ test
- Manually tested getting metrics with integration test
   - Actually verifying metrics in the integ test will be cumbersome, TODO later
- Taking in the server port as configuration will be handled in a later task, as this will require a little bit of a refactor in how we parse configuration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
