### PR TITLE
First cut of adding metrics to Service Map Stateful Prepper

### DIFF
--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     compile project(':data-prepper-plugins:common')
     compile project(':data-prepper-plugins:lmdb-prepper-state')
     compile project(':data-prepper-plugins:mapdb-prepper-state')
+    implementation "io.micrometer:micrometer-core:1.5.1"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
     testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Initial cut of adding the following metrics to the Service Map Stateful Prepper:

  - 1. uniqueRelationshipsCounter
  - 2. uniqueTraceGroupsCounter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
