### PR TITLE
Adding code coverage target for service map stateful processor

### DIFF
--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -21,3 +21,14 @@ dependencies {
     testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
     testImplementation "org.mockito:mockito-core:${versionMap.mockito}"
 }
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule { //in addition to core projects rule
+            limit {
+                minimum = 0.9
+            }
+        }
+    }
+}

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/processor/ServiceMapStatefulProcessorTest.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/processor/ServiceMapStatefulProcessorTest.java
@@ -60,6 +60,15 @@ public class ServiceMapStatefulProcessorTest {
     }
 
     @Test
+    public void testPluginSettingConstructor() {
+        final PluginSetting pluginSetting = new PluginSetting("testPluginSetting", Collections.emptyMap());
+        pluginSetting.setProcessWorkers(4);
+        pluginSetting.setPipelineName("TestPipeline");
+        //Nothing is accessible to validate, so just verify that no exception is thrown.
+        final ServiceMapStatefulProcessor serviceMapStatefulProcessor = new ServiceMapStatefulProcessor(pluginSetting);
+    }
+
+    @Test
     public void testTraceGroups() throws Exception {
         final Clock clock = Mockito.mock(Clock.class);
         Mockito.when(clock.millis()).thenReturn(1L);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/data-prepper/issues/239

*Description of changes:*
- Adding 90% code coverage target for service map stateful processor
- There are catch blocks in this code that are not testable currently, because they would require us injecting a factory for creating the processor state objects. That work only buys us more testability, so for now it seems that it is not high priority

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
