### PR TITLE
Fix Data Prepper Server shutdown flow.

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
@@ -78,6 +78,12 @@ public class DataPrepper {
         transformationPipelines.forEach((name, pipeline) -> {
             pipeline.shutdown();
         });
+    }
+
+    /**
+     * Triggers shutdown of the Data Prepper server.
+     */
+    public void shutdownDataPrepperServer(){
         dataPrepperServer.stop();
     }
 

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
@@ -4,14 +4,17 @@ import com.amazon.dataprepper.DataPrepper;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import com.sun.net.httpserver.HttpServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class to handle any serving that the data prepper instance needs to do.
  * Currently, only serves metrics in prometheus format.
  */
 public class DataPrepperServer {
-
+    private static final Logger LOG = LoggerFactory.getLogger(DataPrepperServer.class);
     private final HttpServer server;
+    private final int port;
 
     public DataPrepperServer(final int port, final DataPrepper dataPrepper) {
         try {
@@ -22,6 +25,7 @@ public class DataPrepperServer {
             server.createContext("/metrics/prometheus", new PrometheusMetricsHandler());
             server.createContext("/list", new ListPipelinesHandler(dataPrepper));
             server.createContext("/shutdown", new ShutdownHandler(dataPrepper));
+            this.port = port;
         } catch (IOException e) {
             throw new RuntimeException("Failed to create server", e);
         }
@@ -32,6 +36,8 @@ public class DataPrepperServer {
      */
     public void start() {
         server.start();
+        LOG.info("Data Prepper server running at :{}", port);
+
     }
 
     /**
@@ -39,5 +45,6 @@ public class DataPrepperServer {
      */
     public void stop() {
         server.stop(0);
+        LOG.info("Data Prepper server stopped");
     }
 }

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/ShutdownHandler.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/ShutdownHandler.java
@@ -30,6 +30,7 @@ public class ShutdownHandler implements HttpHandler {
             exchange.sendResponseHeaders(HttpURLConnection.HTTP_INTERNAL_ERROR, 0);
         } finally {
             exchange.getResponseBody().close();
+            dataPrepper.shutdownDataPrepperServer();
         }
     }
 }


### PR DESCRIPTION
*Description of changes:*

* A small fix to the Data Prepper server shutdown logic. By doing the server shutdown before the response prints an unwanted exception of stream channel closed. 
* Added log statements to print start and shutdown of Data Prepper Server.


Note: When I included the ElasticsearchSink the shutdown doesn't happen gracefully this is because the ElasticSearchSink uses highlevel client and this needs to closed. 

https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-high-getting-started-initialization.html 


*Testing*

** Logs **
```


~/open-source/Data-Prepper/release/archives/macos/build/distributions/data-prepper-v0.7.0-alpha-macos-x64 master* ⇡
❯ ./data-prepper-tar-install.sh /Users/kowshikn/open-source/Data-Prepper/examples/file_sink.yml
/usr/local/opt/openjdk/bin/java
Found openjdk version  of 14.0
0    [main] INFO  com.amazon.dataprepper.pipeline.server.DataPrepperServer  – Data Prepper server running at :4900
75   [main] INFO  com.amazon.dataprepper.parser.PipelineParser  – Building pipeline [entry-pipeline] from provided configuration
75   [main] INFO  com.amazon.dataprepper.parser.PipelineParser  – Building [otel_trace_source] as source component for the pipeline [entry-pipeline]
201  [main] INFO  com.amazon.dataprepper.parser.PipelineParser  – Building buffer for the pipeline [entry-pipeline]
214  [main] INFO  com.amazon.dataprepper.parser.PipelineParser  – Building processors for the pipeline [entry-pipeline]
215  [main] INFO  com.amazon.dataprepper.parser.PipelineParser  – Building sinks for the pipeline [entry-pipeline]
215  [main] INFO  com.amazon.dataprepper.parser.PipelineParser  – Building [file] as sink component
217  [main] INFO  com.amazon.dataprepper.pipeline.Pipeline  – Pipeline [entry-pipeline] - Initiating pipeline execution
856  [main] INFO  com.amazon.dataprepper.pipeline.Pipeline  – Pipeline [entry-pipeline] - Submitting request to initiate the pipeline processing
965  [entry-pipeline-process-worker-1-thread-1] INFO  com.amazon.dataprepper.pipeline.ProcessWorker  –  entry-pipeline Worker: No records received from buffer
14644 [HTTP-Dispatcher] INFO  com.amazon.dataprepper.pipeline.Pipeline  – Pipeline [entry-pipeline] - Received shutdown signal with timeout 5000, will initiate the shutdown process
16694 [HTTP-Dispatcher] INFO  com.amazon.dataprepper.pipeline.Pipeline  – Pipeline [entry-pipeline] - Shutting down process workers
16733 [HTTP-Dispatcher] INFO  com.amazon.dataprepper.pipeline.server.DataPrepperServer  – Data Prepper server stopped

```
** Shutdown commands **

```
❯ curl -v -XGET http://localhost:4900/shutdown
Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 4900 (#0)
> GET /shutdown HTTP/1.1
> Host: localhost:4900
> User-Agent: curl/7.64.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Thu, 17 Dec 2020 03:47:24 GMT
< Transfer-encoding: chunked
< 
* Connection #0 to host localhost left intact
* Closing connection 0

```

**Yml**

```
entry-pipeline:
  delay: "100"
  source:
    otel_trace_source:
  processor:
    - otel_trace_raw_processor:
  sink:
    - file:
        path: /Users/kowshikn/open-source/Data-Prepper/some-output.txt

```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
