### PR TITLE
#200: Updated PeerListProvider interface to extend Listenable, update…

### DIFF
--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
@@ -17,12 +17,18 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.function.Consumer;
 
+/**
+ * Consistent hashing implementation used to map trace IDs to Data Prepper hosts.
+ * See https://en.wikipedia.org/wiki/Consistent_hashing for more information.
+ */
 @NotThreadSafe
 public class HashRing implements Consumer<List<Endpoint>> {
     private static final Logger LOG = LoggerFactory.getLogger(HashRing.class);
     private static final String MD5 = "MD5";
 
+    /* Number of virtual nodes per Data Prepper host to be present on the hash ring */
     private final int numVirtualNodes;
+
     private final PeerListProvider peerListProvider;
 
     private TreeMap<BigInteger, String> hashServerMap = new TreeMap<>();

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
@@ -1,19 +1,25 @@
 package com.amazon.dataprepper.plugins.processor.peerforwarder;
 
 import com.amazon.dataprepper.plugins.processor.peerforwarder.discovery.PeerListProvider;
+import com.linecorp.armeria.client.Endpoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.function.Consumer;
 
 @NotThreadSafe
-public class HashRing {
+public class HashRing implements Consumer<List<Endpoint>> {
+    private static final Logger LOG = LoggerFactory.getLogger(HashRing.class);
     private static final String MD5 = "MD5";
 
     private final int numVirtualNodes;
@@ -27,6 +33,8 @@ public class HashRing {
         this.numVirtualNodes = numVirtualNodes;
 
         buildHashServerMap();
+
+        peerListProvider.addListener(this);
     }
 
     public Optional<String> getServerIp(final String traceId) {
@@ -52,9 +60,22 @@ public class HashRing {
         }
     }
 
+    @Override
+    public void accept(final List<Endpoint> endpoints) {
+        buildHashServerMap();
+    }
+
+    @Override
+    public Consumer<List<Endpoint>> andThen(final Consumer<? super List<Endpoint>> after) {
+        return null;
+    }
+
     private void buildHashServerMap() {
         final TreeMap<BigInteger, String> newHashValueMap = new TreeMap<>();
-        for (final String serverIp : peerListProvider.getPeerList()) {
+        final List<String> endpoints = peerListProvider.getPeerList();
+
+        LOG.info("Building hash ring with endpoints: {}", endpoints);
+        for (final String serverIp : endpoints) {
             addServerIpToHashMap(serverIp, newHashValueMap);
         }
 

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/DnsPeerListProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/DnsPeerListProvider.java
@@ -1,5 +1,6 @@
 package com.amazon.dataprepper.plugins.processor.peerforwarder.discovery;
 
+import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -7,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class DnsPeerListProvider implements PeerListProvider {
@@ -33,5 +35,15 @@ public class DnsPeerListProvider implements PeerListProvider {
                 .stream()
                 .map(endpoint -> endpoint.ipAddr())
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public void addListener(final Consumer<? super List<Endpoint>> listener) {
+        endpointGroup.addListener(listener);
+    }
+
+    @Override
+    public void removeListener(final Consumer<?> listener) {
+        endpointGroup.removeListener(listener);
     }
 }

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/PeerListProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/PeerListProvider.java
@@ -1,10 +1,15 @@
 package com.amazon.dataprepper.plugins.processor.peerforwarder.discovery;
 
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.util.Listenable;
+
 import java.util.List;
 
 /**
  * Provides a list other Data Prepper instance endpoints within the same cluster.
+ * Coupling this to Armeria's Listenable interface for now to leverage existing implementers of it
+ * (see DynamicEndpointGroup), though this can be redefined in the future if more Provider implementations are necessary.
  */
-public interface PeerListProvider {
+public interface PeerListProvider extends Listenable<List<Endpoint>> {
     List<String> getPeerList();
 }

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/StaticPeerListProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/StaticPeerListProvider.java
@@ -1,10 +1,12 @@
 package com.amazon.dataprepper.plugins.processor.peerforwarder.discovery;
 
+import com.linecorp.armeria.client.Endpoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class StaticPeerListProvider implements PeerListProvider {
     private static final Logger LOG = LoggerFactory.getLogger(StaticPeerListProvider.class);
@@ -20,11 +22,21 @@ public class StaticPeerListProvider implements PeerListProvider {
             throw new RuntimeException("Peer endpoints list cannot be empty");
         }
 
-        LOG.info("Found endpoints: {}", String.join(",", endpoints));
+        LOG.info("Found endpoints: {}", endpoints);
     }
 
     @Override
     public List<String> getPeerList() {
         return endpoints;
+    }
+
+    @Override
+    public void addListener(final Consumer<? super List<Endpoint>> listener) {
+        // Do nothing - static peer list isn't expected to change
+    }
+
+    @Override
+    public void removeListener(final Consumer<?> listener) {
+        // Do nothing - static peer list isn't expected to change
     }
 }

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/StaticPeerListProviderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/StaticPeerListProviderTest.java
@@ -1,17 +1,34 @@
 package com.amazon.dataprepper.plugins.processor.peerforwarder.discovery;
 
+import com.amazon.dataprepper.plugins.processor.peerforwarder.HashRing;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verifyNoInteractions;
 
+@RunWith(MockitoJUnitRunner.class)
 public class StaticPeerListProviderTest {
     private static final String ENDPOINT_1 = "10.10.0.1";
     private static final String ENDPOINT_2 = "10.10.0.2";
     private static final List<String> ENDPOINT_LIST = Arrays.asList(ENDPOINT_1, ENDPOINT_2);
+
+    @Mock
+    private HashRing hashRing;
+
+    private StaticPeerListProvider staticPeerListProvider;
+
+    @Before
+    public void setup() {
+        staticPeerListProvider = new StaticPeerListProvider(ENDPOINT_LIST);
+    }
 
     @Test(expected = RuntimeException.class)
     public void testListProviderWithEmptyList() {
@@ -20,9 +37,20 @@ public class StaticPeerListProviderTest {
 
     @Test
     public void testListProviderWithNonEmptyList() {
-        StaticPeerListProvider listProvider = new StaticPeerListProvider(ENDPOINT_LIST);
+        assertEquals(ENDPOINT_LIST.size(), staticPeerListProvider.getPeerList().size());
+        assertEquals(ENDPOINT_LIST, staticPeerListProvider.getPeerList());
+    }
 
-        assertEquals(ENDPOINT_LIST.size(), listProvider.getPeerList().size());
-        assertEquals(ENDPOINT_LIST, listProvider.getPeerList());
+    @Test
+    public void testAddListener() {
+        verifyNoInteractions(hashRing);
+        staticPeerListProvider.addListener(hashRing);
+
+    }
+
+    @Test
+    public void testRemoveListener() {
+        verifyNoInteractions(hashRing);
+        staticPeerListProvider.removeListener(hashRing);
     }
 }


### PR DESCRIPTION
…d implementations.

*Issue #, if available:* #200 

*Description of changes:*
The hash ring needs to be rebuilt whenever the list of peers changes. Hooked in to Armeria's Listenable interface for this purpose.
* Updated PeerListProvider interface to extend Armeria's Listenable interface
* Updated static and DNS implementations

Testing:
Started a cluster w/ DNS discovery, scaled from 1 node to 3 and observed logs:
```
...
1113 [main] INFO  com.amazon.dataprepper.plugins.processor.peerforwarder.HashRing  – Building hash ring with endpoints: [172.17.0.6]
...
5783 [armeria-boss-http-*:21890] INFO  com.linecorp.armeria.server.Server  – Serving HTTP at /0.0.0.0:21890 - http://127.0.0.1:21890/
5783 [main] INFO  com.amazon.dataprepper.plugins.source.oteltrace.OTelTraceSource  – Started otel_trace_source...
5783 [main] INFO  com.amazon.dataprepper.pipeline.Pipeline  – Pipeline [entry-pipeline] - Submitting request to initiate the pipeline processing
5884 [entry-pipeline-process-worker-1-thread-1] INFO  com.amazon.dataprepper.pipeline.ProcessWorker  –  entry-pipeline Worker: No records received from buffer
7914 [raw-pipeline-process-worker-3-thread-1] INFO  com.amazon.dataprepper.pipeline.ProcessWorker  –  raw-pipeline Worker: No records received from buffer
15534 [entry-pipeline-process-worker-1-thread-1] INFO  com.amazon.dataprepper.pipeline.ProcessWorker  –  entry-pipeline Worker: Processing 1 records from buffer
15640 [service-map-pipeline-process-worker-2-thread-1] INFO  com.amazon.dataprepper.pipeline.ProcessWorker  –  service-map-pipeline Worker: Processing 1 records from buffer
...
61119 [armeria-common-worker-epoll-2-1] INFO  com.amazon.dataprepper.plugins.processor.peerforwarder.HashRing  – Building hash ring with endpoints: [172.17.0.11, 172.17.0.12, 172.17.0.6]

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
