### PR TITLE
First pass of renaming 'processor' to 'prepper'.

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/PluginType.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/PluginType.java
@@ -1,14 +1,14 @@
 package com.amazon.dataprepper.model;
 
 import com.amazon.dataprepper.model.buffer.Buffer;
-import com.amazon.dataprepper.model.processor.Processor;
+import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.model.sink.Sink;
 import com.amazon.dataprepper.model.source.Source;
 
 public enum PluginType {
     SOURCE("source", Source.class),
     BUFFER("buffer", Buffer.class),
-    PROCESSOR("processor", Processor.class),
+    PROCESSOR("prepper", Prepper.class),
     SINK("sink", Sink.class);
 
     private final String pluginName;

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/annotations/DataPrepperPlugin.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/annotations/DataPrepperPlugin.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Target;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- * Annotates a Data Prepper Java plugin that includes Source, Sink, Buffer and Processor.
+ * Annotates a Data Prepper Java plugin that includes Source, Sink, Buffer and Prepper.
  * The value returned from {@link #name()} represents the name of the plugin and is used in the pipeline configuration
  * and the optional {@link #type()}
  *

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/Buffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/Buffer.java
@@ -6,7 +6,7 @@ import java.util.Collection;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Buffer queues the records between TI components and acts as a layer between source and processor/sink. Buffer can
+ * Buffer queues the records between TI components and acts as a layer between source and prepper/sink. Buffer can
  * be in-memory, disk based or other a standalone implementation.
  * <p>
  */

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PluginSetting.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PluginSetting.java
@@ -25,7 +25,7 @@ public class PluginSetting {
     /**
      * Returns the number of process workers the pipeline is using; This is only required for special plugin use-cases
      * where plugin implementation depends on the number of process workers. For example, Trace analytics service map
-     * processor plugin uses memory mapped databases and it requires to know the number of workers that operate on it
+     * prepper plugin uses memory mapped databases and it requires to know the number of workers that operate on it
      * concurrently.
      * @return Number of process workers
      */

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/AbstractPrepper.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/AbstractPrepper.java
@@ -1,4 +1,4 @@
-package com.amazon.dataprepper.model.processor;
+package com.amazon.dataprepper.model.prepper;
 
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.metrics.MetricNames;
@@ -9,11 +9,11 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 
 /**
- * Abstract implementation of the {@link com.amazon.dataprepper.model.processor.Processor} interface. This class implements an execute function which records
+ * Abstract implementation of the {@link Prepper} interface. This class implements an execute function which records
  * some basic metrics. Logic of the execute function is handled by extensions of this class in the doExecute function.
  */
 public abstract class AbstractPrepper<InputRecord extends Record<?>, OutputRecord extends Record<?>> implements
-    Processor<InputRecord, OutputRecord> {
+        Prepper<InputRecord, OutputRecord> {
 
     protected final PluginMetrics pluginMetrics;
     private final Counter recordsInCounter;
@@ -42,7 +42,7 @@ public abstract class AbstractPrepper<InputRecord extends Record<?>, OutputRecor
     }
 
     /**
-     * This function should implement the processing logic of the processor
+     * This function should implement the processing logic of the prepper
      * @param records Input records
      * @return Processed records
      */

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/Prepper.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/Prepper.java
@@ -1,17 +1,17 @@
-package com.amazon.dataprepper.model.processor;
+package com.amazon.dataprepper.model.prepper;
 
 import com.amazon.dataprepper.model.record.Record;
 
 import java.util.Collection;
 
 /**
- * Data Prepper Processor interface. These are intermediary processing units using which users can filter,
+ * Prepper interface. These are intermediary processing units using which users can filter,
  * transform and enrich the records into desired format before publishing to the sink.
  */
-public interface Processor<InputRecord extends Record<?>, OutputRecord extends Record<?>> {
+public interface Prepper<InputRecord extends Record<?>, OutputRecord extends Record<?>> {
 
     /**
-     * execute the processor logic which could potentially modify the incoming record. The level to which the record has
+     * execute the prepper logic which could potentially modify the incoming record. The level to which the record has
      * been modified depends on the implementation
      *
      * @param records Input records that will be modified/processed
@@ -20,7 +20,7 @@ public interface Processor<InputRecord extends Record<?>, OutputRecord extends R
     Collection<OutputRecord> execute(Collection<InputRecord> records);
 
     /**
-     * Prepare processor for shutdown, by cleaning up resources and threads.
+     * Prepare prepper for shutdown, by cleaning up resources and threads.
      */
     void shutdown();
 }

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/processor/state/ProcessorState.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/processor/state/ProcessorState.java
@@ -12,36 +12,36 @@ import java.util.function.BiFunction;
 public interface ProcessorState<K, V> {
 
     /**
-     * Puts a key value pair in the processor state
+     * Puts a key value pair in the prepper state
      * @param key Key to put in the state
      * @param value Value to map to the key
      */
     void put(K key, V value);
 
     /**
-     * Gets the value in the processor state for the given key
+     * Gets the value in the prepper state for the given key
      * @param key Key to look up value for
      * @return Value for key, if it exists. Otherwise null.
      */
     V get(K key);
 
     /**
-     * Gets all the data in the processor state
-     * @return All the data in the processor state in the form of a Map
+     * Gets all the data in the prepper state
+     * @return All the data in the prepper state in the form of a Map
      */
     Map<K, V> getAll();
 
     /**
-     * Iterate over the processor state with a bifunction
-     * @param fn BiFunction with which to iterate over the processor state
+     * Iterate over the prepper state with a bifunction
+     * @param fn BiFunction with which to iterate over the prepper state
      * @param <R> Type parameter for return value of BiFunction
      * @return Result of iteration as a list of objects of type R
      */
     public<R> List<R> iterate(BiFunction<K, V, R> fn);
 
     /**
-     * Iterate over a segment of the processor state with a bifunction
-     * @param fn BiFunction with which to iterate over the processor state
+     * Iterate over a segment of the prepper state with a bifunction
+     * @param fn BiFunction with which to iterate over the prepper state
      * @param segments total number of segments
      * @param index segment index
      * @param <R> Type parameter for return value of BiFunction
@@ -50,7 +50,7 @@ public interface ProcessorState<K, V> {
     public<R> List<R> iterate(BiFunction<K, V, R> fn, int segments, int index);
 
     /**
-     * @return Size of the processor state, in terms of number of elements stored.
+     * @return Size of the prepper state, in terms of number of elements stored.
      */
     public long size();
 

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/PluginTypeTests.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/PluginTypeTests.java
@@ -1,7 +1,7 @@
 package com.amazon.dataprepper.model;
 
 import com.amazon.dataprepper.model.buffer.Buffer;
-import com.amazon.dataprepper.model.processor.Processor;
+import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.model.sink.Sink;
 import com.amazon.dataprepper.model.source.Source;
 import org.junit.Test;
@@ -21,7 +21,7 @@ public class PluginTypeTests {
         checkPluginTypeValues(bufferPluginType, "buffer", Buffer.class);
 
         final PluginType processorPluginType = PluginType.PROCESSOR;
-        checkPluginTypeValues(processorPluginType, "processor", Processor.class);
+        checkPluginTypeValues(processorPluginType, "prepper", Prepper.class);
 
         final PluginType sinkPluginType = PluginType.SINK;
         checkPluginTypeValues(sinkPluginType, "sink", Sink.class);

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/prepper/AbstractPrepperTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/prepper/AbstractPrepperTest.java
@@ -1,4 +1,4 @@
-package com.amazon.dataprepper.model.processor;
+package com.amazon.dataprepper.model.prepper;
 
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.metrics.MetricNames;
@@ -25,7 +25,7 @@ public class AbstractPrepperTest {
 
         PluginSetting pluginSetting = new PluginSetting(processorName, Collections.emptyMap());
         pluginSetting.setPipelineName(pipelineName);
-        AbstractPrepper<Record<String>, Record<String>> processor = new ProcessorImpl(pluginSetting);
+        AbstractPrepper<Record<String>, Record<String>> processor = new PrepperImpl(pluginSetting);
 
         processor.execute(Arrays.asList(
                 new Record<>("Value1"),
@@ -52,8 +52,8 @@ public class AbstractPrepperTest {
                 0.2));
     }
 
-    public static class ProcessorImpl extends AbstractPrepper<Record<String>, Record<String>> {
-        public ProcessorImpl(PluginSetting pluginSetting) {
+    public static class PrepperImpl extends AbstractPrepper<Record<String>, Record<String>> {
+        public PrepperImpl(PluginSetting pluginSetting) {
             super(pluginSetting);
         }
 

--- a/data-prepper-benchmarks/service-map-stateful-benchmarks/READEME.md
+++ b/data-prepper-benchmarks/service-map-stateful-benchmarks/READEME.md
@@ -1,6 +1,6 @@
 # Service Map Stateful Benchmarks
 
-This package contains benchmarks for the service map stateful processor using JMH: https://openjdk.java.net/projects/code-tools/jmh/ . 
+This package contains benchmarks for the service map stateful prepper using JMH: https://openjdk.java.net/projects/code-tools/jmh/ . 
 
 Integration with gradle is done with the following gradle plugin for JMH: https://github.com/melix/jmh-gradle-plugin.
 

--- a/data-prepper-benchmarks/service-map-stateful-benchmarks/src/jmh/java/com/amazon/dataprepper/benchmarks/processor/ServiceMapStatefulProcessorBenchmarks.java
+++ b/data-prepper-benchmarks/service-map-stateful-benchmarks/src/jmh/java/com/amazon/dataprepper/benchmarks/processor/ServiceMapStatefulProcessorBenchmarks.java
@@ -1,8 +1,9 @@
 package com.amazon.dataprepper.benchmarks.processor;
 
+import com.amazon.dataprepper.plugins.processor.ServiceMapStatefulPrepper;
 import com.google.protobuf.ByteString;
 import com.amazon.dataprepper.model.record.Record;
-import com.amazon.dataprepper.plugins.processor.ServiceMapStatefulProcessor;
+
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.time.Clock;
@@ -31,7 +32,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Thread)
 public class ServiceMapStatefulProcessorBenchmarks {
 
-    private ServiceMapStatefulProcessor serviceMapStatefulProcessor;
+    private ServiceMapStatefulPrepper serviceMapStatefulProcessor;
     private List<byte[]> spanIds;
     private List<byte[]> traceIds;
     private static final String DB_PATH = "data/benchmark";
@@ -48,7 +49,7 @@ public class ServiceMapStatefulProcessorBenchmarks {
 
     @Setup(Level.Trial)
     public void setupServiceMapStatefulProcessor() {
-        serviceMapStatefulProcessor = new ServiceMapStatefulProcessor(windowDurationSeconds*1000, new File(DB_PATH), Clock.systemDefaultZone());
+        serviceMapStatefulProcessor = new ServiceMapStatefulPrepper(windowDurationSeconds*1000, new File(DB_PATH), Clock.systemDefaultZone());
     }
 
     /**

--- a/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndRawSpanTest.java
+++ b/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndRawSpanTest.java
@@ -78,7 +78,7 @@ public class EndToEndRawSpanTest {
                     final List<Map<String, Object>> foundSources = getSourcesFromSearchHits(searchResponse.getHits());
                     Assert.assertEquals(expectedDocuments.size(), foundSources.size());
                     /**
-                     * Our raw trace processor add more fields than the actual sent object. These are defaults from the proto.
+                     * Our raw trace prepper add more fields than the actual sent object. These are defaults from the proto.
                      * So assertion is done if all the expected fields exists.
                      *
                      * TODO: Can we do better?

--- a/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndServiceMapTest.java
+++ b/data-prepper-core/src/integrationTest/java/com/amazon/dataprepper/integration/EndToEndServiceMapTest.java
@@ -75,7 +75,7 @@ public class EndToEndServiceMapTest {
         builder.withPassword("admin");
         final RestHighLevelClient restHighLevelClient = builder.build().createClient();
 
-        // Wait for service map processor by 2 * window_duration
+        // Wait for service map prepper by 2 * window_duration
         Thread.sleep(6000);
         await().atMost(10, TimeUnit.SECONDS).untilAsserted(
                 () -> {
@@ -103,7 +103,7 @@ public class EndToEndServiceMapTest {
         final List<ServiceMapTestData> testDataSet2 = Stream.of(testDataSet21, testDataSet22)
                 .flatMap(Collection::stream).collect(Collectors.toList());
         possibleEdges.addAll(getPossibleEdges(TEST_TRACEID_2, testDataSet2));
-        // Wait for service map processor by 2 * window_duration
+        // Wait for service map prepper by 2 * window_duration
         Thread.sleep(6000);
         await().atMost(20, TimeUnit.SECONDS).untilAsserted(
                 () -> {

--- a/data-prepper-core/src/integrationTest/resources/pipeline.yml
+++ b/data-prepper-core/src/integrationTest/resources/pipeline.yml
@@ -1,7 +1,7 @@
 entry-pipeline:
   source:
     otel_trace_source:
-  processor:
+  prepper:
     - peer_forwarder:
         discovery_mode: "static"
         static_endpoints: ["data-prepper1", "data-prepper2"]
@@ -14,7 +14,7 @@ raw-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - otel_trace_raw_processor:
   sink:
     - elasticsearch:
@@ -26,7 +26,7 @@ service-map-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - service_map_stateful:
         window_duration: 3
   sink:

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/PipelineParser.java
@@ -2,7 +2,7 @@ package com.amazon.dataprepper.parser;
 
 import com.amazon.dataprepper.model.buffer.Buffer;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
-import com.amazon.dataprepper.model.processor.Processor;
+import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.model.sink.Sink;
 import com.amazon.dataprepper.model.source.Source;
 import com.amazon.dataprepper.parser.model.PipelineConfiguration;
@@ -82,8 +82,8 @@ public class PipelineParser {
             LOG.info("Building buffer for the pipeline [{}]", pipelineName);
             final Buffer buffer = BufferFactory.newBuffer(pipelineConfiguration.getBufferPluginSetting());
 
-            LOG.info("Building processors for the pipeline [{}]", pipelineName);
-            final List<Processor> processors = pipelineConfiguration.getProcessorPluginSettings().stream()
+            LOG.info("Building preppers for the pipeline [{}]", pipelineName);
+            final List<Prepper> preppers = pipelineConfiguration.getProcessorPluginSettings().stream()
                     .map(ProcessorFactory::newProcessor)
                     .collect(Collectors.toList());
             final int processorThreads = pipelineConfiguration.getWorkers();
@@ -94,7 +94,7 @@ public class PipelineParser {
                     .map(this::buildSinkOrConnector)
                     .collect(Collectors.toList());
 
-            final Pipeline pipeline = new Pipeline(pipelineName, source, buffer, processors, sinks, processorThreads, readBatchDelay);
+            final Pipeline pipeline = new Pipeline(pipelineName, source, buffer, preppers, sinks, processorThreads, readBatchDelay);
             pipelineMap.put(pipelineName, pipeline);
         } catch (Exception ex) {
             //If pipeline construction errors out, we will skip that pipeline and proceed

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/PipelineConfiguration.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/PipelineConfiguration.java
@@ -30,7 +30,7 @@ public class PipelineConfiguration {
     public PipelineConfiguration(
             @JsonProperty("source") final Map.Entry<String, Map<String, Object>> source,
             @JsonProperty("buffer") final Map.Entry<String, Map<String, Object>> buffer,
-            @JsonProperty("processor") final List<Map.Entry<String, Map<String, Object>>> processors,
+            @JsonProperty("prepper") final List<Map.Entry<String, Map<String, Object>>> processors,
             @JsonProperty("sink") final List<Map.Entry<String, Map<String, Object>>> sinks,
             @JsonProperty("workers") final Integer workers,
             @JsonProperty("delay") final Integer delay) {

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/ProcessWorker.java
@@ -1,7 +1,7 @@
 package com.amazon.dataprepper.pipeline;
 
 import com.amazon.dataprepper.model.buffer.Buffer;
-import com.amazon.dataprepper.model.processor.Processor;
+import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.sink.Sink;
 import com.amazon.dataprepper.pipeline.common.FutureHelper;
@@ -18,18 +18,18 @@ public class ProcessWorker implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(ProcessWorker.class);
 
     private final Buffer readBuffer;
-    private final List<Processor> processors;
+    private final List<Prepper> preppers;
     private final Collection<Sink> sinks;
     private final Pipeline pipeline;
     private boolean isEmptyRecordsLogged = false;
 
     public ProcessWorker(
             final Buffer readBuffer,
-            final List<Processor> processors,
+            final List<Prepper> preppers,
             final Collection<Sink> sinks,
             final Pipeline pipeline) {
         this.readBuffer = readBuffer;
-        this.processors = processors;
+        this.preppers = preppers;
         this.sinks = sinks;
         this.pipeline = pipeline;
     }
@@ -48,9 +48,9 @@ public class ProcessWorker implements Runnable {
                 } else {
                     LOG.info(" {} Worker: Processing {} records from buffer", pipeline.getName(), records.size());
                 }
-                //Should Empty list from buffer should be sent to the processors? For now sending as the Stateful processors expects it.
-                for (final Processor processor : processors) {
-                    records = processor.execute(records);
+                //Should Empty list from buffer should be sent to the preppers? For now sending as the Stateful preppers expects it.
+                for (final Prepper prepper : preppers) {
+                    records = prepper.execute(records);
                 }
                 if (!records.isEmpty()) {
                     postToSink(records); //TODO use the response to ack the buffer on failure?

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/common/PipelineThreadPoolExecutor.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/common/PipelineThreadPoolExecutor.java
@@ -59,7 +59,7 @@ public class PipelineThreadPoolExecutor extends ThreadPoolExecutor {
         super.afterExecute(runnable, throwable);
 
         // If submit() method is used instead of execute(), the exceptions are wrapped in Future
-        // Processor or Sink failures will enter into this loop
+        // Prepper or Sink failures will enter into this loop
         if (throwable == null && runnable instanceof Future<?>) {
             try {
                 ((Future<?>) runnable).get();

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/pipeline/PipelineTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/pipeline/PipelineTests.java
@@ -1,10 +1,10 @@
 package com.amazon.dataprepper.pipeline;
 
-import com.amazon.dataprepper.model.processor.Processor;
+import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.sink.Sink;
 import com.amazon.dataprepper.model.source.Source;
-import com.amazon.dataprepper.plugins.TestProcessor;
+import com.amazon.dataprepper.plugins.TestPrepper;
 import com.amazon.dataprepper.plugins.TestSink;
 import com.amazon.dataprepper.plugins.TestSource;
 import com.amazon.dataprepper.plugins.buffer.BlockingBuffer;
@@ -54,7 +54,7 @@ public class PipelineTests {
     public void testPipelineStateWithProcessor() {
         final Source<Record<String>> testSource = new TestSource();
         final TestSink testSink = new TestSink();
-        final TestProcessor testProcessor = new TestProcessor();
+        final TestPrepper testProcessor = new TestPrepper();
         final Pipeline testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
                 Collections.singletonList(testProcessor),
                 Collections.singletonList(testSink),
@@ -67,7 +67,7 @@ public class PipelineTests {
         testPipeline.shutdown();
         assertThat("Pipeline isStopRequested is expected to be true", testPipeline.isStopRequested(), is(true));
         assertThat("Sink shutdown should be called", testSink.isShutdown, is(true));
-        assertThat("Processor shutdown should be called", testProcessor.isShutdown, is(true));
+        assertThat("Prepper shutdown should be called", testProcessor.isShutdown, is(true));
     }
 
     @Test
@@ -104,10 +104,10 @@ public class PipelineTests {
     public void testExecuteFailingProcessor() {
         final Source<Record<String>> testSource = new TestSource();
         final Sink<Record<String>> testSink = new TestSink();
-        final Processor<Record<String>, Record<String>> testProcessor = new Processor<Record<String>, Record<String>>() {
+        final Prepper<Record<String>, Record<String>> testPrepper = new Prepper<Record<String>, Record<String>>() {
             @Override
             public Collection<Record<String>> execute(Collection<Record<String>> records) {
-                throw new RuntimeException("Processor is expected to fail");
+                throw new RuntimeException("Prepper is expected to fail");
             }
 
             @Override
@@ -117,13 +117,13 @@ public class PipelineTests {
         };
         try {
             testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
-                    Collections.singletonList(testProcessor), Collections.singletonList(testSink), TEST_PROCESSOR_THREADS,
+                    Collections.singletonList(testPrepper), Collections.singletonList(testSink), TEST_PROCESSOR_THREADS,
                     TEST_READ_BATCH_TIMEOUT);
             testPipeline.execute();
             Thread.sleep(TEST_READ_BATCH_TIMEOUT);
         } catch (Exception ex) {
-            assertThat("Incorrect exception message", ex.getMessage().contains("Processor is expected to fail"));
-            assertThat("Exception from processor should trigger shutdown of pipeline", testPipeline.isStopRequested());
+            assertThat("Incorrect exception message", ex.getMessage().contains("Prepper is expected to fail"));
+            assertThat("Exception from prepper should trigger shutdown of pipeline", testPipeline.isStopRequested());
         }
     }
 

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/plugins/TestPrepper.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/plugins/TestPrepper.java
@@ -1,10 +1,10 @@
 package com.amazon.dataprepper.plugins;
 
-import com.amazon.dataprepper.model.processor.Processor;
+import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.model.record.Record;
 import java.util.Collection;
 
-public class TestProcessor implements Processor<Record<String>, Record<String>> {
+public class TestPrepper implements Prepper<Record<String>, Record<String>> {
     public boolean isShutdown = false;
 
     @Override

--- a/data-prepper-core/src/test/resources/valid_multiple_processors.yml
+++ b/data-prepper-core/src/test/resources/valid_multiple_processors.yml
@@ -10,7 +10,7 @@ raw-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - string_converter:
         upper_case: true
     - string_converter:
@@ -22,7 +22,7 @@ service-map-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - string_converter:
         upper_case: true
     - string_converter:

--- a/data-prepper-core/src/test/resources/valid_multiple_sinks.yml
+++ b/data-prepper-core/src/test/resources/valid_multiple_sinks.yml
@@ -10,7 +10,7 @@ raw-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - string_converter:
         upper_case: true
   sink:
@@ -20,7 +20,7 @@ service-map-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - string_converter:
         upper_case: true
   sink:

--- a/data-prepper-plugins/common/README.md
+++ b/data-prepper-plugins/common/README.md
@@ -9,7 +9,7 @@ A buffer based off `LinkedBlockingQueue` bounded to the specified capacity. One 
 
 ## `string_coverter`
 
-A processor plugin to generate new string records with upper or lower case conversion on the content of input records.
+A prepper plugin to generate new string records with upper or lower case conversion on the content of input records.
 
 - upper_case (boolean): convert to upper case if true; otherwise convert to lower case
 

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/PluginRepository.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/PluginRepository.java
@@ -3,7 +3,7 @@ package com.amazon.dataprepper.plugins;
 import com.amazon.dataprepper.model.PluginType;
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.buffer.Buffer;
-import com.amazon.dataprepper.model.processor.Processor;
+import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.model.sink.Sink;
 import com.amazon.dataprepper.model.source.Source;
 import org.reflections.Reflections;
@@ -23,7 +23,7 @@ public final class  PluginRepository {
     private static final String DEFAULT_PLUGINS_CLASSPATH = "com.amazon.dataprepper.plugins";
     private static final Map<String, Class<Source>> SOURCES = new HashMap<>();
     private static final Map<String, Class<Buffer>> BUFFERS = new HashMap<>();
-    private static final Map<String, Class<Processor>> PROCESSORS = new HashMap<>();
+    private static final Map<String, Class<Prepper>> PROCESSORS = new HashMap<>();
     private static final Map<String, Class<Sink>> SINKS = new HashMap<>();
 
     static {
@@ -46,7 +46,7 @@ public final class  PluginRepository {
                     BUFFERS.put(pluginName, (Class<Buffer>) annotatedClass);
                     break;
                 case PROCESSOR:
-                    PROCESSORS.put(pluginName, (Class<Processor>) annotatedClass);
+                    PROCESSORS.put(pluginName, (Class<Prepper>) annotatedClass);
                     break;
                 case SINK:
                     SINKS.put(pluginName, (Class<Sink>) annotatedClass);
@@ -77,7 +77,7 @@ public final class  PluginRepository {
         return BUFFERS.get(name);
     }
 
-    public static Class<Processor> getProcessorClass(final String name) {
+    public static Class<Prepper> getProcessorClass(final String name) {
         return PROCESSORS.get(name);
     }
 

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/processor/NoOpPrepper.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/processor/NoOpPrepper.java
@@ -3,27 +3,27 @@ package com.amazon.dataprepper.plugins.processor;
 import com.amazon.dataprepper.model.PluginType;
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
-import com.amazon.dataprepper.model.processor.Processor;
+import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.model.record.Record;
 
 import java.util.Collection;
 
 @DataPrepperPlugin(name = "no-op", type = PluginType.PROCESSOR)
-public class NoOpProcessor<InputT extends Record<?>> implements Processor<InputT, InputT> {
+public class NoOpPrepper<InputT extends Record<?>> implements Prepper<InputT, InputT> {
 
     /**
      * Mandatory constructor for Data Prepper Component - This constructor is used by Data Prepper
-     * runtime engine to construct an instance of {@link NoOpProcessor} using an instance of {@link PluginSetting} which
+     * runtime engine to construct an instance of {@link NoOpPrepper} using an instance of {@link PluginSetting} which
      * has access to pluginSetting metadata from pipeline
      * pluginSetting file.
      *
      * @param pluginSetting instance with metadata information from pipeline pluginSetting file.
      */
-    public NoOpProcessor(final PluginSetting pluginSetting) {
+    public NoOpPrepper(final PluginSetting pluginSetting) {
         //no op
     }
 
-    public NoOpProcessor() {
+    public NoOpPrepper() {
 
     }
 

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/processor/ProcessorFactory.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/processor/ProcessorFactory.java
@@ -1,14 +1,14 @@
 package com.amazon.dataprepper.plugins.processor;
 
 import com.amazon.dataprepper.model.configuration.PluginSetting;
-import com.amazon.dataprepper.model.processor.Processor;
+import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.plugins.PluginFactory;
 import com.amazon.dataprepper.plugins.PluginRepository;
 
 @SuppressWarnings({"rawtypes"})
 public class ProcessorFactory extends PluginFactory {
 
-    public static Processor newProcessor(final PluginSetting pluginSetting) {
-        return (Processor) newPlugin(pluginSetting, PluginRepository.getProcessorClass(pluginSetting.getName()));
+    public static Prepper newProcessor(final PluginSetting pluginSetting) {
+        return (Prepper) newPlugin(pluginSetting, PluginRepository.getProcessorClass(pluginSetting.getName()));
     }
 }

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/processor/StringPrepper.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/processor/StringPrepper.java
@@ -3,30 +3,30 @@ package com.amazon.dataprepper.plugins.processor;
 import com.amazon.dataprepper.model.PluginType;
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
-import com.amazon.dataprepper.model.processor.Processor;
+import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.model.record.Record;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
 /**
- * An simple String implementation of {@link Processor} which generates new Records with upper case or lowercase content. The current
+ * An simple String implementation of {@link Prepper} which generates new Records with upper case or lowercase content. The current
  * simpler implementation does not handle errors (if any).
  */
 @DataPrepperPlugin(name = "string_converter", type = PluginType.PROCESSOR)
-public class StringProcessor implements Processor<Record<String>, Record<String>> {
+public class StringPrepper implements Prepper<Record<String>, Record<String>> {
 
     private final boolean upperCase;
 
     /**
      * Mandatory constructor for Data Prepper Component - This constructor is used by Data Prepper
-     * runtime engine to construct an instance of {@link StringProcessor} using an instance of {@link PluginSetting} which
+     * runtime engine to construct an instance of {@link StringPrepper} using an instance of {@link PluginSetting} which
      * has access to pluginSetting metadata from pipeline
      * pluginSetting file.
      *
      * @param pluginSetting instance with metadata information from pipeline pluginSetting file.
      */
-    public StringProcessor(final PluginSetting pluginSetting) {
+    public StringPrepper(final PluginSetting pluginSetting) {
         this.upperCase = pluginSetting.getBooleanOrDefault("upper_case", true);
     }
 

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/processor/PrepperFactoryTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/processor/PrepperFactoryTests.java
@@ -1,7 +1,7 @@
 package com.amazon.dataprepper.plugins.processor;
 
 import com.amazon.dataprepper.model.configuration.PluginSetting;
-import com.amazon.dataprepper.model.processor.Processor;
+import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.plugins.PluginException;
 import com.amazon.dataprepper.plugins.sink.SinkFactory;
 import org.junit.Test;
@@ -16,7 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 
 @SuppressWarnings("rawtypes")
-public class ProcessorFactoryTests {
+public class PrepperFactoryTests {
     private static String TEST_PIPELINE = "test-pipeline";
     /**
      * Tests if ProcessorFactory is able to retrieve default Source plugins by name
@@ -25,10 +25,10 @@ public class ProcessorFactoryTests {
     public void testNewSinkClassByNameThatExists() {
         final PluginSetting noOpProcessorConfiguration = new PluginSetting("no-op", new HashMap<>());
         noOpProcessorConfiguration.setPipelineName(TEST_PIPELINE);
-        final Processor actualProcessor = ProcessorFactory.newProcessor(noOpProcessorConfiguration);
-        final Processor expectedProcessor = new NoOpProcessor();
-        assertThat(actualProcessor, notNullValue());
-        assertThat(actualProcessor.getClass().getSimpleName(), is(equalTo(expectedProcessor.getClass().getSimpleName())));
+        final Prepper actualPrepper = ProcessorFactory.newProcessor(noOpProcessorConfiguration);
+        final Prepper expectedPrepper = new NoOpPrepper();
+        assertThat(actualPrepper, notNullValue());
+        assertThat(actualPrepper.getClass().getSimpleName(), is(equalTo(expectedPrepper.getClass().getSimpleName())));
     }
 
     /**

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/processor/state/PrepperStateTest.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/processor/state/PrepperStateTest.java
@@ -11,7 +11,7 @@ import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
-public abstract class ProcessorStateTest {
+public abstract class PrepperStateTest {
 
     protected static final Random random = new Random();
 
@@ -22,7 +22,7 @@ public abstract class ProcessorStateTest {
 
     @Test
     public void testSize() {
-        //Put two random Pojos in the processor state
+        //Put two random Pojos in the prepper state
         final DataClass data1 = new DataClass(UUID.randomUUID().toString(), random.nextInt());
         final byte[] key1 = UUID.randomUUID().toString().getBytes();
 
@@ -37,7 +37,7 @@ public abstract class ProcessorStateTest {
 
     @Test
     public void testPutAndGet() {
-        //Put two random Pojos in the processor state
+        //Put two random Pojos in the prepper state
         final DataClass data1 = new DataClass(UUID.randomUUID().toString(), random.nextInt());
         final byte[] key1 = UUID.randomUUID().toString().getBytes();
 
@@ -55,7 +55,7 @@ public abstract class ProcessorStateTest {
 
     @Test
     public void testPutAndGetAll() {
-        //Put two random Pojos in the processor state
+        //Put two random Pojos in the prepper state
         final DataClass data1 = new DataClass(UUID.randomUUID().toString(), random.nextInt());
         final byte[] key1 = UUID.randomUUID().toString().getBytes();
 

--- a/data-prepper-plugins/elasticsearch/README.md
+++ b/data-prepper-plugins/elasticsearch/README.md
@@ -146,7 +146,7 @@ If not provided, failed records will be written into the default log file.
 ### Bulk size (Optional)
 
 A long of bulk size in bulk requests in MB. Default to 5 MB. If set to be less than 0, 
-all the records received from the upstream processor at a time will be sent as a single bulk request. 
+all the records received from the upstream prepper at a time will be sent as a single bulk request. 
 If a single record turns out to be larger than the set bulk size, it will be sent as a bulk request of a single document.
 
 ## Compatibility

--- a/data-prepper-plugins/lmdb-processor-state/src/main/java/com/amazon/dataprepper/plugins/processor/state/LmdbProcessorState.java
+++ b/data-prepper-plugins/lmdb-processor-state/src/main/java/com/amazon/dataprepper/plugins/processor/state/LmdbProcessorState.java
@@ -29,7 +29,7 @@ public class LmdbProcessorState<T> implements ProcessorState<byte[], T> {
     private final File dbFile;
 
     /**
-     * Constructor for LMDB processor state. See LMDB-Java for more info:
+     * Constructor for LMDB prepper state. See LMDB-Java for more info:
      * https://github.com/lmdbjava/lmdbjava
      * @param dbFile The directory in which to store the LMDB data files
      * @param dbName Name of the database

--- a/data-prepper-plugins/lmdb-processor-state/src/test/java/com/amazon/dataprepper/plugins/processor/state/LmdbPrepperStateTest.java
+++ b/data-prepper-plugins/lmdb-processor-state/src/test/java/com/amazon/dataprepper/plugins/processor/state/LmdbPrepperStateTest.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-public class LmdbProcessorStateTest extends ProcessorStateTest {
+public class LmdbPrepperStateTest extends PrepperStateTest {
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/data-prepper-plugins/mapdb-processor-state/src/test/java/com/amazon/dataprepper/plugins/processor/state/MapDbPrepperStateTest.java
+++ b/data-prepper-plugins/mapdb-processor-state/src/test/java/com/amazon/dataprepper/plugins/processor/state/MapDbPrepperStateTest.java
@@ -10,7 +10,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class MapDbProcessorStateTest extends ProcessorStateTest {
+public class MapDbPrepperStateTest extends PrepperStateTest {
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/data-prepper-plugins/otel-trace-raw-processor/README.md
+++ b/data-prepper-plugins/otel-trace-raw-processor/README.md
@@ -1,8 +1,8 @@
 # OTel Trace Raw Processor
 
-This is a processor that serializes collection of `ExportTraceServiceRequest` sent from [otel-trace-source](../dataPrepper-plugins/otel-trace-source) into collection of string records. 
+This is a prepper that serializes collection of `ExportTraceServiceRequest` sent from [otel-trace-source](../dataPrepper-plugins/otel-trace-source) into collection of string records. 
 
 ```
-processor:
+prepper:
     - otel_trace_raw_processor:
 ```

--- a/data-prepper-plugins/otel-trace-raw-processor/src/main/java/com/amazon/dataprepper/plugins/processor/oteltrace/OTelTraceRawPrepper.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/main/java/com/amazon/dataprepper/plugins/processor/oteltrace/OTelTraceRawPrepper.java
@@ -3,7 +3,7 @@ package com.amazon.dataprepper.plugins.processor.oteltrace;
 import com.amazon.dataprepper.model.PluginType;
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
-import com.amazon.dataprepper.model.processor.AbstractPrepper;
+import com.amazon.dataprepper.model.prepper.AbstractPrepper;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.processor.oteltrace.model.OTelProtoHelper;
 import com.amazon.dataprepper.plugins.processor.oteltrace.model.RawSpanBuilder;
@@ -25,7 +25,7 @@ import java.util.Map;
 
 
 @DataPrepperPlugin(name = "otel_trace_raw_processor", type = PluginType.PROCESSOR)
-public class OTelTraceRawProcessor extends AbstractPrepper<Record<ExportTraceServiceRequest>, Record<String>> {
+public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServiceRequest>, Record<String>> {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String INSTRUMENTATION_LIBRARY_SPANS = "instrumentationLibrarySpans";
@@ -39,7 +39,7 @@ public class OTelTraceRawProcessor extends AbstractPrepper<Record<ExportTraceSer
     private static final String END_TIME = "endTime";
     private static final BigDecimal MILLIS_TO_NANOS = new BigDecimal(1_000_000);
     private static final BigDecimal SEC_TO_MILLIS = new BigDecimal(1_000);
-    private static final Logger log = LoggerFactory.getLogger(OTelTraceRawProcessor.class);
+    private static final Logger log = LoggerFactory.getLogger(OTelTraceRawPrepper.class);
 
     public static final String SPAN_PROCESSING_ERRORS = "spanProcessingErrors";
     public static final String RESOURCE_SPANS_PROCESSING_ERRORS = "resourceSpansProcessingErrors";
@@ -51,7 +51,7 @@ public class OTelTraceRawProcessor extends AbstractPrepper<Record<ExportTraceSer
 
 
     //TODO: https://github.com/opendistro-for-elasticsearch/simple-ingest-transformation-utility-pipeline/issues/66
-    public OTelTraceRawProcessor(final PluginSetting pluginSetting) {
+    public OTelTraceRawPrepper(final PluginSetting pluginSetting) {
         super(pluginSetting);
         spanErrorsCounter = pluginMetrics.counter(SPAN_PROCESSING_ERRORS);
         resourceSpanErrorsCounter = pluginMetrics.counter(RESOURCE_SPANS_PROCESSING_ERRORS);
@@ -60,7 +60,7 @@ public class OTelTraceRawProcessor extends AbstractPrepper<Record<ExportTraceSer
 
 
     /**
-     * execute the processor logic which could potentially modify the incoming record. The level to which the record has
+     * execute the prepper logic which could potentially modify the incoming record. The level to which the record has
      * been modified depends on the implementation
      *
      * @param records Input records that will be modified/processed

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/java/com/amazon/dataprepper/plugins/processor/oteltrace/OTelTraceRawPrepperTest.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/java/com/amazon/dataprepper/plugins/processor/oteltrace/OTelTraceRawPrepperTest.java
@@ -29,17 +29,17 @@ import java.util.StringJoiner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-public class OTelTraceRawProcessorTest {
+public class OTelTraceRawPrepperTest {
 
     private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     PluginSetting pluginSetting;
-    public OTelTraceRawProcessor oTelTraceRawProcessor;
+    public OTelTraceRawPrepper oTelTraceRawProcessor;
 
     @Before
     public void setup() {
         pluginSetting = new PluginSetting("OTelTrace", Collections.EMPTY_MAP);
         pluginSetting.setPipelineName("pipelineOTelTrace");
-        oTelTraceRawProcessor = new OTelTraceRawProcessor(pluginSetting);
+        oTelTraceRawProcessor = new OTelTraceRawPrepper(pluginSetting);
     }
 
     @Test
@@ -59,10 +59,10 @@ public class OTelTraceRawProcessorTest {
 
         final List<Measurement> resourceSpansErrorsMeasurement = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add("pipelineOTelTrace").add("OTelTrace")
-                        .add(OTelTraceRawProcessor.RESOURCE_SPANS_PROCESSING_ERRORS).toString());
+                        .add(OTelTraceRawPrepper.RESOURCE_SPANS_PROCESSING_ERRORS).toString());
         final List<Measurement> totalErrorsMeasurement = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add("pipelineOTelTrace").add("OTelTrace")
-                        .add(OTelTraceRawProcessor.TOTAL_PROCESSING_ERRORS).toString());
+                        .add(OTelTraceRawPrepper.TOTAL_PROCESSING_ERRORS).toString());
 
         Assert.assertEquals(1, resourceSpansErrorsMeasurement.size());
         Assert.assertEquals(1.0, resourceSpansErrorsMeasurement.get(0).getValue(), 0);
@@ -94,7 +94,7 @@ public class OTelTraceRawProcessorTest {
 
         final List<Measurement> spanErrorsMeasurement = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add("pipelineOTelTrace").add("OTelTrace")
-                        .add(OTelTraceRawProcessor.SPAN_PROCESSING_ERRORS).toString());
+                        .add(OTelTraceRawPrepper.SPAN_PROCESSING_ERRORS).toString());
         Assert.assertEquals(1, spanErrorsMeasurement.size());
         Assert.assertEquals(1.0, spanErrorsMeasurement.get(0).getValue(), 0);
     }

--- a/data-prepper-plugins/otel-trace-raw-processor/src/test/java/com/amazon/dataprepper/plugins/processor/oteltrace/model/RawBuilderTest.java
+++ b/data-prepper-plugins/otel-trace-raw-processor/src/test/java/com/amazon/dataprepper/plugins/processor/oteltrace/model/RawBuilderTest.java
@@ -76,7 +76,7 @@ public class RawBuilderTest {
     }
 
     /**
-     * You can submit empty object and the processor will process it without any error
+     * You can submit empty object and the prepper will process it without any error
      */
     @Test
     public void testRawSpanEmpty() {

--- a/data-prepper-plugins/peer-forwarder/README.md
+++ b/data-prepper-plugins/peer-forwarder/README.md
@@ -1,5 +1,5 @@
 # Peer Forwarder
-This processor forwards `ExportTraceServiceRequest` via gRPC to other Data Prepper instances. The primary usecase of this processor is 
+This prepper forwards `ExportTraceServiceRequest` via gRPC to other Data Prepper instances. The primary usecase of this prepper is 
 to ensure that groups of traces are aggregated by trace ID and processed by the same Prepper instance.
 
 Presently peer discovery is provided by either a static list (configured in yaml) or by a DNS record lookup.
@@ -7,7 +7,7 @@ Presently peer discovery is provided by either a static list (configured in yaml
 ## Configuration
 Static list example:
 ```
-processor:
+prepper:
     - peer_forwarder:
         time_out: 300
         span_agg_count: 48
@@ -19,7 +19,7 @@ processor:
 
 DNS lookup example:
 ```
-processor:
+prepper:
     - peer_forwarder:
         time_out: 300
         span_agg_count: 48

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarder.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/processor/peerforwarder/PeerForwarder.java
@@ -3,7 +3,7 @@ package com.amazon.dataprepper.plugins.processor.peerforwarder;
 import com.amazon.dataprepper.model.PluginType;
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
-import com.amazon.dataprepper.model.processor.AbstractPrepper;
+import com.amazon.dataprepper.model.prepper.AbstractPrepper;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.processor.peerforwarder.discovery.PeerListProvider;
 import com.amazon.dataprepper.plugins.processor.peerforwarder.discovery.StaticPeerListProvider;

--- a/data-prepper-plugins/service-map-stateful/README.md
+++ b/data-prepper-plugins/service-map-stateful/README.md
@@ -1,9 +1,9 @@
 # Service-Map Stateful Processor
 
-This is a special processor that consumes Opentelemetry traces, stores them in a LMDB data store and evaluate relationships at fixed ```window_duration```. 
+This is a special prepper that consumes Opentelemetry traces, stores them in a LMDB data store and evaluate relationships at fixed ```window_duration```. 
 The lmdb databases are stored in the ```data/service-map/*``` path.
 ```
-processor:
+prepper:
     service-map-stateful:
 ```
 

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/processor/ServiceMapStatefulPrepperTest.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/processor/ServiceMapStatefulPrepperTest.java
@@ -65,7 +65,7 @@ public class ServiceMapStatefulPrepperTest {
         pluginSetting.setProcessWorkers(4);
         pluginSetting.setPipelineName("TestPipeline");
         //Nothing is accessible to validate, so just verify that no exception is thrown.
-        final ServiceMapStatefulProcessor serviceMapStatefulProcessor = new ServiceMapStatefulProcessor(pluginSetting);
+        final ServiceMapStatefulPrepper serviceMapStatefulPrepper = new ServiceMapStatefulPrepper(pluginSetting);
     }
 
     @Test

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/processor/ServiceMapStatefulPrepperTest.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/processor/ServiceMapStatefulPrepperTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 
-public class ServiceMapStatefulProcessorTest {
+public class ServiceMapStatefulPrepperTest {
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -75,8 +75,8 @@ public class ServiceMapStatefulProcessorTest {
         Mockito.when(clock.instant()).thenReturn(Instant.now());
         ExecutorService threadpool = Executors.newCachedThreadPool();
         final File path = new File(ServiceMapProcessorConfig.DEFAULT_LMDB_PATH);
-        final ServiceMapStatefulProcessor serviceMapStateful1 = new ServiceMapStatefulProcessor(100, path, clock, 16, PLUGIN_SETTING);
-        final ServiceMapStatefulProcessor serviceMapStateful2 = new ServiceMapStatefulProcessor(100, path, clock, 16, PLUGIN_SETTING);
+        final ServiceMapStatefulPrepper serviceMapStateful1 = new ServiceMapStatefulPrepper(100, path, clock, 16, PLUGIN_SETTING);
+        final ServiceMapStatefulPrepper serviceMapStateful2 = new ServiceMapStatefulPrepper(100, path, clock, 16, PLUGIN_SETTING);
 
         final byte[] rootSpanId1 = ServiceMapTestUtils.getRandomBytes(8);
         final byte[] rootSpanId2 = ServiceMapTestUtils.getRandomBytes(8);

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/processor/ServiceMapTestUtils.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/processor/ServiceMapTestUtils.java
@@ -37,7 +37,7 @@ public class ServiceMapTestUtils {
         return resourceSpans.getInstrumentationLibrarySpans(0).getSpans(0).getSpanId().toByteArray();
     }
 
-    public static Future<Set<ServiceMapRelationship>> startExecuteAsync(ExecutorService threadpool, ServiceMapStatefulProcessor processor,
+    public static Future<Set<ServiceMapRelationship>> startExecuteAsync(ExecutorService threadpool, ServiceMapStatefulPrepper processor,
                                                                  Collection<Record<ExportTraceServiceRequest>> records) {
         return threadpool.submit(() -> {
             return processor.execute(records)

--- a/docs/dev/trace-analytics-rfc.md
+++ b/docs/dev/trace-analytics-rfc.md
@@ -26,7 +26,7 @@ Data Prepper is an ingestion service which provides users to ingest and transfor
 Below are the fundamental concepts of Data Prepper,
 
 *Pipeline:*
-A Data Prepper pipeline has four key components source, buffer, processor, and sink. A single instance of Data Prepper can have one or more pipelines. A pipeline definition contains two required components source and sink. By default, the Data Prepper pipeline will use the default buffer and no processor. All the components are pluggable and enable a user to plugin their custom implementations. Please note that custom implementations will have implications on guarantees however the basic interfaces will remain the same.
+A Data Prepper pipeline has four key components source, buffer, prepper, and sink. A single instance of Data Prepper can have one or more pipelines. A pipeline definition contains two required components source and sink. By default, the Data Prepper pipeline will use the default buffer and no prepper. All the components are pluggable and enable a user to plugin their custom implementations. Please note that custom implementations will have implications on guarantees however the basic interfaces will remain the same.
 
 *Source:*
 The source is the input component of a pipeline, it defines the mechanism through which a Data Prepper pipeline will consume records. The source component could consume records either by receiving over http/s or reading from external endpoints like Kafka, SQS, Cloudwatch, etc.  The source will have its own configuration options based on the type like the format of the records (string/JSON/cloudwatch logs/open telemetry trace), security, concurrency threads, etc. The source component will consume records and write them to the buffer component. 
@@ -38,7 +38,7 @@ The buffer component will act as the layer between the source and sink. The buff
 Sink in the output component of the pipeline, it defines the one or more destinations to which a Data Prepper pipeline will publish the records. A sink destination could be either service like elastic search, s3. The sink will have its own configuration options based on the destination type like security, request batching, etc. A sink can be another Data Prepper pipeline, this would provide users the benefit chain multiple Data Prepper pipelines.
 
 *Processor:*
-Processor component of the pipeline, these are intermediary processing units using which users can filter, transform, and enrich the records into the desired format before publishing to the sink. The processor is an optional component of the pipeline, if not defined the records will be published in the format as defined in the source. You can have more than one processor and they are executed in the order they are defined in the pipeline spec.
+Processor component of the pipeline, these are intermediary processing units using which users can filter, transform, and enrich the records into the desired format before publishing to the sink. The prepper is an optional component of the pipeline, if not defined the records will be published in the format as defined in the source. You can have more than one prepper and they are executed in the order they are defined in the pipeline spec.
 
 
 Data Prepper will be an ODFE community-driven project, the end goal is to make multiple Source, Sink, and Processor plugins available.
@@ -59,9 +59,9 @@ mean we will support transport over gRPC, HTTP/Proto and HTTP/JSON. The source w
 
 ##### Processors
 
-We are building two processors for the Trace Analytics feature,
-* *otel-trace-raw-processor* -  This processor will be responsible for converting the trace data in [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-proto/tree/master/opentelemetry/proto/trace/v1) to elasticsearch friendly (JSON) docs. These elasticsearch friendly docs will have minimal additional fields like duration which are not part of the original specification. These additional fields are to make the instant kibana dashboards user-friendly.
-* *service-map-processor* -  This processor will perform the required preprocessing on the trace data and build metadata to display the service-map kibana dashboards.
+We are building two preppers for the Trace Analytics feature,
+* *otel-trace-raw-prepper* -  This prepper will be responsible for converting the trace data in [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-proto/tree/master/opentelemetry/proto/trace/v1) to elasticsearch friendly (JSON) docs. These elasticsearch friendly docs will have minimal additional fields like duration which are not part of the original specification. These additional fields are to make the instant kibana dashboards user-friendly.
+* *service-map-prepper* -  This prepper will perform the required preprocessing on the trace data and build metadata to display the service-map kibana dashboards.
 
 
 ##### Elasticsearch sink
@@ -69,8 +69,8 @@ We are building two processors for the Trace Analytics feature,
 We will build a generic sink that will write the data to elasticsearch as the destination. The elasticsearch sink will have configuration options related to elasticsearch cluster like endpoint, SSL/Username, index name, index template, index state management, etc. 
 For the trace analytics feature, the sink will have specific configurations which will make the sink to use indices and index templates specific to the feature. Trace analytics specific elasticsearch indices are,
                                                                                                                                                                  
-* *apm-trace-raw-v1* -  This index will store the output from otel-trace-raw-processor. 
-* *apm-service-map-v1* - This index will store the output from the service-map-processor.
+* *apm-trace-raw-v1* -  This index will store the output from otel-trace-raw-prepper. 
+* *apm-service-map-v1* - This index will store the output from the service-map-prepper.
 
 ## 4. Kibana
 

--- a/docs/readme/error_handling.md
+++ b/docs/readme/error_handling.md
@@ -9,7 +9,7 @@ Single pipeline is a pipeline that doesn't use the pipeline connectors.
 
 * If an exception encountered when creating a pipeline, the pipeline stops and exits using `system.exit(1)`. 
 * If an exception encountered during pipeline `start()` method, the pipeline stops with appropriate logs. 
-* If an exception encountered in Pipeline `processors` or `sinks` during runtime, the pipeline stops with appropriate logs.
+* If an exception encountered in Pipeline `preppers` or `sinks` during runtime, the pipeline stops with appropriate logs.
 
 ## Connected Pipelines
 
@@ -18,5 +18,5 @@ Connected Pipelines is scenario where two or more pipelines connected using the 
 
 * If an exception encountered when creating any of the connected pipelines, all the connected pipelines stop and exits using `system.exit(1)`. 
 * If an exception encountered during pipeline `start()` method in any of the connected pipelines, the pipeline that encountered the exception will shutdown and other pipelines will run but not receive or process any data as a connected pipeline is unavailable.
-* If an exception encountered in Pipeline `processors` or `sinks` during runtime in any of the connected pipelines, the pipeline that encountered the exception will shutdown and other pipelines will run for a while and shutdown as a connected pipeline is unavailable.
+* If an exception encountered in Pipeline `preppers` or `sinks` during runtime in any of the connected pipelines, the pipeline that encountered the exception will shutdown and other pipelines will run for a while and shutdown as a connected pipeline is unavailable.
 

--- a/docs/readme/overview.md
+++ b/docs/readme/overview.md
@@ -10,7 +10,7 @@ The broader vision for Data Prepper is to enable an end-to-end data analysis lif
 Below are the fundamental concepts of Data Prepper,
 
 ### Pipeline
-A Data Prepper pipeline has four key components a *source*, a *buffer*, one or more *processors*, and one or more *sinks*. A single instance of Data Prepper can have one or more pipelines. A pipeline definition contains two required components *source* and *sink*. If other components are missing the Data Prepper pipeline will use default buffer and no-op processor. All the components are pluggable and enable customers to plugin their custom implementations. Please note that custom implementations will have implications on guarantees however the basic interfaces will remain same.
+A Data Prepper pipeline has four key components a *source*, a *buffer*, one or more *preppers*, and one or more *sinks*. A single instance of Data Prepper can have one or more pipelines. A pipeline definition contains two required components *source* and *sink*. If other components are missing the Data Prepper pipeline will use default buffer and no-op prepper. All the components are pluggable and enable customers to plugin their custom implementations. Please note that custom implementations will have implications on guarantees however the basic interfaces will remain same.
 
 ### Source
 Source is the input component of a pipeline, it defines the mechanism through which a Data Prepper pipeline will consume records. A pipeline can have only one source. Source component could consume records either by receiving over http/s or reading from external endpoints like Kafka, SQS, Cloudwatch etc.  Source will have its own configuration options based on the type like the format of the records (string/json/cloudwatch logs/open telemetry trace) , security, concurrency threads etc . The source component will consume records and write them to the buffer component. 
@@ -22,7 +22,7 @@ The buffer component will act as the layer between the *source* and *sink.* The 
 Sink in the output component of pipeline, it defines the one or more destinations to which a Data Prepper pipeline will publish the records. A sink destination could be either services like elastic search, s3 or another Data Prepper pipeline. By using another Data Prepper pipeline as sink, we could chain multiple Data Prepper pipelines. Sink will have its own configuration options based on the destination type like security, request batching etc. 
 
 ### Processor
-Processor component of the pipeline, these are intermediary processing units using which users can filter, transform and enrich the records into desired format before publishing to the sink. The processor is an optional component of the pipeline, if not defined the records will be published in the format as defined in the source. You can have more than one processor, and they are executed in the order they are defined in the pipeline spec.
+Processor component of the pipeline, these are intermediary processing units using which users can filter, transform and enrich the records into desired format before publishing to the sink. The prepper is an optional component of the pipeline, if not defined the records will be published in the format as defined in the source. You can have more than one prepper, and they are executed in the order they are defined in the pipeline spec.
 
 ### Sample Pipeline configuration
 
@@ -52,7 +52,7 @@ sample-pipeline:
     bounded_blocking:
       buffer_size: 1024 # max number of records the buffer will accept
       batch_size: 256 # max number of records the buffer will drain for each read
-  processor:
+  prepper:
     - string_converter:
        upper_case: true
   sink:
@@ -60,14 +60,14 @@ sample-pipeline:
        path: path/to/output-file
 ```
 
-The above pipeline has a file source that reads string records from the `input-file`. The source pushes the data to buffer bounded by max size of `1024`. The pipeline configured to have `4` workers each of them reading maximum of `256` records from the buffer for every `100 milliseconds`. Each worker will execute the `string_converter` processor and write the output of the processor to the `output-file`
+The above pipeline has a file source that reads string records from the `input-file`. The source pushes the data to buffer bounded by max size of `1024`. The pipeline configured to have `4` workers each of them reading maximum of `256` records from the buffer for every `100 milliseconds`. Each worker will execute the `string_converter` prepper and write the output of the prepper to the `output-file`
 
 
 
 
 ## Pipeline Connectors
 
-Some use-cases requires to use one or more heterogeneous sinks/processors. This means the pipeline architecture is now dependent on heterogeneous components which are diverse and could impact the availability and performance of one another. To avoid this, Data Prepper offers Pipeline Connectors. Pipeline Connectors help to process data from single source in multiple pipelines which are made up of heterogeneous components. Pipeline connectors are simple components which act as sink and source.
+Some use-cases requires to use one or more heterogeneous sinks/preppers. This means the pipeline architecture is now dependent on heterogeneous components which are diverse and could impact the availability and performance of one another. To avoid this, Data Prepper offers Pipeline Connectors. Pipeline Connectors help to process data from single source in multiple pipelines which are made up of heterogeneous components. Pipeline connectors are simple components which act as sink and source.
 
 ### Sample configuration 
 
@@ -85,7 +85,7 @@ output-pipeline-1:
   source:
     pipeline:
       name: "input-pipeline"
-  processor:
+  prepper:
     - string_converter:
        upper_case: true
   sink:
@@ -95,7 +95,7 @@ output-pipeline-2:
   source:
     pipeline:
       name: "input-pipeline"
-  processor:
+  prepper:
     - string_converter:
        upper_case: false
   sink:

--- a/docs/readme/trace_overview.md
+++ b/docs/readme/trace_overview.md
@@ -13,9 +13,9 @@ The OpenTelemetry source accepts trace data from the OpenTelemetry collector. Th
 
 ## Processors
 
-We have two processors for the Trace Analytics feature,
-* *otel_trace_raw_processor* -  This processor is responsible for converting the trace data in [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-proto/tree/master/opentelemetry/proto/trace/v1) to elasticsearch friendly (JSON) docs. These elasticsearch friendly docs have certain additional fields like duration which are not part of the original OpenTelemetry specification. These additional fields are to make the instant kibana dashboards user-friendly.
-* *service_map_stateful* -  This processor performs the required preprocessing on the trace data and build metadata to display the service-map kibana dashboards.
+We have two preppers for the Trace Analytics feature,
+* *otel_trace_raw_processor* -  This prepper is responsible for converting the trace data in [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-proto/tree/master/opentelemetry/proto/trace/v1) to elasticsearch friendly (JSON) docs. These elasticsearch friendly docs have certain additional fields like duration which are not part of the original OpenTelemetry specification. These additional fields are to make the instant kibana dashboards user-friendly.
+* *service_map_stateful* -  This prepper performs the required preprocessing on the trace data and build metadata to display the service-map kibana dashboards.
 
 
 ## Elasticsearch sink
@@ -23,8 +23,8 @@ We have two processors for the Trace Analytics feature,
 We have a generic sink that writes the data to elasticsearch as the destination. The elasticsearch sink has configuration options related to elasticsearch cluster like endpoint, SSL/Username, index name, index template, index state management, etc. 
 For the trace analytics feature, the sink has specific configurations which enables the sink to use indices and index templates specific to this feature. Trace analytics specific elasticsearch indices are,
                                                                                                                                                                  
-* *otel-v1-apm-span* -  This index stores the output from otel-trace-raw-processor. 
-* *otel-v1-apm-service-map* - This index stores the output from the service-map-processor.
+* *otel-v1-apm-span* -  This index stores the output from otel-trace-raw-prepper. 
+* *otel-v1-apm-service-map* - This index stores the output from the service-map-prepper.
 
 
 ## Trace Analytics Pipeline Configuration
@@ -45,7 +45,7 @@ raw-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - otel_trace_raw_processor:
   sink:
     - elasticsearch:
@@ -59,7 +59,7 @@ service-map-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - service_map_stateful:
   sink:
     - elasticsearch:

--- a/examples/dev/trace-analytics-sample-app/resources/trace_analytics_no_ssl.yml
+++ b/examples/dev/trace-analytics-sample-app/resources/trace_analytics_no_ssl.yml
@@ -11,7 +11,7 @@ raw-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - otel_trace_raw_processor:
   sink:
     - elasticsearch:
@@ -25,7 +25,7 @@ service-map-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - service_map_stateful:
   sink:
     - elasticsearch:

--- a/examples/trace_analytics.yml
+++ b/examples/trace_analytics.yml
@@ -14,7 +14,7 @@ raw-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  prepper:
+  processor:
     - otel_trace_raw_processor:
   sink:
     - elasticsearch:
@@ -28,7 +28,7 @@ service-map-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  prepper:
+  processor:
     - service_map_stateful:
   sink:
     - elasticsearch:

--- a/examples/trace_analytics.yml
+++ b/examples/trace_analytics.yml
@@ -14,7 +14,7 @@ raw-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - otel_trace_raw_processor:
   sink:
     - elasticsearch:
@@ -28,7 +28,7 @@ service-map-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - service_map_stateful:
   sink:
     - elasticsearch:

--- a/examples/trace_analytics_no_ssl.yml
+++ b/examples/trace_analytics_no_ssl.yml
@@ -11,7 +11,7 @@ raw-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  prepper:
+  processor:
     - otel_trace_raw_processor:
   sink:
     - elasticsearch:
@@ -25,7 +25,7 @@ service-map-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  prepper:
+  processor:
     - service_map_stateful:
   sink:
     - elasticsearch:

--- a/examples/trace_analytics_no_ssl.yml
+++ b/examples/trace_analytics_no_ssl.yml
@@ -11,7 +11,7 @@ raw-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - otel_trace_raw_processor:
   sink:
     - elasticsearch:
@@ -25,7 +25,7 @@ service-map-pipeline:
   source:
     pipeline:
       name: "entry-pipeline"
-  processor:
+  prepper:
     - service_map_stateful:
   sink:
     - elasticsearch:


### PR DESCRIPTION
*Issue #, if available:* #209

*Description of changes:*
* Used IDE refactor to rename Processor interface and package
* Manually fixed some config yaml files to reference `prepper:` instead of `processor:`

There are still references to "processor" in some of the core files and plugins, will issue follow-up PRs to keep the size managable.

Tested these changes using the dev docker-compose test project, sample log:
```
204  [main] INFO  com.amazon.dataprepper.parser.PipelineParser  – Building preppers for the pipeline [entry-pipeline]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
