### PR TITLE
Adding and supporting DataPrepperConfiguration

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/PluginMetrics.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/PluginMetrics.java
@@ -41,7 +41,7 @@ public class PluginMetrics {
     }
 
     public <T extends Number> T gauge(final String name, T number) {
-        return Metrics.gauge(name, number);
+        return Metrics.gauge(getMeterName(name), number);
     }
 
     private String getMeterName(final String name) {

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/metrics/PluginMetricsTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/metrics/PluginMetricsTest.java
@@ -6,6 +6,7 @@ import java.util.StringJoiner;
 import java.util.concurrent.atomic.AtomicInteger;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 import org.junit.Assert;
 import org.junit.Test;
@@ -52,6 +53,10 @@ public class PluginMetricsTest {
     public void testGauge() {
         final AtomicInteger atomicInteger = new AtomicInteger(0);
         final AtomicInteger gauge = PLUGIN_METRICS.gauge("gauge", atomicInteger);
+        Assert.assertNotNull(
+                Metrics.globalRegistry.get(new StringJoiner(MetricNames.DELIMITER)
+                        .add(PIPELINE_NAME).add(PLUGIN_NAME)
+                        .add("gauge").toString()).meter());
         Assert.assertEquals(atomicInteger.get(), gauge.get());
     }
 

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
@@ -1,12 +1,15 @@
 package com.amazon.dataprepper;
 
 import com.amazon.dataprepper.parser.PipelineParser;
+import com.amazon.dataprepper.parser.model.DataPrepperConfiguration;
 import com.amazon.dataprepper.pipeline.Pipeline;
 import com.amazon.dataprepper.pipeline.server.DataPrepperServer;
+import java.io.File;
 import java.util.Map;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.apache.log4j.PropertyConfigurator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,13 +21,20 @@ import org.slf4j.LoggerFactory;
  */
 public class DataPrepper {
     private static final Logger LOG = LoggerFactory.getLogger(DataPrepper.class);
-    private static final int SERVER_PORT = 4900;
 
     private Map<String, Pipeline> transformationPipelines;
 
     private static volatile DataPrepper dataPrepper;
 
     private static DataPrepperServer dataPrepperServer;
+    private static DataPrepperConfiguration configuration = DataPrepperConfiguration.DEFAULT_CONFIG;
+
+    public static void configure(final String configurationFile) {
+        final DataPrepperConfiguration dataPrepperConfiguration =
+                DataPrepperConfiguration.fromFile(new File(configurationFile));
+        PropertyConfigurator.configure(dataPrepperConfiguration.getLog4JConfiguration().getProperties());
+        configuration = dataPrepperConfiguration;
+    }
 
     public static DataPrepper getInstance() {
         if (dataPrepper == null) {
@@ -41,8 +51,7 @@ public class DataPrepper {
             throw new RuntimeException("Please use getInstance() for an instance of this Data Prepper");
         }
         startPrometheusBackend();
-        dataPrepperServer = new DataPrepperServer(SERVER_PORT, this);
-        dataPrepperServer.start();
+        dataPrepperServer = new DataPrepperServer(this);
     }
 
     /**
@@ -100,10 +109,15 @@ public class DataPrepper {
         return  transformationPipelines;
     }
 
+    public DataPrepperConfiguration getConfiguration() {
+        return configuration;
+    }
+
     private boolean initiateExecution() {
         transformationPipelines.forEach((name, pipeline) -> {
             pipeline.execute();
         });
+        dataPrepperServer.start();
         return true;
     }
 }

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
@@ -113,7 +113,7 @@ public class DataPrepper {
         return  transformationPipelines;
     }
 
-    public DataPrepperConfiguration getConfiguration() {
+    public static DataPrepperConfiguration getConfiguration() {
         return configuration;
     }
 

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
@@ -29,6 +29,10 @@ public class DataPrepper {
     private static DataPrepperServer dataPrepperServer;
     private static DataPrepperConfiguration configuration = DataPrepperConfiguration.DEFAULT_CONFIG;
 
+    /**
+     * Set the DataPrepperConfiguration from a file
+     * @param configurationFile File containing DataPrepperConfiguration yaml
+     */
     public static void configure(final String configurationFile) {
         final DataPrepperConfiguration dataPrepperConfiguration =
                 DataPrepperConfiguration.fromFile(new File(configurationFile));

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepperExecute.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepperExecute.java
@@ -10,6 +10,9 @@ public class DataPrepperExecute {
     private static final Logger LOG = LoggerFactory.getLogger(DataPrepperExecute.class);
 
     public static void main(String[] args) {
+        if(args.length > 1) {
+            DataPrepper.configure(args[1]);
+        }
         final DataPrepper dataPrepper = DataPrepper.getInstance();
         if (args.length > 0) {
             dataPrepper.execute(args[0]);

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/DataPrepperConfiguration.java
@@ -35,16 +35,24 @@ public class DataPrepperConfiguration {
 
     @JsonCreator
     public DataPrepperConfiguration(
-            @JsonProperty("serverPort") final int serverPort,
+            @JsonProperty("serverPort") final String serverPort,
             @JsonProperty("log4jConfig") final Log4JConfiguration log4JConfiguration
     ) {
         setServerPort(serverPort);
         setLog4JConfiguration(log4JConfiguration);
     }
 
-    private void setServerPort(int serverPort) {
-        if(serverPort != 0) {
-            this.serverPort = serverPort;
+    private void setServerPort(final String serverPort) {
+        if(serverPort != null && !serverPort.isEmpty()) {
+            try {
+                int port = Integer.parseInt(serverPort);
+                if(port <= 0) {
+                    throw new IllegalArgumentException("Server port must be a positive integer");
+                }
+                this.serverPort = port;
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Server port must be a positive integer");
+            }
         }
     }
 

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/DataPrepperConfiguration.java
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
+/**
+ * Class to hold configuration for DataPrepper, including server port and Log4j settings
+ */
 public class DataPrepperConfiguration {
     private int serverPort = 4900;
     private Log4JConfiguration log4JConfiguration = Log4JConfiguration.DEFAULT_CONFIG;
@@ -15,6 +18,11 @@ public class DataPrepperConfiguration {
 
     public static final DataPrepperConfiguration DEFAULT_CONFIG = new DataPrepperConfiguration();
 
+    /**
+     * Construct a DataPrepperConfiguration from a yaml file
+     * @param file
+     * @return
+     */
     public static DataPrepperConfiguration fromFile(File file) {
         try {
             return OBJECT_MAPPER.readValue(file, DataPrepperConfiguration.class);

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/DataPrepperConfiguration.java
@@ -1,0 +1,56 @@
+package com.amazon.dataprepper.parser.model;
+
+import java.io.File;
+import java.io.IOException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+public class DataPrepperConfiguration {
+    private int serverPort = 4900;
+    private Log4JConfiguration log4JConfiguration = Log4JConfiguration.DEFAULT_CONFIG;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
+
+    public static final DataPrepperConfiguration DEFAULT_CONFIG = new DataPrepperConfiguration();
+
+    public static DataPrepperConfiguration fromFile(File file) {
+        try {
+            return OBJECT_MAPPER.readValue(file, DataPrepperConfiguration.class);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Invalid DataPrepper configuratino file.");
+        }
+    }
+
+    private DataPrepperConfiguration() {}
+
+    @JsonCreator
+    public DataPrepperConfiguration(
+            @JsonProperty("serverPort") final int serverPort,
+            @JsonProperty("log4jConfig") final Log4JConfiguration log4JConfiguration
+    ) {
+        setServerPort(serverPort);
+        setLog4JConfiguration(log4JConfiguration);
+    }
+
+    private void setServerPort(int serverPort) {
+        if(serverPort != 0) {
+            this.serverPort = serverPort;
+        }
+    }
+
+    private void setLog4JConfiguration(Log4JConfiguration log4JConfiguration) {
+        if(log4JConfiguration != null) {
+            this.log4JConfiguration = log4JConfiguration;
+        }
+    }
+
+    public int getServerPort() {
+        return serverPort;
+    }
+
+    public Log4JConfiguration getLog4JConfiguration() {
+        return log4JConfiguration;
+    }
+}

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/DataPrepperConfiguration.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/DataPrepperConfiguration.java
@@ -27,7 +27,7 @@ public class DataPrepperConfiguration {
         try {
             return OBJECT_MAPPER.readValue(file, DataPrepperConfiguration.class);
         } catch (IOException e) {
-            throw new IllegalArgumentException("Invalid DataPrepper configuratino file.");
+            throw new IllegalArgumentException("Invalid DataPrepper configuration file.");
         }
     }
 

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/Log4JConfiguration.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/Log4JConfiguration.java
@@ -1,0 +1,116 @@
+package com.amazon.dataprepper.parser.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.log4j.Level;
+
+public class Log4JConfiguration {
+    private Level level = Level.ERROR;
+    private String filePath = "logs/Data-Prepper.log";
+    private String maxFileSize = "10MB";
+    private String maxBackupIndex = "5";
+    //TODO: Support log level by plugin
+
+    public static final Log4JConfiguration DEFAULT_CONFIG = new Log4JConfiguration();
+
+    private Log4JConfiguration() {
+
+    }
+
+    @JsonCreator
+    public Log4JConfiguration(
+        @JsonProperty("logLevel") final String logLevel,
+        @JsonProperty("filePath") final String filePath,
+        @JsonProperty("maxFileSize") final String maxFileSize,
+        @JsonProperty("maxBackupIndex") final String maxBackupIndex
+    ) {
+        setLevel(logLevel);
+        setFilePath(filePath);
+        setMaxFileSize(maxFileSize);
+        setMaxBackupIndex(maxBackupIndex);
+    }
+
+    private void setLevel(String level) {
+        if(level != null && !level.isEmpty()) {
+            this.level = Level.toLevel(level);
+        }
+    }
+
+    private void setFilePath(String filePath) {
+        if(filePath != null && !filePath.isEmpty()) {
+            this.filePath = filePath;
+        }
+    }
+
+    private void setMaxFileSize(String maxFileSize) {
+        if(maxFileSize != null && !maxFileSize.isEmpty()) {
+            this.maxFileSize = maxFileSize;
+        }
+    }
+
+    private void setMaxBackupIndex(String maxBackupIndex) {
+        if(maxBackupIndex != null && !maxBackupIndex.isEmpty()) {
+            this.maxBackupIndex = maxBackupIndex;
+        }
+    }
+
+    public Level getLevel() {
+        return level;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public String getMaxFileSize() {
+        return maxFileSize;
+    }
+
+    public String getMaxBackupIndex() {
+        return maxBackupIndex;
+    }
+
+    public Properties getProperties() {
+        Properties properties = new Properties();
+        properties.putAll(PRESET_PROPERTIES);
+        properties.put(Log4JPropertyKeys.ROOT_LOGGER, level.toString() + ", CONSOLE");
+        properties.put(Log4JPropertyKeys.FILE, filePath);
+        properties.put(Log4JPropertyKeys.FILE_MAX_SIZE, maxFileSize);
+        properties.put(Log4JPropertyKeys.FILE_MAX_BACKUP_INDEX, maxBackupIndex);
+        return properties;
+    }
+
+    private static Map<String, String> PRESET_PROPERTIES = new HashMap<String, String>(){{
+        put(Log4JPropertyKeys.CONSOLE_APPENDER, "org.apache.log4j.ConsoleAppender");
+        put(Log4JPropertyKeys.CONSOLE_LAYOUT, "org.apache.log4j.PatternLayout");
+        put(Log4JPropertyKeys.CONSOLE_THRESHOLD, "INFO");
+        put(Log4JPropertyKeys.CONSOLE_CONVERSION_PATTERN, "%-4r [%t] %-5p %c %x \\u2013 %m%n");
+        put(Log4JPropertyKeys.FILE_APPENDER, "org.apache.log4j.RollingFileAppender");
+        put(Log4JPropertyKeys.FILE_THRESHOLD, "INFO");
+        put(Log4JPropertyKeys.FILE_LAYOUT, "org.apache.log4j.PatternLayout");
+        put(Log4JPropertyKeys.FILE_LAYOUT_CONVERSION_PATTERN, "%d{ISO8601} [%t] %-5p %40C - %m%n");
+        put(Log4JPropertyKeys.PIPELINE_LOG_LEVEL, "INFO");
+        put(Log4JPropertyKeys.PARSER_LOG_LEVEL, "INFO");
+    }};
+
+    private static class Log4JPropertyKeys {
+        public static String ROOT_LOGGER = "log4j.rootLogger";
+        public static String CONSOLE_APPENDER = "log4j.appender.CONSOLE";
+        public static String CONSOLE_LAYOUT = "log4j.appender.CONSOLE.layout";
+        public static String CONSOLE_THRESHOLD = "log4j.appender.CONSOLE.Threshold";
+        public static String CONSOLE_CONVERSION_PATTERN = "log4j.appender.CONSOLE.layout.ConversionPattern";
+        public static String FILE_APPENDER = "log4j.appender.file";
+        public static String FILE = "log4j.appender.file.File";
+        public static String FILE_MAX_SIZE = "log4j.appender.file.MaxFileSize";
+        public static String FILE_MAX_BACKUP_INDEX = "log4j.appender.file.MaxBackupIndex";
+        public static String FILE_THRESHOLD = "log4j.appender.file.Threshold";
+        public static String FILE_LAYOUT = "log4j.appender.file.layout";
+        public static String FILE_LAYOUT_CONVERSION_PATTERN = "log4j.appender.file.layout.ConversionPattern";
+        public static String PIPELINE_LOG_LEVEL = "log4j.logger.com.amazon.dataprepper.pipeline";
+        public static String PARSER_LOG_LEVEL = "log4j.logger.com.amazon.dataprepper.parser";
+    }
+
+}

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/Log4JConfiguration.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/Log4JConfiguration.java
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.log4j.Level;
 
+/**
+ * Class to hold Log4J properties
+ */
 public class Log4JConfiguration {
     private Level level = Level.ERROR;
     private String filePath = "logs/Data-Prepper.log";
@@ -73,6 +76,11 @@ public class Log4JConfiguration {
         return maxBackupIndex;
     }
 
+    /**
+     * Return this configuration as a Properties object, for ease of use with
+     * Log4j runtime API for setting properties
+     * @return
+     */
     public Properties getProperties() {
         Properties properties = new Properties();
         properties.putAll(PRESET_PROPERTIES);

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
@@ -18,7 +18,7 @@ public class DataPrepperServer {
 
     public DataPrepperServer(final DataPrepper dataPrepper) {
         try {
-            this.port = dataPrepper.getConfiguration().getServerPort();
+            this.port = DataPrepper.getConfiguration().getServerPort();
             server = HttpServer.create(
                     new InetSocketAddress(this.port),
                     0

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
@@ -16,16 +16,17 @@ public class DataPrepperServer {
     private final HttpServer server;
     private final int port;
 
-    public DataPrepperServer(final int port, final DataPrepper dataPrepper) {
+    public DataPrepperServer(final DataPrepper dataPrepper) {
         try {
+            this.port = dataPrepper.getConfiguration().getServerPort();
             server = HttpServer.create(
-                    new InetSocketAddress(port),
+                    new InetSocketAddress(this.port),
                     0
             );
             server.createContext("/metrics/prometheus", new PrometheusMetricsHandler());
             server.createContext("/list", new ListPipelinesHandler(dataPrepper));
             server.createContext("/shutdown", new ShutdownHandler(dataPrepper));
-            this.port = port;
+
         } catch (IOException e) {
             throw new RuntimeException("Failed to create server", e);
         }

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/DataPrepperTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/DataPrepperTests.java
@@ -40,13 +40,6 @@ public class DataPrepperTests {
     }
 
     @Test
-    public void testDefaultConfiguration() {
-        DataPrepper testInstance = DataPrepper.getInstance();
-        assertThat("Data prepper should have default config if no config is passed in",
-                DataPrepper.getConfiguration(), is(DataPrepperConfiguration.DEFAULT_CONFIG));
-    }
-
-    @Test
     public void testCustomConfiguration() {
         DataPrepper.configure(TestDataProvider.VALID_DATA_PREPPER_CONFIG_FILE);
         DataPrepper testInstance = DataPrepper.getInstance();

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/DataPrepperTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/DataPrepperTests.java
@@ -1,6 +1,9 @@
 package com.amazon.dataprepper;
 
+import com.amazon.dataprepper.parser.model.DataPrepperConfiguration;
+import org.apache.log4j.Level;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,6 +37,24 @@ public class DataPrepperTests {
         assertThat("Failed to retrieve a valid Data Prepper instance", testDataPrepper1, is(notNullValue()));
         DataPrepper testDataPrepper2 = DataPrepper.getInstance();
         assertThat("Data Prepper has to be singleton", testDataPrepper2, is(testDataPrepper1));
+    }
+
+    @Test
+    public void testDefaultConfiguration() {
+        DataPrepper testInstance = DataPrepper.getInstance();
+        assertThat("Data prepper should have default config if no config is passed in",
+                testInstance.getConfiguration(), is(DataPrepperConfiguration.DEFAULT_CONFIG));
+    }
+
+    @Test
+    public void testCustomConfiguration() {
+        DataPrepper.configure(TestDataProvider.VALID_DATA_PREPPER_CONFIG_FILE);
+        DataPrepper testInstance = DataPrepper.getInstance();
+        Assert.assertEquals(1234, testInstance.getConfiguration().getServerPort());
+        Assert.assertEquals(Level.DEBUG, testInstance.getConfiguration().getLog4JConfiguration().getLevel());
+        Assert.assertEquals("file.txt", testInstance.getConfiguration().getLog4JConfiguration().getFilePath());
+        Assert.assertEquals("1GB", testInstance.getConfiguration().getLog4JConfiguration().getMaxFileSize());
+        Assert.assertEquals("10", testInstance.getConfiguration().getLog4JConfiguration().getMaxBackupIndex());
     }
 
     @Test

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/DataPrepperTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/DataPrepperTests.java
@@ -43,18 +43,18 @@ public class DataPrepperTests {
     public void testDefaultConfiguration() {
         DataPrepper testInstance = DataPrepper.getInstance();
         assertThat("Data prepper should have default config if no config is passed in",
-                testInstance.getConfiguration(), is(DataPrepperConfiguration.DEFAULT_CONFIG));
+                DataPrepper.getConfiguration(), is(DataPrepperConfiguration.DEFAULT_CONFIG));
     }
 
     @Test
     public void testCustomConfiguration() {
         DataPrepper.configure(TestDataProvider.VALID_DATA_PREPPER_CONFIG_FILE);
         DataPrepper testInstance = DataPrepper.getInstance();
-        Assert.assertEquals(1234, testInstance.getConfiguration().getServerPort());
-        Assert.assertEquals(Level.DEBUG, testInstance.getConfiguration().getLog4JConfiguration().getLevel());
-        Assert.assertEquals("file.txt", testInstance.getConfiguration().getLog4JConfiguration().getFilePath());
-        Assert.assertEquals("1GB", testInstance.getConfiguration().getLog4JConfiguration().getMaxFileSize());
-        Assert.assertEquals("10", testInstance.getConfiguration().getLog4JConfiguration().getMaxBackupIndex());
+        Assert.assertEquals(1234, DataPrepper.getConfiguration().getServerPort());
+        Assert.assertEquals(Level.DEBUG, DataPrepper.getConfiguration().getLog4JConfiguration().getLevel());
+        Assert.assertEquals("file.txt", DataPrepper.getConfiguration().getLog4JConfiguration().getFilePath());
+        Assert.assertEquals("1GB", DataPrepper.getConfiguration().getLog4JConfiguration().getMaxFileSize());
+        Assert.assertEquals("10", DataPrepper.getConfiguration().getLog4JConfiguration().getMaxBackupIndex());
     }
 
     @Test

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/TestDataProvider.java
@@ -40,6 +40,9 @@ public class TestDataProvider {
     public static final String VALID_DATA_PREPPER_DEFAULT_LOG4J_CONFIG_FILE = "src/test/resources/valid_data_prepper_config_default_log4j.yml";
     public static final String VALID_DATA_PREPPER_SOME_DEFAULT_CONFIG_FILE = "src/test/resources/valid_data_prepper_some_default_config.yml";
     public static final String INVALID_DATA_PREPPER_CONFIG_FILE = "src/test/resources/invalid_data_prepper_config.yml";
+    public static final String INVALID_PORT_DATA_PREPPER_CONFIG_FILE = "src/test/resources/invalid_port_data_prepper_config.yml";
+
+
 
 
     public static Set<String> VALID_MULTIPLE_PIPELINE_NAMES = new HashSet<>(Arrays.asList("test-pipeline-1",

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/TestDataProvider.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/TestDataProvider.java
@@ -36,6 +36,11 @@ public class TestDataProvider {
     public static final String VALID_MULTIPLE_SINKS_CONFIG_FILE = "src/test/resources/valid_multiple_sinks.yml";
     public static final String VALID_MULTIPLE_PROCESSORS_CONFIG_FILE = "src/test/resources/valid_multiple_sinks.yml";
     public static final String NO_PIPELINES_EXECUTE_CONFIG_FILE = "src/test/resources/no_pipelines_to_execute.yml";
+    public static final String VALID_DATA_PREPPER_CONFIG_FILE = "src/test/resources/valid_data_prepper_config.yml";
+    public static final String VALID_DATA_PREPPER_DEFAULT_LOG4J_CONFIG_FILE = "src/test/resources/valid_data_prepper_config_default_log4j.yml";
+    public static final String VALID_DATA_PREPPER_SOME_DEFAULT_CONFIG_FILE = "src/test/resources/valid_data_prepper_some_default_config.yml";
+    public static final String INVALID_DATA_PREPPER_CONFIG_FILE = "src/test/resources/invalid_data_prepper_config.yml";
+
 
     public static Set<String> VALID_MULTIPLE_PIPELINE_NAMES = new HashSet<>(Arrays.asList("test-pipeline-1",
             "test-pipeline-2", "test-pipeline-3"));

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/model/DataPrepperConfigurationTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/model/DataPrepperConfigurationTests.java
@@ -1,0 +1,52 @@
+package com.amazon.dataprepper.parser.model;
+
+import java.io.File;
+import org.apache.log4j.Level;
+import org.junit.Assert;
+import org.junit.Test;
+import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_CONFIG_FILE;
+import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_DEFAULT_LOG4J_CONFIG_FILE;
+import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_SOME_DEFAULT_CONFIG_FILE;
+import static com.amazon.dataprepper.TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE;
+
+public class DataPrepperConfigurationTests {
+
+    @Test
+    public void testParseConfig() {
+        final DataPrepperConfiguration dataPrepperConfiguration =
+                DataPrepperConfiguration.fromFile(new File(VALID_DATA_PREPPER_CONFIG_FILE));
+        Assert.assertEquals(1234, dataPrepperConfiguration.getServerPort());
+        Assert.assertEquals(Level.DEBUG, dataPrepperConfiguration.getLog4JConfiguration().getLevel());
+        Assert.assertEquals("file.txt", dataPrepperConfiguration.getLog4JConfiguration().getFilePath());
+        Assert.assertEquals("1GB", dataPrepperConfiguration.getLog4JConfiguration().getMaxFileSize());
+        Assert.assertEquals("10", dataPrepperConfiguration.getLog4JConfiguration().getMaxBackupIndex());
+    }
+
+    @Test
+    public void testDefaultLog4jConfig() {
+        final DataPrepperConfiguration dataPrepperConfiguration =
+                DataPrepperConfiguration.fromFile(new File(VALID_DATA_PREPPER_DEFAULT_LOG4J_CONFIG_FILE));
+        Assert.assertEquals(1234, dataPrepperConfiguration.getServerPort());
+        Assert.assertEquals(Log4JConfiguration.DEFAULT_CONFIG.getLevel(), dataPrepperConfiguration.getLog4JConfiguration().getLevel());
+        Assert.assertEquals(Log4JConfiguration.DEFAULT_CONFIG.getFilePath(), dataPrepperConfiguration.getLog4JConfiguration().getFilePath());
+        Assert.assertEquals(Log4JConfiguration.DEFAULT_CONFIG.getMaxFileSize(), dataPrepperConfiguration.getLog4JConfiguration().getMaxFileSize());
+        Assert.assertEquals(Log4JConfiguration.DEFAULT_CONFIG.getMaxBackupIndex(), dataPrepperConfiguration.getLog4JConfiguration().getMaxBackupIndex());
+    }
+
+    @Test
+    public void testSomeDefaultConfig() {
+        final DataPrepperConfiguration dataPrepperConfiguration =
+                DataPrepperConfiguration.fromFile(new File(VALID_DATA_PREPPER_SOME_DEFAULT_CONFIG_FILE));
+        Assert.assertEquals(DataPrepperConfiguration.DEFAULT_CONFIG.getServerPort(), dataPrepperConfiguration.getServerPort());
+        Assert.assertEquals(Log4JConfiguration.DEFAULT_CONFIG.getLevel(), dataPrepperConfiguration.getLog4JConfiguration().getLevel());
+        Assert.assertEquals("file.txt", dataPrepperConfiguration.getLog4JConfiguration().getFilePath());
+        Assert.assertEquals(Log4JConfiguration.DEFAULT_CONFIG.getMaxFileSize(), dataPrepperConfiguration.getLog4JConfiguration().getMaxFileSize());
+        Assert.assertEquals(Log4JConfiguration.DEFAULT_CONFIG.getMaxBackupIndex(), dataPrepperConfiguration.getLog4JConfiguration().getMaxBackupIndex());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidConfig() {
+            final DataPrepperConfiguration dataPrepperConfiguration =
+                    DataPrepperConfiguration.fromFile(new File(INVALID_DATA_PREPPER_CONFIG_FILE));
+    }
+}

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/model/DataPrepperConfigurationTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/model/DataPrepperConfigurationTests.java
@@ -8,6 +8,7 @@ import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_CONFIG_
 import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_DEFAULT_LOG4J_CONFIG_FILE;
 import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_SOME_DEFAULT_CONFIG_FILE;
 import static com.amazon.dataprepper.TestDataProvider.INVALID_DATA_PREPPER_CONFIG_FILE;
+import static com.amazon.dataprepper.TestDataProvider.INVALID_PORT_DATA_PREPPER_CONFIG_FILE;
 
 public class DataPrepperConfigurationTests {
 
@@ -48,5 +49,11 @@ public class DataPrepperConfigurationTests {
     public void testInvalidConfig() {
             final DataPrepperConfiguration dataPrepperConfiguration =
                     DataPrepperConfiguration.fromFile(new File(INVALID_DATA_PREPPER_CONFIG_FILE));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidPortConfig() {
+        final DataPrepperConfiguration dataPrepperConfiguration =
+                DataPrepperConfiguration.fromFile(new File(INVALID_PORT_DATA_PREPPER_CONFIG_FILE));
     }
 }

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/model/Log4JConfigurationTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/model/Log4JConfigurationTests.java
@@ -1,0 +1,51 @@
+package com.amazon.dataprepper.parser.model;
+
+import java.util.Properties;
+import java.util.UUID;
+import org.apache.log4j.Level;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Log4JConfigurationTests {
+
+    @Test
+    public void testLog4J() {
+        final Level level = Level.INFO;
+        final String filePath = UUID.randomUUID().toString();
+        final String maxFileSize = UUID.randomUUID().toString();
+        final String maxBackup = UUID.randomUUID().toString();
+
+        final Log4JConfiguration log4JConfiguration = new Log4JConfiguration(
+                level.toString(),
+                filePath,
+                maxFileSize,
+                maxBackup
+        );
+
+        Assert.assertEquals(level, log4JConfiguration.getLevel());
+        Assert.assertEquals(filePath, log4JConfiguration.getFilePath());
+        Assert.assertEquals(maxFileSize, log4JConfiguration.getMaxFileSize());
+        Assert.assertEquals(maxBackup, log4JConfiguration.getMaxBackupIndex());
+    }
+
+    @Test
+    public void testProperties() {
+        final Log4JConfiguration log4JConfiguration = new Log4JConfiguration(null, null, null, null);
+        final Properties properties = log4JConfiguration.getProperties();
+        Assert.assertEquals("ERROR, CONSOLE", properties.getProperty("log4j.rootLogger"));
+        Assert.assertEquals("org.apache.log4j.ConsoleAppender", properties.getProperty("log4j.appender.CONSOLE"));
+        Assert.assertEquals("org.apache.log4j.PatternLayout", properties.getProperty("log4j.appender.CONSOLE.layout"));
+        Assert.assertEquals("INFO", properties.getProperty("log4j.appender.CONSOLE.Threshold"));
+        Assert.assertEquals("%-4r [%t] %-5p %c %x \\u2013 %m%n", properties.getProperty("log4j.appender.CONSOLE.layout.ConversionPattern"));
+        Assert.assertEquals("org.apache.log4j.RollingFileAppender", properties.getProperty("log4j.appender.file"));
+        Assert.assertEquals("logs/Data-Prepper.log", properties.getProperty("log4j.appender.file.File"));
+        Assert.assertEquals("10MB", properties.getProperty("log4j.appender.file.MaxFileSize"));
+        Assert.assertEquals("5", properties.getProperty("log4j.appender.file.MaxBackupIndex"));
+        Assert.assertEquals("INFO", properties.getProperty("log4j.appender.file.Threshold"));
+        Assert.assertEquals("org.apache.log4j.PatternLayout", properties.getProperty("log4j.appender.file.layout"));
+        Assert.assertEquals("%d{ISO8601} [%t] %-5p %40C - %m%n", properties.getProperty("log4j.appender.file.layout.ConversionPattern"));
+        Assert.assertEquals("INFO", properties.getProperty("log4j.logger.com.amazon.dataprepper.pipeline"));
+        Assert.assertEquals("INFO", properties.getProperty("log4j.logger.com.amazon.dataprepper.parser"));
+    }
+
+}

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/server/DataPrepperServerTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/server/DataPrepperServerTest.java
@@ -1,8 +1,7 @@
 package com.amazon.dataprepper.server;
 
 import com.amazon.dataprepper.DataPrepper;
-import com.amazon.dataprepper.parser.model.DataPrepperConfiguration;
-import com.amazon.dataprepper.pipeline.Pipeline;
+import com.amazon.dataprepper.TestDataProvider;
 import com.amazon.dataprepper.pipeline.server.DataPrepperServer;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -29,7 +28,7 @@ public class DataPrepperServerTest {
     private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private DataPrepperServer dataPrepperServer;
     private DataPrepper dataPrepper;
-    private final int port = 8080;
+    private final int port = 1234;
 
     private void setRegistry(PrometheusMeterRegistry prometheusMeterRegistry) {
         Metrics.globalRegistry.getRegistries().iterator().forEachRemaining(meterRegistry -> Metrics.globalRegistry.remove(meterRegistry));
@@ -38,7 +37,7 @@ public class DataPrepperServerTest {
 
     private void setupDataPrepper() {
         dataPrepper = Mockito.mock(DataPrepper.class);
-        Mockito.when(dataPrepper.getConfiguration()).thenReturn(new DataPrepperConfiguration(port, null));
+        DataPrepper.configure(TestDataProvider.VALID_DATA_PREPPER_DEFAULT_LOG4J_CONFIG_FILE);
     }
 
     @Before
@@ -87,7 +86,7 @@ public class DataPrepperServerTest {
         setupDataPrepper();
         final String pipelineName = "testPipeline";
         Mockito.when(dataPrepper.getTransformationPipelines()).thenReturn(
-                Collections.singletonMap(pipelineName, Mockito.mock(Pipeline.class))
+                Collections.singletonMap("testPipeline", null)
         );
         dataPrepperServer = new DataPrepperServer(dataPrepper);
         dataPrepperServer.start();

--- a/data-prepper-core/src/test/resources/invalid_data_prepper_config.yml
+++ b/data-prepper-core/src/test/resources/invalid_data_prepper_config.yml
@@ -1,0 +1,1 @@
+badKey: badValue

--- a/data-prepper-core/src/test/resources/invalid_port_data_prepper_config.yml
+++ b/data-prepper-core/src/test/resources/invalid_port_data_prepper_config.yml
@@ -1,0 +1,6 @@
+serverPort: -550
+log4jConfig:
+  logLevel: "DEBUG"
+  filePath: "file.txt"
+  maxFileSize: "1GB"
+  maxBackupIndex: "10"

--- a/data-prepper-core/src/test/resources/valid_data_prepper_config.yml
+++ b/data-prepper-core/src/test/resources/valid_data_prepper_config.yml
@@ -1,0 +1,6 @@
+serverPort: 1234
+log4jConfig:
+  logLevel: "DEBUG"
+  filePath: "file.txt"
+  maxFileSize: "1GB"
+  maxBackupIndex: "10"

--- a/data-prepper-core/src/test/resources/valid_data_prepper_config_default_log4j.yml
+++ b/data-prepper-core/src/test/resources/valid_data_prepper_config_default_log4j.yml
@@ -1,0 +1,1 @@
+serverPort: 1234

--- a/data-prepper-core/src/test/resources/valid_data_prepper_some_default_config.yml
+++ b/data-prepper-core/src/test/resources/valid_data_prepper_some_default_config.yml
@@ -1,0 +1,2 @@
+log4jConfig:
+  filePath: "file.txt"

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/source/RandomStringSource.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/source/RandomStringSource.java
@@ -1,0 +1,71 @@
+package com.amazon.dataprepper.plugins.source;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.amazon.dataprepper.model.PluginType;
+import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
+import com.amazon.dataprepper.model.buffer.Buffer;
+import com.amazon.dataprepper.model.configuration.PluginSetting;
+import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.model.source.Source;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Generates a random string every 500 milliseconds. Intended to be used for testing setups
+ */
+@DataPrepperPlugin(name = "random", type = PluginType.SOURCE)
+public class RandomStringSource implements Source<Record<String>> {
+
+    private static Logger LOG = LoggerFactory.getLogger(RandomStringSource.class);
+
+    private ExecutorService executorService;
+    private boolean stop = false;
+
+    public RandomStringSource(final PluginSetting pluginSetting) {
+
+    }
+
+    private void setExecutorService() {
+        if(executorService == null || executorService.isShutdown()) {
+            executorService = Executors.newSingleThreadExecutor(
+                    new ThreadFactoryBuilder().setDaemon(false).setNameFormat("random-source-pool-%d").build()
+            );
+        }
+    }
+
+    @Override
+    public void start(Buffer<Record<String>> buffer) {
+        setExecutorService();
+        executorService.execute(() -> {
+            while (!stop) {
+                try {
+                    LOG.info("Writing to buffer");
+                    buffer.write(new Record<>(UUID.randomUUID().toString()), 500);
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    break;
+                } catch (TimeoutException e) {
+                    // Do nothing
+                }
+            }
+        });
+    }
+
+    @Override
+    public void stop() {
+        stop = true;
+        executorService.shutdown();
+        try {
+            if (!executorService.awaitTermination(500, TimeUnit.MILLISECONDS)) {
+                executorService.shutdownNow();
+            }
+        } catch (InterruptedException ex) {
+            executorService.shutdownNow();
+        }
+    }
+}

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/source/RandomStringSourceTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/source/RandomStringSourceTests.java
@@ -1,0 +1,33 @@
+package com.amazon.dataprepper.plugins.source;
+
+import com.amazon.dataprepper.model.configuration.PluginSetting;
+import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.plugins.buffer.TestBuffer;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Queue;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RandomStringSourceTests {
+
+    @Test
+    public void testPutRecord() throws InterruptedException {
+        final RandomStringSource randomStringSource =
+                new RandomStringSource(new PluginSetting("random", Collections.emptyMap()));
+        final Queue<Record<String>> bufferQueue = new LinkedList<>();
+        final TestBuffer buffer = new TestBuffer(bufferQueue, 1);
+        //Start source, and sleep for 100 millis
+        randomStringSource.start(buffer);
+        Thread.sleep(100);
+        //Make sure that 1 record is in buffer
+        Assert.assertEquals(1, buffer.size());
+        //Stop the source, and wait long enough that another message would be sent
+        //if the source was running
+        randomStringSource.stop();
+        Thread.sleep(500);
+        //Make sure there is still only 1 record in buffer
+        Assert.assertEquals(1, buffer.size());
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/data-prepper/issues/202

*Description of changes:*
- Supporting DataPrepperConfiguration for server port and Log4j properties
- Adding RandomStringSource for easier local testing 

Note: The cleanest way of setting Log4j properties at runtime is to reconfigure Log4j with a complete set of Properties. Overriding a single property is not easily supported (it is possible with log level, but not log file). Because of this, I had to add the whole set of properties that we want to set and not change to the Log4JConfiguration class

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
