### PR TITLE
ADD: custom metrics in peer-forwarder

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/PluginMetrics.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/PluginMetrics.java
@@ -9,6 +9,10 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 
+/**
+ * Provides reference to APIs that register timer, counter, gauge into global registry.
+ * See https://micrometer.io/docs/concepts#_registry
+ */
 public class PluginMetrics {
 
     private final String metricsPrefix;

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/PluginMetrics.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/PluginMetrics.java
@@ -2,6 +2,8 @@ package com.amazon.dataprepper.metrics;
 
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import java.util.StringJoiner;
+import java.util.function.ToDoubleFunction;
+
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Metrics;
@@ -41,7 +43,11 @@ public class PluginMetrics {
     }
 
     public <T extends Number> T gauge(final String name, T number) {
-        return Metrics.gauge(name, number);
+        return Metrics.gauge(getMeterName(name), number);
+    }
+
+    public <T> T gauge(String name, T obj, ToDoubleFunction<T> valueFunction) {
+        return Metrics.gauge(getMeterName(name), obj, valueFunction);
     }
 
     private String getMeterName(final String name) {

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/metrics/PluginMetricsTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/metrics/PluginMetricsTest.java
@@ -50,7 +50,7 @@ public class PluginMetricsTest {
     }
 
     @Test
-    public void testGauge() {
+    public void testNumberGauge() {
         final AtomicInteger atomicInteger = new AtomicInteger(0);
         final AtomicInteger gauge = PLUGIN_METRICS.gauge("gauge", atomicInteger);
         Assert.assertNotNull(
@@ -58,6 +58,17 @@ public class PluginMetricsTest {
                         .add(PIPELINE_NAME).add(PLUGIN_NAME)
                         .add("gauge").toString()).meter());
         Assert.assertEquals(atomicInteger.get(), gauge.get());
+    }
+
+    @Test
+    public void testReferenceGauge() {
+        final String testString = "abc";
+        final String gauge = PLUGIN_METRICS.gauge("gauge", testString, String::length);
+        Assert.assertNotNull(
+                Metrics.globalRegistry.get(new StringJoiner(MetricNames.DELIMITER)
+                        .add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add("gauge").toString()).meter());
+        Assert.assertEquals(3, gauge.length());
     }
 
     @Test

--- a/data-prepper-plugins/peer-forwarder/build.gradle
+++ b/data-prepper-plugins/peer-forwarder/build.gradle
@@ -11,6 +11,7 @@ repositories {
 
 dependencies {
     compile project(':data-prepper-api')
+    testCompile project(':data-prepper-api').sourceSets.test.output
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
     implementation "com.linecorp.armeria:armeria:1.0.0"
     implementation "com.linecorp.armeria:armeria-grpc:1.0.0"

--- a/data-prepper-plugins/peer-forwarder/build.gradle
+++ b/data-prepper-plugins/peer-forwarder/build.gradle
@@ -16,7 +16,5 @@ dependencies {
     implementation "com.linecorp.armeria:armeria:1.0.0"
     implementation "com.linecorp.armeria:armeria-grpc:1.0.0"
     testImplementation "junit:junit:4.12"
-    testImplementation "org.powermock:powermock-api-mockito2:2.0.9"
-    testImplementation "org.powermock:powermock-module-junit4:2.0.9"
     testImplementation "org.mockito:mockito-inline:3.6.28"
 }

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarder.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarder.java
@@ -53,7 +53,7 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
         this.hashRing = hashRing;
         this.maxNumSpansPerRequest = maxNumSpansPerRequest;
         this.peerListProvider = pluginMetrics.gauge(
-                PEER_ENDPOINTS, peerListProvider, provider -> (double) provider.getPeerList().size());
+                PEER_ENDPOINTS, peerListProvider, provider -> provider.getPeerList().size());
         forwardedRequestCounters = new HashMap<>();
         forwardRequestErrorCounters = new HashMap<>();
         forwardRequestTimers = new HashMap<>();

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarder.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarder.java
@@ -1,11 +1,11 @@
 package com.amazon.dataprepper.plugins.processor.peerforwarder;
 
-import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.PluginType;
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.processor.AbstractPrepper;
 import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.plugins.processor.peerforwarder.discovery.PeerListProvider;
 import com.amazon.dataprepper.plugins.processor.peerforwarder.discovery.StaticPeerListProvider;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
@@ -30,6 +30,7 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
     public static final String FORWARD_REQUEST_LATENCY_PREFIX = "forwardRequestLatency";
     public static final String FORWARD_REQUEST_SUCCESS_PREFIX = "forwardRequestSuccess";
     public static final String FORWARD_REQUEST_ERRORS_PREFIX = "forwardRequestErrors";
+    public static final String PEER_ENDPOINTS = "peerEndpoints";
 
     private static final Logger LOG = LoggerFactory.getLogger(PeerForwarder.class);
 
@@ -40,8 +41,10 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
     private final Map<String, Timer> forwardRequestTimers;
     private final Map<String, Counter> forwardedRequestCounters;
     private final Map<String, Counter> forwardRequestErrorCounters;
+    private final PeerListProvider peerListProvider;
 
     public PeerForwarder(final PluginSetting pluginSetting,
+                         final PeerListProvider peerListProvider,
                          final PeerClientPool peerClientPool,
                          final HashRing hashRing,
                          final int maxNumSpansPerRequest) {
@@ -49,6 +52,8 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
         this.peerClientPool = peerClientPool;
         this.hashRing = hashRing;
         this.maxNumSpansPerRequest = maxNumSpansPerRequest;
+        this.peerListProvider = pluginMetrics.gauge(
+                PEER_ENDPOINTS, peerListProvider, provider -> (double) provider.getPeerList().size());
         forwardedRequestCounters = new HashMap<>();
         forwardRequestErrorCounters = new HashMap<>();
         forwardRequestTimers = new HashMap<>();
@@ -61,6 +66,7 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
     public PeerForwarder(final PluginSetting pluginSetting, final PeerForwarderConfig peerForwarderConfig) {
         this(
                 pluginSetting,
+                peerForwarderConfig.getPeerListProvider(),
                 peerForwarderConfig.getPeerClientPool(),
                 peerForwarderConfig.getHashRing(),
                 peerForwarderConfig.getMaxNumSpansPerRequest()

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderConfig.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderConfig.java
@@ -23,16 +23,19 @@ public class PeerForwarderConfig {
 
     private final HashRing hashRing;
     private final PeerClientPool peerClientPool;
+    private final PeerListProvider peerListProvider;
     private final int timeOut;
     private final int maxNumSpansPerRequest;
 
-    private PeerForwarderConfig(final PeerClientPool peerClientPool,
+    private PeerForwarderConfig(final PeerListProvider peerListProvider,
+                                final PeerClientPool peerClientPool,
                                 final HashRing hashRing,
                                 final int timeOut,
                                 final int maxNumSpansPerRequest) {
         checkNotNull(peerClientPool);
         checkNotNull(hashRing);
 
+        this.peerListProvider = peerListProvider;
         this.peerClientPool = peerClientPool;
         this.hashRing = hashRing;
         this.timeOut = timeOut;
@@ -62,6 +65,7 @@ public class PeerForwarderConfig {
         peerClientPool.setSslKeyCertChainFile(sslKeyCertChainFile);
 
         return new PeerForwarderConfig(
+                peerListProvider,
                 peerClientPool,
                 hashRing,
                 pluginSetting.getIntegerOrDefault(TIME_OUT, 3),
@@ -70,6 +74,10 @@ public class PeerForwarderConfig {
 
     public HashRing getHashRing() {
         return hashRing;
+    }
+
+    public PeerListProvider getPeerListProvider() {
+        return peerListProvider;
     }
 
     public PeerClientPool getPeerClientPool() {

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderTest.java
@@ -65,6 +65,9 @@ public class PeerForwarderTest {
     @Mock
     private PeerClientPool peerClientPool;
 
+    @Mock
+    private TraceServiceGrpc.TraceServiceBlockingStub client;
+
     @Before
     public void setUp() {
         peerClientPoolClassMock = Mockito.mockStatic(PeerClientPool.class);
@@ -116,10 +119,9 @@ public class PeerForwarderTest {
     }
 
     @Test
-    public void testSingleRemoteIpBothLocalAndForwardedRequest() throws Exception {
+    public void testSingleRemoteIpBothLocalAndForwardedRequest() {
         final List<String> testIps = generateTestIps(2);
         final Channel channel = mock(Channel.class);
-        final TraceServiceGrpc.TraceServiceBlockingStub client = mock(TraceServiceGrpc.TraceServiceBlockingStub.class);
         final String peerIp = testIps.get(1);
         when(channel.authority()).thenReturn(String.format("%s:21890", peerIp));
         when(peerClientPool.getClient(peerIp)).thenReturn(client);
@@ -185,7 +187,6 @@ public class PeerForwarderTest {
     public void testSingleRemoteIpForwardedRequestOnly() throws Exception {
         final List<String> testIps = generateTestIps(2);
         final Channel channel = mock(Channel.class);
-        final TraceServiceGrpc.TraceServiceBlockingStub client = mock(TraceServiceGrpc.TraceServiceBlockingStub.class);
         final String peerIp = testIps.get(1);
         final String fullPeerIp = String.format("%s:21890", peerIp);
         when(channel.authority()).thenReturn(fullPeerIp);
@@ -241,7 +242,6 @@ public class PeerForwarderTest {
     public void testSingleRemoteIpForwardRequestError() {
         final List<String> testIps = generateTestIps(2);
         final Channel channel = mock(Channel.class);
-        final TraceServiceGrpc.TraceServiceBlockingStub client = mock(TraceServiceGrpc.TraceServiceBlockingStub.class);
         final String peerIp = testIps.get(1);
         final String fullPeerIp = String.format("%s:21890", peerIp);
         when(channel.authority()).thenReturn(fullPeerIp);

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderTest.java
@@ -237,8 +237,9 @@ public class PeerForwarderTest {
         final Channel channel = mock(Channel.class);
         final PeerClientPool peerClientPool = mock(PeerClientPool.class);
         final TraceServiceGrpc.TraceServiceBlockingStub client = mock(TraceServiceGrpc.TraceServiceBlockingStub.class);
-        when(channel.authority()).thenReturn(String.format("%s:21890", testIps.get(1)));
-        when(peerClientPool.getClient(anyString())).thenReturn(client);
+        final String peerIp = testIps.get(1);
+        when(channel.authority()).thenReturn(String.format("%s:21890", peerIp));
+        when(peerClientPool.getClient(peerIp)).thenReturn(client);
         when(client.export(any(ExportTraceServiceRequest.class))).thenThrow(new RuntimeException());
         when(client.getChannel()).thenReturn(channel);
 

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderTest.java
@@ -1,15 +1,10 @@
 package com.amazon.dataprepper.plugins.processor.peerforwarder;
 
-import com.amazon.dataprepper.metrics.MetricNames;
 import com.amazon.dataprepper.metrics.MetricsTestUtil;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
 import com.google.protobuf.ByteString;
-import com.linecorp.armeria.client.ClientBuilder;
-import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.Clients;
 import io.grpc.Channel;
-import io.micrometer.core.instrument.Measurement;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import io.opentelemetry.proto.common.v1.InstrumentationLibrary;
@@ -263,8 +258,9 @@ public class PeerForwarderTest {
             final List<ResourceSpans> forwardedResourceSpans = exportedRequest.getResourceSpansList();
             Assert.assertTrue(forwardedResourceSpans.containsAll(expectedLocalResourceSpans));
             Assert.assertTrue(expectedLocalResourceSpans.containsAll(forwardedResourceSpans));
-            // TODO: Verify metrics
         }
+
+        // TODO: Verify metrics
     }
 
     /**

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderTest.java
@@ -131,7 +131,14 @@ public class PeerForwarderTest {
             return null;
         }).when(client).export(any(ExportTraceServiceRequest.class));
 
+        MetricsTestUtil.initMetrics();
         final PeerForwarder testPeerForwarder = generatePeerForwarder(testIps, 3);
+        // Verify activePeers
+        final List<Measurement> activePeers = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add("testPipeline").add("peer_forwarder")
+                        .add(PeerForwarder.PEER_ENDPOINTS).toString());
+        Assert.assertEquals(1, activePeers.size());
+        Assert.assertEquals(2.0, activePeers.get(0).getValue(), 0);
 
         final List<Record<ExportTraceServiceRequest>> exportedRecords = testPeerForwarder
                 .doExecute(Arrays.asList(new Record<>(REQUEST_1), new Record<>(REQUEST_2)));

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarderTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PeerForwarderTest {
+    private static final String TEST_PIPELINE_NAME = "testPipeline";
     private static final String LOCAL_IP = "127.0.0.1";
     private static final Span SPAN_1 = Span.newBuilder()
             .setTraceId(ByteString.copyFromUtf8("traceIdA")).setSpanId(ByteString.copyFromUtf8("spanId1")).build();
@@ -135,7 +136,7 @@ public class PeerForwarderTest {
         final PeerForwarder testPeerForwarder = generatePeerForwarder(testIps, 3);
         // Verify activePeers
         final List<Measurement> activePeers = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add("testPipeline").add("peer_forwarder")
+                new StringJoiner(MetricNames.DELIMITER).add(TEST_PIPELINE_NAME).add("peer_forwarder")
                         .add(PeerForwarder.PEER_ENDPOINTS).toString());
         Assert.assertEquals(1, activePeers.size());
         Assert.assertEquals(2.0, activePeers.get(0).getValue(), 0);
@@ -215,17 +216,17 @@ public class PeerForwarderTest {
 
         // Verify metrics
         final List<Measurement> forwardRequestErrorMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add("testPipeline").add("peer_forwarder")
+                new StringJoiner(MetricNames.DELIMITER).add(TEST_PIPELINE_NAME).add("peer_forwarder")
                         .add(String.format("%s:%s", PeerForwarder.FORWARD_REQUEST_ERRORS_PREFIX, fullPeerIp)).toString());
         Assert.assertEquals(1, forwardRequestErrorMeasurements.size());
         Assert.assertEquals(0.0, forwardRequestErrorMeasurements.get(0).getValue(), 0);
         final List<Measurement> forwardRequestSuccessMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add("testPipeline").add("peer_forwarder")
+                new StringJoiner(MetricNames.DELIMITER).add(TEST_PIPELINE_NAME).add("peer_forwarder")
                         .add(String.format("%s:%s", PeerForwarder.FORWARD_REQUEST_SUCCESS_PREFIX, fullPeerIp)).toString());
         Assert.assertEquals(1, forwardRequestSuccessMeasurements.size());
         Assert.assertEquals(1.0, forwardRequestSuccessMeasurements.get(0).getValue(), 0);
         final List<Measurement> forwardRequestLatencyMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add("testPipeline").add("peer_forwarder")
+                new StringJoiner(MetricNames.DELIMITER).add(TEST_PIPELINE_NAME).add("peer_forwarder")
                         .add(String.format("%s:%s", PeerForwarder.FORWARD_REQUEST_LATENCY_PREFIX, fullPeerIp)).toString());
         Assert.assertEquals(3, forwardRequestLatencyMeasurements.size());
         // COUNT
@@ -264,17 +265,17 @@ public class PeerForwarderTest {
 
         // Verify metrics
         final List<Measurement> forwardRequestErrorMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add("testPipeline").add("peer_forwarder")
+                new StringJoiner(MetricNames.DELIMITER).add(TEST_PIPELINE_NAME).add("peer_forwarder")
                         .add(String.format("%s:%s", PeerForwarder.FORWARD_REQUEST_ERRORS_PREFIX, fullPeerIp)).toString());
         Assert.assertEquals(1, forwardRequestErrorMeasurements.size());
         Assert.assertEquals(1.0, forwardRequestErrorMeasurements.get(0).getValue(), 0);
         final List<Measurement> forwardRequestSuccessMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add("testPipeline").add("peer_forwarder")
+                new StringJoiner(MetricNames.DELIMITER).add(TEST_PIPELINE_NAME).add("peer_forwarder")
                         .add(String.format("%s:%s", PeerForwarder.FORWARD_REQUEST_SUCCESS_PREFIX, fullPeerIp)).toString());
         Assert.assertEquals(1, forwardRequestSuccessMeasurements.size());
         Assert.assertEquals(0.0, forwardRequestSuccessMeasurements.get(0).getValue(), 0);
         final List<Measurement> forwardRequestLatencyMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add("testPipeline").add("peer_forwarder")
+                new StringJoiner(MetricNames.DELIMITER).add(TEST_PIPELINE_NAME).add("peer_forwarder")
                         .add(String.format("%s:%s", PeerForwarder.FORWARD_REQUEST_LATENCY_PREFIX, fullPeerIp)).toString());
         Assert.assertEquals(3, forwardRequestLatencyMeasurements.size());
         // COUNT
@@ -305,6 +306,6 @@ public class PeerForwarderTest {
         settings.put(PeerForwarderConfig.STATIC_ENDPOINTS, staticEndpoints);
         settings.put(PeerForwarderConfig.MAX_NUM_SPANS_PER_REQUEST, spansPerRequest);
         settings.put(PeerForwarderConfig.TIME_OUT, 300);
-        return new PeerForwarder(new PluginSetting("peer_forwarder", settings) {{setPipelineName("testPipeline");}});
+        return new PeerForwarder(new PluginSetting("peer_forwarder", settings) {{setPipelineName(TEST_PIPELINE_NAME);}});
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#200 

*Description of changes:*
- ~Added forwardRequestErrorCounter as a custom metric in PeerForwarder~
- ~Added a test case to cover the metric~

This PR 

- Add an overload of gauge API in PluginMetrics
- Introduced peerforwarder custom metrics as in the checklist
  - [x] Timer
     - [x] Timer on forwarding each request per target peer IP
  - [x] Counter
     - [x] Counter on number of forwarded requests per target peer IP
     - [x] Counter on number of forward request errors per target peer IP
  - [x] Gauge
     - [x] Number of active peer IPs returned by PeerProviderList
- Refined test cases on PeerForwarder and verified metrics values

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
