### PR TITLE
Adding "/list" and "/shutdown" APIs to DataPrepperServer

### DIFF
--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -12,7 +12,8 @@ ext.versionMap = [
         slf4j_api              : '1.7.30',
         slf4j_log4j12          : '1.7.30',
         validation_api         : '2.0.1.Final',
-        opentelemetry_proto    : '0.10.0'
+        opentelemetry_proto    : '0.10.0',
+        mockito                : '2.1.0'
 ]
 
 ext.coreProjects = [project(':data-prepper-api'), project(':data-prepper-core'), project('data-prepper-plugins:common')]

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation "io.micrometer:micrometer-core:1.5.1"
     implementation "io.micrometer:micrometer-registry-prometheus:1.5.1"
     testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
-    testImplementation "org.mockito:mockito-all:1.10.19"
+    testImplementation "org.mockito:mockito-core:${versionMap.mockito}"
 }
 
 jar {

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation "io.micrometer:micrometer-core:1.5.1"
     implementation "io.micrometer:micrometer-registry-prometheus:1.5.1"
     testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
+    testImplementation "org.mockito:mockito-all:1.10.19"
 }
 
 jar {

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
@@ -42,7 +42,7 @@ public class DataPrepper {
             throw new RuntimeException("Please use getInstance() for an instance of this Data Prepper");
         }
         startPrometheusBackend();
-        dataPrepperServer = new DataPrepperServer(SERVER_PORT);
+        dataPrepperServer = new DataPrepperServer(SERVER_PORT, this);
         dataPrepperServer.start();
     }
 
@@ -89,6 +89,10 @@ public class DataPrepper {
         if(transformationPipelines.containsKey(pipeline)) {
             transformationPipelines.get(pipeline).shutdown();
         }
+    }
+
+    public Map<String, Pipeline> getTransformationPipelines() {
+        return  transformationPipelines;
     }
 
     private boolean initiateExecution() {

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
@@ -1,5 +1,6 @@
 package com.amazon.dataprepper.pipeline.server;
 
+import com.amazon.dataprepper.DataPrepper;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import com.sun.net.httpserver.HttpServer;
@@ -11,14 +12,18 @@ import com.sun.net.httpserver.HttpServer;
 public class DataPrepperServer {
 
     private final HttpServer server;
+    private final DataPrepper dataPrepper;
 
-    public DataPrepperServer(final int port) {
+    public DataPrepperServer(final int port, final DataPrepper dataPrepper) {
+        this.dataPrepper = dataPrepper;
         try {
             server = HttpServer.create(
                     new InetSocketAddress(port),
                     0
             );
             server.createContext("/metrics/prometheus", new PrometheusMetricsHandler());
+            server.createContext("/list", new ListPipelinesHandler(dataPrepper));
+            server.createContext("/shutdown", new ShutdownHandler(dataPrepper));
         } catch (IOException e) {
             throw new RuntimeException("Failed to create server", e);
         }

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
@@ -12,10 +12,8 @@ import com.sun.net.httpserver.HttpServer;
 public class DataPrepperServer {
 
     private final HttpServer server;
-    private final DataPrepper dataPrepper;
 
     public DataPrepperServer(final int port, final DataPrepper dataPrepper) {
-        this.dataPrepper = dataPrepper;
         try {
             server = HttpServer.create(
                     new InetSocketAddress(port),

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/ListPipelinesHandler.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/ListPipelinesHandler.java
@@ -1,0 +1,54 @@
+package com.amazon.dataprepper.pipeline.server;
+
+import com.amazon.dataprepper.DataPrepper;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * HttpHandler to handle requests for listing pipelines running on the data prepper instance
+ */
+public class ListPipelinesHandler implements HttpHandler {
+
+    private final DataPrepper dataPrepper;
+    private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private final Logger LOG = LoggerFactory.getLogger(ListPipelinesHandler.class);
+
+    public ListPipelinesHandler(final DataPrepper dataPrepper) {
+        this.dataPrepper = dataPrepper;
+    }
+
+    private static class PipelineListing {
+        public String name;
+
+        public PipelineListing(final String name) {
+            this.name = name;
+        }
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        try {
+            List<PipelineListing> pipelines = dataPrepper.getTransformationPipelines()
+                    .entrySet()
+                    .stream()
+                    .map(entry -> new PipelineListing(entry.getKey()))
+                    .collect(Collectors.toList());
+            final byte[] response = OBJECT_MAPPER.writeValueAsString(Collections.singletonMap("pipelines", pipelines)).getBytes();
+            exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.getResponseBody().close();
+        } catch (Exception e) {
+            LOG.error("Caught exception listing pipelines", e);
+            exchange.sendResponseHeaders(500, 0);
+            exchange.getResponseBody().close();
+        }
+    }
+}

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/ListPipelinesHandler.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/ListPipelinesHandler.java
@@ -2,6 +2,7 @@ package com.amazon.dataprepper.pipeline.server;
 
 import com.amazon.dataprepper.DataPrepper;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -42,12 +43,12 @@ public class ListPipelinesHandler implements HttpHandler {
                     .collect(Collectors.toList());
             final byte[] response = OBJECT_MAPPER.writeValueAsString(Collections.singletonMap("pipelines", pipelines)).getBytes();
             exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
-            exchange.sendResponseHeaders(200, response.length);
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
             exchange.getResponseBody().write(response);
-            exchange.getResponseBody().close();
         } catch (Exception e) {
             LOG.error("Caught exception listing pipelines", e);
-            exchange.sendResponseHeaders(500, 0);
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_INTERNAL_ERROR, 0);
+        } finally {
             exchange.getResponseBody().close();
         }
     }

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/PrometheusMetricsHandler.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/PrometheusMetricsHandler.java
@@ -1,6 +1,7 @@
 package com.amazon.dataprepper.pipeline.server;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import io.micrometer.core.instrument.Metrics;
@@ -25,12 +26,12 @@ public class PrometheusMetricsHandler implements HttpHandler {
         try {
             byte response[] = prometheusMeterRegistry.scrape().getBytes("UTF-8");
             exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
-            exchange.sendResponseHeaders(200, response.length);
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
             exchange.getResponseBody().write(response);
-            exchange.getResponseBody().close();
         } catch (Exception e) {
             LOG.error("Encountered exception scarping prometheus meter registry", e);
-            exchange.sendResponseHeaders(500, 0);
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_INTERNAL_ERROR, 0);
+        } finally {
             exchange.getResponseBody().close();
         }
     }

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/ShutdownHandler.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/ShutdownHandler.java
@@ -1,0 +1,34 @@
+package com.amazon.dataprepper.pipeline.server;
+
+import com.amazon.dataprepper.DataPrepper;
+import java.io.IOException;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * HttpHandler to handle requests to shut down the data prepper instance
+ */
+public class ShutdownHandler implements HttpHandler {
+
+    private final DataPrepper dataPrepper;
+    private final static Logger LOG = LoggerFactory.getLogger(ShutdownHandler.class);
+
+    public ShutdownHandler(final DataPrepper dataPrepper) {
+        this.dataPrepper = dataPrepper;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        try {
+            dataPrepper.shutdown();
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().close();
+        } catch (Exception e) {
+            LOG.error("Caught exception shutting down data prepper", e);
+            exchange.sendResponseHeaders(500, 0);
+            exchange.getResponseBody().close();
+        }
+    }
+}

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/ShutdownHandler.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/ShutdownHandler.java
@@ -2,6 +2,7 @@ package com.amazon.dataprepper.pipeline.server;
 
 import com.amazon.dataprepper.DataPrepper;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import org.slf4j.Logger;
@@ -23,11 +24,11 @@ public class ShutdownHandler implements HttpHandler {
     public void handle(HttpExchange exchange) throws IOException {
         try {
             dataPrepper.shutdown();
-            exchange.sendResponseHeaders(200, 0);
-            exchange.getResponseBody().close();
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, 0);
         } catch (Exception e) {
             LOG.error("Caught exception shutting down data prepper", e);
-            exchange.sendResponseHeaders(500, 0);
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_INTERNAL_ERROR, 0);
+        } finally {
             exchange.getResponseBody().close();
         }
     }

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/server/DataPrepperServerTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/server/DataPrepperServerTest.java
@@ -4,6 +4,7 @@ import com.amazon.dataprepper.DataPrepper;
 import com.amazon.dataprepper.pipeline.Pipeline;
 import com.amazon.dataprepper.pipeline.server.DataPrepperServer;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
@@ -16,17 +17,30 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public class DataPrepperServerTest {
 
     private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private DataPrepperServer dataPrepperServer;
 
     private void setRegistry(PrometheusMeterRegistry prometheusMeterRegistry) {
         Metrics.globalRegistry.getRegistries().iterator().forEachRemaining(meterRegistry -> Metrics.globalRegistry.remove(meterRegistry));
         Metrics.addRegistry(prometheusMeterRegistry);
+    }
+
+    @Before
+    public void initMetrics() {
+        setRegistry(new PrometheusRegistryMockScrape(PrometheusConfig.DEFAULT, ""));
+    }
+
+    @After
+    public void stopServer() {
+        dataPrepperServer.stop();
     }
 
     @Test
@@ -34,13 +48,13 @@ public class DataPrepperServerTest {
         final String scrape = UUID.randomUUID().toString();
         final PrometheusMeterRegistry prometheusMeterRegistry = new PrometheusRegistryMockScrape(PrometheusConfig.DEFAULT, scrape);
         setRegistry(prometheusMeterRegistry);
-        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080, null);
+        dataPrepperServer = new DataPrepperServer(8080, null);
         dataPrepperServer.start();
 
         HttpRequest request = HttpRequest.newBuilder(new URI("http://127.0.0.1:8080/metrics/prometheus"))
                 .GET().build();
         HttpResponse response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-        Assert.assertEquals(200, response.statusCode());
+        Assert.assertEquals(HttpURLConnection.HTTP_OK, response.statusCode());
         Assert.assertEquals(scrape, response.body());
         dataPrepperServer.stop();
     }
@@ -48,25 +62,24 @@ public class DataPrepperServerTest {
     @Test
     public void testScrapeFailure() throws IOException, InterruptedException, URISyntaxException {
         setRegistry(new PrometheusRegistryThrowingScrape(PrometheusConfig.DEFAULT));
-        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080, null);
+        dataPrepperServer = new DataPrepperServer(8080, null);
         dataPrepperServer.start();
 
         HttpRequest request = HttpRequest.newBuilder(new URI("http://127.0.0.1:8080/metrics/prometheus"))
                 .GET().build();
         HttpResponse response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-        Assert.assertEquals(500, response.statusCode());
+        Assert.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, response.statusCode());
         dataPrepperServer.stop();
     }
 
     @Test
     public void testListPipelines() throws URISyntaxException, IOException, InterruptedException {
-        setRegistry(new PrometheusRegistryMockScrape(PrometheusConfig.DEFAULT, ""));
         final DataPrepper mockDataPrepper = Mockito.mock(DataPrepper.class);
         final String pipelineName = "testPipeline";
         Mockito.when(mockDataPrepper.getTransformationPipelines()).thenReturn(
                 Collections.singletonMap(pipelineName, Mockito.mock(Pipeline.class))
         );
-        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080, mockDataPrepper);
+        dataPrepperServer = new DataPrepperServer(8080, mockDataPrepper);
         dataPrepperServer.start();
 
         HttpRequest request = HttpRequest.newBuilder(new URI("http://127.0.0.1:8080/list"))
@@ -77,53 +90,50 @@ public class DataPrepperServerTest {
                         Collections.singletonMap("name", pipelineName)
                 ))
         );
-        Assert.assertEquals(200, response.statusCode());
+        Assert.assertEquals(HttpURLConnection.HTTP_OK, response.statusCode());
         Assert.assertEquals(expectedResponse, response.body());
         dataPrepperServer.stop();
     }
 
     @Test
     public void testListPipelinesFailure() throws URISyntaxException, IOException, InterruptedException {
-        setRegistry(new PrometheusRegistryMockScrape(PrometheusConfig.DEFAULT, ""));
         final DataPrepper mockDataPrepper = Mockito.mock(DataPrepper.class);
         Mockito.when(mockDataPrepper.getTransformationPipelines()).thenThrow(new RuntimeException(""));
-        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080, mockDataPrepper);
+        dataPrepperServer = new DataPrepperServer(8080, mockDataPrepper);
         dataPrepperServer.start();
 
         HttpRequest request = HttpRequest.newBuilder(new URI("http://127.0.0.1:8080/list"))
                 .GET().build();
         HttpResponse response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-        Assert.assertEquals(500, response.statusCode());
+        Assert.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, response.statusCode());
         dataPrepperServer.stop();
     }
 
     @Test
     public void testShutdown() throws URISyntaxException, IOException, InterruptedException {
-        setRegistry(new PrometheusRegistryMockScrape(PrometheusConfig.DEFAULT, ""));
         final DataPrepper mockDataPrepper = Mockito.mock(DataPrepper.class);
-        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080, mockDataPrepper);
+        dataPrepperServer = new DataPrepperServer(8080, mockDataPrepper);
         dataPrepperServer.start();
 
         HttpRequest request = HttpRequest.newBuilder(new URI("http://127.0.0.1:8080/shutdown"))
                 .GET().build();
         HttpResponse response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-        Assert.assertEquals(200, response.statusCode());
+        Assert.assertEquals(HttpURLConnection.HTTP_OK, response.statusCode());
         Mockito.verify(mockDataPrepper).shutdown();
         dataPrepperServer.stop();
     }
 
     @Test
     public void testShutdownFailure() throws URISyntaxException, IOException, InterruptedException {
-        setRegistry(new PrometheusRegistryMockScrape(PrometheusConfig.DEFAULT, ""));
         final DataPrepper mockDataPrepper = Mockito.mock(DataPrepper.class);
         Mockito.doThrow(new RuntimeException("")).when(mockDataPrepper).shutdown();
-        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080, mockDataPrepper);
+        dataPrepperServer = new DataPrepperServer(8080, mockDataPrepper);
         dataPrepperServer.start();
 
         HttpRequest request = HttpRequest.newBuilder(new URI("http://127.0.0.1:8080/shutdown"))
                 .GET().build();
         HttpResponse response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-        Assert.assertEquals(500, response.statusCode());
+        Assert.assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, response.statusCode());
         Mockito.verify(mockDataPrepper).shutdown();
         dataPrepperServer.stop();
     }

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/server/DataPrepperServerTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/server/DataPrepperServerTest.java
@@ -1,5 +1,7 @@
 package com.amazon.dataprepper.server;
 
+import com.amazon.dataprepper.DataPrepper;
+import com.amazon.dataprepper.pipeline.Pipeline;
 import com.amazon.dataprepper.pipeline.server.DataPrepperServer;
 import java.io.IOException;
 import java.net.URI;
@@ -7,14 +9,20 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.UUID;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class DataPrepperServerTest {
+
+    private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private void setRegistry(PrometheusMeterRegistry prometheusMeterRegistry) {
         Metrics.globalRegistry.getRegistries().iterator().forEachRemaining(meterRegistry -> Metrics.globalRegistry.remove(meterRegistry));
@@ -26,7 +34,7 @@ public class DataPrepperServerTest {
         final String scrape = UUID.randomUUID().toString();
         final PrometheusMeterRegistry prometheusMeterRegistry = new PrometheusRegistryMockScrape(PrometheusConfig.DEFAULT, scrape);
         setRegistry(prometheusMeterRegistry);
-        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080);
+        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080, null);
         dataPrepperServer.start();
 
         HttpRequest request = HttpRequest.newBuilder(new URI("http://127.0.0.1:8080/metrics/prometheus"))
@@ -40,13 +48,83 @@ public class DataPrepperServerTest {
     @Test
     public void testScrapeFailure() throws IOException, InterruptedException, URISyntaxException {
         setRegistry(new PrometheusRegistryThrowingScrape(PrometheusConfig.DEFAULT));
-        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080);
+        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080, null);
         dataPrepperServer.start();
 
         HttpRequest request = HttpRequest.newBuilder(new URI("http://127.0.0.1:8080/metrics/prometheus"))
                 .GET().build();
         HttpResponse response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
         Assert.assertEquals(500, response.statusCode());
+        dataPrepperServer.stop();
+    }
+
+    @Test
+    public void testListPipelines() throws URISyntaxException, IOException, InterruptedException {
+        setRegistry(new PrometheusRegistryMockScrape(PrometheusConfig.DEFAULT, ""));
+        final DataPrepper mockDataPrepper = Mockito.mock(DataPrepper.class);
+        final String pipelineName = "testPipeline";
+        Mockito.when(mockDataPrepper.getTransformationPipelines()).thenReturn(
+                Collections.singletonMap(pipelineName, Mockito.mock(Pipeline.class))
+        );
+        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080, mockDataPrepper);
+        dataPrepperServer.start();
+
+        HttpRequest request = HttpRequest.newBuilder(new URI("http://127.0.0.1:8080/list"))
+                .GET().build();
+        HttpResponse response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        final String expectedResponse = OBJECT_MAPPER.writeValueAsString(
+                Collections.singletonMap("pipelines", Arrays.asList(
+                        Collections.singletonMap("name", pipelineName)
+                ))
+        );
+        Assert.assertEquals(200, response.statusCode());
+        Assert.assertEquals(expectedResponse, response.body());
+        dataPrepperServer.stop();
+    }
+
+    @Test
+    public void testListPipelinesFailure() throws URISyntaxException, IOException, InterruptedException {
+        setRegistry(new PrometheusRegistryMockScrape(PrometheusConfig.DEFAULT, ""));
+        final DataPrepper mockDataPrepper = Mockito.mock(DataPrepper.class);
+        Mockito.when(mockDataPrepper.getTransformationPipelines()).thenThrow(new RuntimeException(""));
+        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080, mockDataPrepper);
+        dataPrepperServer.start();
+
+        HttpRequest request = HttpRequest.newBuilder(new URI("http://127.0.0.1:8080/list"))
+                .GET().build();
+        HttpResponse response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        Assert.assertEquals(500, response.statusCode());
+        dataPrepperServer.stop();
+    }
+
+    @Test
+    public void testShutdown() throws URISyntaxException, IOException, InterruptedException {
+        setRegistry(new PrometheusRegistryMockScrape(PrometheusConfig.DEFAULT, ""));
+        final DataPrepper mockDataPrepper = Mockito.mock(DataPrepper.class);
+        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080, mockDataPrepper);
+        dataPrepperServer.start();
+
+        HttpRequest request = HttpRequest.newBuilder(new URI("http://127.0.0.1:8080/shutdown"))
+                .GET().build();
+        HttpResponse response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        Assert.assertEquals(200, response.statusCode());
+        Mockito.verify(mockDataPrepper).shutdown();
+        dataPrepperServer.stop();
+    }
+
+    @Test
+    public void testShutdownFailure() throws URISyntaxException, IOException, InterruptedException {
+        setRegistry(new PrometheusRegistryMockScrape(PrometheusConfig.DEFAULT, ""));
+        final DataPrepper mockDataPrepper = Mockito.mock(DataPrepper.class);
+        Mockito.doThrow(new RuntimeException("")).when(mockDataPrepper).shutdown();
+        final DataPrepperServer dataPrepperServer = new DataPrepperServer(8080, mockDataPrepper);
+        dataPrepperServer.start();
+
+        HttpRequest request = HttpRequest.newBuilder(new URI("http://127.0.0.1:8080/shutdown"))
+                .GET().build();
+        HttpResponse response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        Assert.assertEquals(500, response.statusCode());
+        Mockito.verify(mockDataPrepper).shutdown();
         dataPrepperServer.stop();
     }
 

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -19,5 +19,5 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
     testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
-    testImplementation "org.mockito:mockito-core:2.1.0"
+    testImplementation "org.mockito:mockito-core:${versionMap.mockito}"
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/Data-Prepper/issues/233


*Description of changes:*
- Adding HttpHandlers for List and Shutdown APIs
- Accepting pointer to DataPrepper into the DataPrepperServer constructor
- Adding tests for the 2 new handlers

Note: The PipelineListing object will contain more information about the pipeline (such as isRunning) in the future, when that information is available from the pipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
