### PR TITLE
CLN: elasticsearch dependency

### DIFF
--- a/data-prepper-plugins/elasticsearch/build.gradle
+++ b/data-prepper-plugins/elasticsearch/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     compile project(':data-prepper-api')
     compile project(':data-prepper-plugins:common')
     implementation "org.elasticsearch.client:elasticsearch-rest-high-level-client:${es_version}"
-    implementation "org.elasticsearch:elasticsearch:${es_version}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versionMap.jackson_dataformat_yaml}"
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Remove unnecessary elasticsearch core library dependency in ES sink

Note: For now javax.ws.rs is used for HttpMethod constants such as GET, PUT, DELETE, HEAD. So I will keep it there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
