### PR TITLE
ENH: custom metrics in ElasticsearchSink

### DIFF
--- a/data-prepper-plugins/elasticsearch/build.gradle
+++ b/data-prepper-plugins/elasticsearch/build.gradle
@@ -29,11 +29,13 @@ ext {
 
 dependencies {
     compile project(':data-prepper-api')
+    testCompile project(':data-prepper-api').sourceSets.test.output
     compile project(':data-prepper-plugins:common')
     implementation "org.elasticsearch.client:elasticsearch-rest-high-level-client:${es_version}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versionMap.jackson_dataformat_yaml}"
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
+    implementation "io.micrometer:micrometer-core:1.5.1"
     testImplementation("junit:junit:${versionMap.junit}") {
         exclude group:'org.hamcrest' // workaround for jarHell
     }

--- a/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/BulkRetryStrategy.java
@@ -120,6 +120,8 @@ public final class BulkRetryStrategy {
                         logFailure.accept(request.requests().get(index), bulkItemResponse.getFailure().getCause());
                         documentErrorsCounter.increment();
                     }
+                } else {
+                    sentDocumentsCounter.increment();
                 }
                 index++;
             }

--- a/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/BulkRetryStrategy.java
+++ b/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/BulkRetryStrategy.java
@@ -1,5 +1,6 @@
 package com.amazon.dataprepper.plugins.sink.elasticsearch;
 
+import com.amazon.dataprepper.metrics.PluginMetrics;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BackoffPolicy;
@@ -27,13 +28,16 @@ public final class BulkRetryStrategy {
 
     private final RequestFunction<BulkRequest, BulkResponse> requestFunction;
     private final BiConsumer<DocWriteRequest<?>, Throwable> logFailure;
+    private final PluginMetrics pluginMetrics;
     private final Supplier<BulkRequest> bulkRequestSupplier;
 
     public BulkRetryStrategy(final RequestFunction<BulkRequest, BulkResponse> requestFunction,
                              final BiConsumer<DocWriteRequest<?>, Throwable> logFailure,
+                             final PluginMetrics pluginMetrics,
                              final Supplier<BulkRequest> bulkRequestSupplier) {
         this.requestFunction = requestFunction;
         this.logFailure = logFailure;
+        this.pluginMetrics = pluginMetrics;
         this.bulkRequestSupplier = bulkRequestSupplier;
     }
 

--- a/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSink.java
+++ b/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSink.java
@@ -133,13 +133,15 @@ public class ElasticsearchSink extends AbstractSink<Record<String>> {
   }
 
   private void flushBatch(final BulkRequest bulkRequest) {
-    try {
-      bulkRetryStrategy.execute(bulkRequest);
-    } catch (final InterruptedException e) {
-      LOG.error("Unexpected Interrupt:", e);
-      bulkRequestErrorsCounter.increment();
-      Thread.currentThread().interrupt();
-    }
+    bulkRequestTimer.record(() -> {
+      try {
+        bulkRetryStrategy.execute(bulkRequest);
+      } catch (final InterruptedException e) {
+        LOG.error("Unexpected Interrupt:", e);
+        bulkRequestErrorsCounter.increment();
+        Thread.currentThread().interrupt();
+      }
+    });
   }
 
   private void createIndexTemplate(final String ismPolicyId) throws IOException {

--- a/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/BulkRetryStrategyTests.java
+++ b/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/BulkRetryStrategyTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -34,6 +35,11 @@ public class BulkRetryStrategyTests {
         setPipelineName(PIPELINE_NAME);
     }};
     private static final PluginMetrics PLUGIN_METRICS = PluginMetrics.fromPluginSetting(PLUGIN_SETTING);
+
+    @Before
+    public void metricsInit() {
+        MetricsTestUtil.initMetrics();
+    }
 
     @Test
     public void testCanRetry() {
@@ -64,7 +70,6 @@ public class BulkRetryStrategyTests {
         final FakeClient client = new FakeClient(testIndex);
         final FakeLogger logger = new FakeLogger();
 
-        MetricsTestUtil.initMetrics();
         final BulkRetryStrategy bulkRetryStrategy = new BulkRetryStrategy(
                 client::bulk, logger::logFailure, PLUGIN_METRICS, BulkRequest::new);
         final BulkRequest testBulkRequest = new BulkRequest();
@@ -104,7 +109,6 @@ public class BulkRetryStrategyTests {
         client.retryable = false;
         final FakeLogger logger = new FakeLogger();
 
-        MetricsTestUtil.initMetrics();
         final BulkRetryStrategy bulkRetryStrategy = new BulkRetryStrategy(
                 client::bulk, logger::logFailure, PLUGIN_METRICS, BulkRequest::new);
         final BulkRequest testBulkRequest = new BulkRequest();

--- a/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
+++ b/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 
 import javax.ws.rs.HttpMethod;
 import java.io.BufferedReader;
@@ -63,6 +64,11 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
   private static final String DEFAULT_RAW_SPAN_FILE_1 = "raw-span-1.json";
   private static final String DEFAULT_RAW_SPAN_FILE_2 = "raw-span-2.json";
   private static final String DEFAULT_SERVICE_MAP_FILE = "service-map-1.json";
+
+  @Before
+  public void metricsInit() {
+    MetricsTestUtil.initMetrics();
+  }
 
   public void testInstantiateSinkRawSpanDefault() throws IOException {
     final PluginSetting pluginSetting = generatePluginSetting(true, false, null, null);
@@ -112,7 +118,6 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
 
     final List<Record<String>> testRecords = Arrays.asList(new Record<>(testDoc1), new Record<>(testDoc2));
     final PluginSetting pluginSetting = generatePluginSetting(true, false, null, null);
-    MetricsTestUtil.initMetrics();
     final ElasticsearchSink sink = new ElasticsearchSink(pluginSetting);
     sink.output(testRecords);
 
@@ -165,7 +170,6 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
     final String expDLQFile = tempDirectory.getAbsolutePath() + "/test-dlq.txt";
     pluginSetting.getSettings().put(RetryConfiguration.DLQ_FILE, expDLQFile);
 
-    MetricsTestUtil.initMetrics();
     final ElasticsearchSink sink = new ElasticsearchSink(pluginSetting);
     sink.output(testRecords);
     sink.shutdown();
@@ -220,7 +224,6 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
 
     final List<Record<String>> testRecords = Collections.singletonList(new Record<>(testDoc));
     final PluginSetting pluginSetting = generatePluginSetting(false, true, null, null);
-    MetricsTestUtil.initMetrics();
     ElasticsearchSink sink = new ElasticsearchSink(pluginSetting);
     sink.output(testRecords);
     final String expIndexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(IndexConstants.SERVICE_MAP);
@@ -268,7 +271,6 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
     final List<Record<String>> testRecords = Collections.singletonList(generateCustomRecord(testIdField, testId));
     final PluginSetting pluginSetting = generatePluginSetting(false, false, testIndexAlias, testTemplateFile);
     pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
-    MetricsTestUtil.initMetrics();
     final ElasticsearchSink sink = new ElasticsearchSink(pluginSetting);
     sink.output(testRecords);
     final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);

--- a/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
+++ b/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
@@ -149,6 +149,11 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
                     .add(BulkRetryStrategy.DOCUMENTS_SUCCESS).toString());
     assertEquals(1, documentsSuccessMeasurements.size());
     assertEquals(2.0, documentsSuccessMeasurements.get(0).getValue(), 0);
+    final List<Measurement> documentsSuccessFirstAttemptMeasurements = MetricsTestUtil.getMeasurementList(
+            new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                    .add(BulkRetryStrategy.DOCUMENTS_SUCCESS_FIRST_ATTEMPT).toString());
+    assertEquals(1, documentsSuccessFirstAttemptMeasurements.size());
+    assertEquals(2.0, documentsSuccessFirstAttemptMeasurements.get(0).getValue(), 0);
     final List<Measurement> documentErrorsMeasurements = MetricsTestUtil.getMeasurementList(
             new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
                     .add(BulkRetryStrategy.DOCUMENT_ERRORS).toString());

--- a/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
+++ b/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
@@ -1,8 +1,11 @@
 package com.amazon.dataprepper.plugins.sink.elasticsearch;
 
+import com.amazon.dataprepper.metrics.MetricNames;
+import com.amazon.dataprepper.metrics.MetricsTestUtil;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.Measurement;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
@@ -29,6 +32,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.After;
+import org.junit.Assert;
 
 import javax.ws.rs.HttpMethod;
 import java.io.BufferedReader;
@@ -45,11 +49,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import static org.apache.http.HttpStatus.SC_OK;
 
 public class ElasticsearchSinkIT extends ESRestTestCase {
+  private static final String PLUGIN_NAME = "elasticsearch";
+  private static final String PIPELINE_NAME = "integTestPipeline";
   public List<String> HOSTS = Arrays.stream(System.getProperty("tests.rest.cluster").split(","))
       .map(ip -> String.format("%s://%s", getProtocol(), ip)).collect(Collectors.toList());
   private static final String DEFAULT_TEMPLATE_FILE = "test-index-template.json";
@@ -105,6 +112,7 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
 
     final List<Record<String>> testRecords = Arrays.asList(new Record<>(testDoc1), new Record<>(testDoc2));
     final PluginSetting pluginSetting = generatePluginSetting(true, false, null, null);
+    MetricsTestUtil.initMetrics();
     final ElasticsearchSink sink = new ElasticsearchSink(pluginSetting);
     sink.output(testRecords);
 
@@ -114,6 +122,33 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
     assertTrue(retSources.containsAll(Arrays.asList(expData1, expData2)));
     assertEquals(Integer.valueOf(1), getDocumentCount(expIndexAlias, "_id", (String)expData1.get("spanId")));
     sink.shutdown();
+
+    // Verify metrics
+    final List<Measurement> bulkRequestErrors = MetricsTestUtil.getMeasurementList(
+            new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                    .add(ElasticsearchSink.BULKREQUEST_ERRORS).toString());
+    assertEquals(1, bulkRequestErrors.size());
+    Assert.assertEquals(0.0, bulkRequestErrors.get(0).getValue(), 0);
+    final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
+            new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                    .add(ElasticsearchSink.BULKREQUEST_LATENCY).toString());
+    assertEquals(3, bulkRequestLatencies.size());
+    // COUNT
+    Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
+    // TOTAL_TIME
+    Assert.assertTrue(bulkRequestLatencies.get(1).getValue() > 0.0);
+    // MAX
+    Assert.assertTrue(bulkRequestLatencies.get(2).getValue() > 0.0);
+    final List<Measurement> documentsSuccessMeasurements = MetricsTestUtil.getMeasurementList(
+            new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                    .add(BulkRetryStrategy.DOCUMENTS_SUCCESS).toString());
+    assertEquals(1, documentsSuccessMeasurements.size());
+    assertEquals(2.0, documentsSuccessMeasurements.get(0).getValue(), 0);
+    final List<Measurement> documentErrorsMeasurements = MetricsTestUtil.getMeasurementList(
+            new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                    .add(BulkRetryStrategy.DOCUMENT_ERRORS).toString());
+    assertEquals(1, documentErrorsMeasurements.size());
+    assertEquals(0.0, documentErrorsMeasurements.get(0).getValue(), 0);
   }
 
   public void testOutputRawSpanWithDLQ() throws IOException, InterruptedException {
@@ -130,6 +165,7 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
     final String expDLQFile = tempDirectory.getAbsolutePath() + "/test-dlq.txt";
     pluginSetting.getSettings().put(RetryConfiguration.DLQ_FILE, expDLQFile);
 
+    MetricsTestUtil.initMetrics();
     final ElasticsearchSink sink = new ElasticsearchSink(pluginSetting);
     sink.output(testRecords);
     sink.shutdown();
@@ -144,6 +180,18 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
 
     // clean up temporary directory
     FileUtils.deleteQuietly(tempDirectory);
+
+    // verify metrics
+    final List<Measurement> documentsSuccessMeasurements = MetricsTestUtil.getMeasurementList(
+            new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                    .add(BulkRetryStrategy.DOCUMENTS_SUCCESS).toString());
+    assertEquals(1, documentsSuccessMeasurements.size());
+    assertEquals(1.0, documentsSuccessMeasurements.get(0).getValue(), 0);
+    final List<Measurement> documentErrorsMeasurements = MetricsTestUtil.getMeasurementList(
+            new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                    .add(BulkRetryStrategy.DOCUMENT_ERRORS).toString());
+    assertEquals(1, documentErrorsMeasurements.size());
+    assertEquals(1.0, documentErrorsMeasurements.get(0).getValue(), 0);
   }
 
   public void testInstantiateSinkServiceMapDefault() throws IOException {
@@ -172,6 +220,7 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
 
     final List<Record<String>> testRecords = Collections.singletonList(new Record<>(testDoc));
     final PluginSetting pluginSetting = generatePluginSetting(false, true, null, null);
+    MetricsTestUtil.initMetrics();
     ElasticsearchSink sink = new ElasticsearchSink(pluginSetting);
     sink.output(testRecords);
     final String expIndexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(IndexConstants.SERVICE_MAP);
@@ -180,6 +229,14 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
     assertEquals(expData, retSources.get(0));
     assertEquals(Integer.valueOf(1), getDocumentCount(expIndexAlias, "_id", (String)expData.get("hashId")));
     sink.shutdown();
+
+    // verify metrics
+    final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
+            new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                    .add(ElasticsearchSink.BULKREQUEST_LATENCY).toString());
+    assertEquals(3, bulkRequestLatencies.size());
+    // COUNT
+    Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
 
     // Check restart for index already exists
     sink = new ElasticsearchSink(pluginSetting);
@@ -211,12 +268,21 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
     final List<Record<String>> testRecords = Collections.singletonList(generateCustomRecord(testIdField, testId));
     final PluginSetting pluginSetting = generatePluginSetting(false, false, testIndexAlias, testTemplateFile);
     pluginSetting.getSettings().put(IndexConfiguration.DOCUMENT_ID_FIELD, testIdField);
+    MetricsTestUtil.initMetrics();
     final ElasticsearchSink sink = new ElasticsearchSink(pluginSetting);
     sink.output(testRecords);
     final List<Map<String, Object>> retSources = getSearchResponseDocSources(testIndexAlias);
     assertEquals(1, retSources.size());
     assertEquals(Integer.valueOf(1), getDocumentCount(testIndexAlias, "_id", testId));
     sink.shutdown();
+
+    // verify metrics
+    final List<Measurement> bulkRequestLatencies = MetricsTestUtil.getMeasurementList(
+            new StringJoiner(MetricNames.DELIMITER).add(PIPELINE_NAME).add(PLUGIN_NAME)
+                    .add(ElasticsearchSink.BULKREQUEST_LATENCY).toString());
+    assertEquals(3, bulkRequestLatencies.size());
+    // COUNT
+    Assert.assertEquals(1.0, bulkRequestLatencies.get(0).getValue(), 0);
   }
 
   private PluginSetting generatePluginSetting(final boolean isRaw, final boolean isServiceMap, final String indexAlias, final String templateFilePath) {
@@ -233,8 +299,8 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
       metadata.put(ConnectionConfiguration.PASSWORD, password);
     }
 
-    final PluginSetting pluginSetting = new PluginSetting("elasticsearch", metadata);
-    pluginSetting.setPipelineName("integTestPipeline");
+    final PluginSetting pluginSetting = new PluginSetting(PLUGIN_NAME, metadata);
+    pluginSetting.setPipelineName(PIPELINE_NAME);
     return pluginSetting;
   }
 


### PR DESCRIPTION
*Issue #, if available:*
#253 

*Description of changes:*
- Added meters to produce desired custom metrics as listed in #253 .
- Modified BulkRetryStrategyTests to cover metrics.
- Modified ElasticsearchSinkIT to cover metrics.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
