### PR TITLE
Clean up jacoco in the overall build and enforce minimum coverage on peerforwarder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ subprojects {
         }
     }
     build.dependsOn test
+    jacocoTestReport {
+        dependsOn test // tests are required to run before generating the report
+    }
 }
 
 configure(coreProjects) {
@@ -35,9 +38,6 @@ configure(coreProjects) {
     test {
         useJUnit()
         finalizedBy jacocoTestReport // report is always generated after tests run
-    }
-    jacocoTestReport {
-        dependsOn test // tests are required to run before generating the report
     }
     jacocoTestCoverageVerification {
         dependsOn jacocoTestReport

--- a/data-prepper-plugins/peer-forwarder/build.gradle
+++ b/data-prepper-plugins/peer-forwarder/build.gradle
@@ -18,3 +18,14 @@ dependencies {
     testImplementation "junit:junit:4.12"
     testImplementation "org.mockito:mockito-inline:3.6.28"
 }
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.90
+            }
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
#239 

*Description of changes:*
- Remove redundant jacocoTestReport in coreProjects config
- Enforce jacocoTestReport to depend on tests in all subprojects
- Enforced 90% coverage on peerforwarder.

Note: right now peerforwarder is covered up to 94%. The missing lines and branches concentrate in `Peerforwarder.isAddressDefinedLocally(String)` which is a private method and includes some adhoc exception related to java.net. Pushing for testability on that API might require refactoring.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
