### PR TITLE
Increased unit test coverage for peer-forwader plugin package.

### DIFF
--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
@@ -53,7 +53,7 @@ public class HashRing implements Consumer<List<Endpoint>> {
         try {
             md = MessageDigest.getInstance(MD5);
         } catch (NoSuchAlgorithmException e) {
-            throw (AssertionError)new AssertionError("unreachable", e);
+            throw (AssertionError) new AssertionError("unreachable", e);
         }
 
         md.update(traceIdInBytes);
@@ -72,11 +72,6 @@ public class HashRing implements Consumer<List<Endpoint>> {
     @Override
     public void accept(final List<Endpoint> endpoints) {
         buildHashServerMap();
-    }
-
-    @Override
-    public Consumer<List<Endpoint>> andThen(final Consumer<? super List<Endpoint>> after) {
-        throw new UnsupportedOperationException();
     }
 
     private void buildHashServerMap() {
@@ -98,7 +93,7 @@ public class HashRing implements Consumer<List<Endpoint>> {
         try {
             md = MessageDigest.getInstance(MD5);
         } catch (NoSuchAlgorithmException e) {
-            throw (AssertionError)new AssertionError("unreachable", e);
+            throw (AssertionError) new AssertionError("unreachable", e);
         }
 
         final ByteBuffer intBuffer = ByteBuffer.allocate(4);

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRing.java
@@ -47,15 +47,18 @@ public class HashRing implements Consumer<List<Endpoint>> {
         if (hashServerMap.isEmpty()) {
             return Optional.empty();
         }
+
         final byte[] traceIdInBytes = traceId.getBytes();
         final MessageDigest md;
         try {
             md = MessageDigest.getInstance(MD5);
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
+            throw (AssertionError)new AssertionError("unreachable", e);
         }
+
         md.update(traceIdInBytes);
         final BigInteger hashcode = new BigInteger(md.digest());
+
         // obtain Map.Entry with key greater than the hashcode
         final Map.Entry<BigInteger, String> entry = hashServerMap.higherEntry(hashcode);
         if (entry == null) {
@@ -73,7 +76,7 @@ public class HashRing implements Consumer<List<Endpoint>> {
 
     @Override
     public Consumer<List<Endpoint>> andThen(final Consumer<? super List<Endpoint>> after) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     private void buildHashServerMap() {
@@ -91,11 +94,13 @@ public class HashRing implements Consumer<List<Endpoint>> {
     private void addServerIpToHashMap(final String serverIp, final Map<BigInteger, String> targetMap) {
         final byte[] serverIpInBytes = serverIp.getBytes();
         final MessageDigest md;
+
         try {
             md = MessageDigest.getInstance(MD5);
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
+            throw (AssertionError)new AssertionError("unreachable", e);
         }
+
         final ByteBuffer intBuffer = ByteBuffer.allocate(4);
         for (int i = 0; i < numVirtualNodes; i++) {
             md.update(serverIpInBytes);

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/PeerListProviderFactory.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/PeerListProviderFactory.java
@@ -39,7 +39,7 @@ public class PeerListProviderFactory {
 
                 return new StaticPeerListProvider(endpoints);
             default:
-                throw new UnsupportedOperationException(String.format("Unsupported discovery mode: {}", discoveryMode));
+                throw new UnsupportedOperationException(String.format("Unsupported discovery mode: %s", discoveryMode));
         }
     }
 }

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/HashRingTest.java
@@ -131,11 +131,4 @@ public class HashRingTest {
         // Second call during rebuild
         verify(peerListProvider, times(2)).getPeerList();
     }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testAndThenImplementationThrowsUnsupportedOperationException() {
-        sut = new HashRing(peerListProvider, SINGLE_VIRTUAL_NODE_COUNT);
-
-        sut.andThen(sut);
-    }
 }

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/DiscoveryMode.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/DiscoveryMode.java
@@ -1,5 +1,8 @@
 package com.amazon.dataprepper.plugins.processor.peerforwarder.discovery;
 
+/**
+ * Test enum defined to provide an UNSUPPORTED value for use in unit testing.
+ */
 public enum DiscoveryMode {
     STATIC,
     DNS,

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/DiscoveryMode.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/DiscoveryMode.java
@@ -1,0 +1,7 @@
+package com.amazon.dataprepper.plugins.processor.peerforwarder.discovery;
+
+public enum DiscoveryMode {
+    STATIC,
+    DNS,
+    UNSUPPORTED
+}

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/DnsPeerListProviderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/DnsPeerListProviderTest.java
@@ -12,9 +12,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,6 +49,15 @@ public class DnsPeerListProviderTest {
     @Test(expected = NullPointerException.class)
     public void testDefaultListProviderWithNullHostname() {
         new DnsPeerListProvider(null);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testConstructWithInterruptedException() throws Exception {
+        CompletableFuture mockFuture = mock(CompletableFuture.class);
+        when(mockFuture.get()).thenThrow(new InterruptedException());
+        when(dnsAddressEndpointGroup.whenReady()).thenReturn(mockFuture);
+
+        new DnsPeerListProvider(dnsAddressEndpointGroup);
     }
 
     @Test

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/PeerListProviderFactoryTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/PeerListProviderFactoryTest.java
@@ -57,6 +57,13 @@ public class PeerListProviderFactoryTest {
         factory.createProvider(pluginSetting);
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUnsupportedDiscoveryModeEnum() {
+        pluginSetting.getSettings().put(PeerForwarderConfig.DISCOVERY_MODE, DiscoveryMode.UNSUPPORTED.toString());
+
+        factory.createProvider(pluginSetting);
+    }
+
     @Test(expected = NullPointerException.class)
     public void testCreateProviderStaticInstanceNoEndpoints() {
         pluginSetting.getSettings().put(PeerForwarderConfig.DISCOVERY_MODE, DiscoveryMode.STATIC.toString());

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/StaticPeerListProviderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/processor/peerforwarder/discovery/StaticPeerListProviderTest.java
@@ -35,6 +35,11 @@ public class StaticPeerListProviderTest {
         new StaticPeerListProvider(Collections.emptyList());
     }
 
+    @Test(expected = RuntimeException.class)
+    public void testListProviderWithNullList() {
+        new StaticPeerListProvider(null);
+    }
+
     @Test
     public void testListProviderWithNonEmptyList() {
         assertEquals(ENDPOINT_LIST.size(), staticPeerListProvider.getPeerList().size());


### PR DESCRIPTION
*Issue #, if available:* #239

*Description of changes:*
Small PR to increase coverage of classes in the peer-forwarder project. I'm leaving the actual PeerForwarder class alone as it is undergoing development. 

New coverage values are 69%/56% (lines/branches). It's interesting to note that the PeerForwarder class shows 0% coverage, probably something with the way it's instrumented. Will fix in a future PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
