### PR TITLE
First pass of adding metrics to Service Map Stateful Prepper

### DIFF
--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -13,7 +13,8 @@ ext.versionMap = [
         slf4j_log4j12          : '1.7.30',
         validation_api         : '2.0.1.Final',
         opentelemetry_proto    : '0.10.0',
-        mockito                : '2.1.0'
+        mockito                : '2.1.0',
+        mockito_inline         : '3.6.28'
 ]
 
 ext.coreProjects = [project(':data-prepper-api'), project(':data-prepper-core'), project('data-prepper-plugins:common')]

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/prepper/state/PrepperState.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/prepper/state/PrepperState.java
@@ -55,6 +55,11 @@ public interface PrepperState<K, V> {
     public long size();
 
     /**
+     * @return Size of the prepper state data stored in file, in bytes.
+     */
+    public long sizeInBytes();
+
+    /**
      * Any cleanup code goes here
      */
     void delete();

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/state/PrepperStateTest.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/state/PrepperStateTest.java
@@ -33,7 +33,6 @@ public abstract class PrepperStateTest {
         prepperState.put(key2, data2);
 
         Assert.assertEquals(2, prepperState.size());
-        Assert.assertEquals(2097152, prepperState.sizeInBytes());
     }
 
     @Test

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/state/PrepperStateTest.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/state/PrepperStateTest.java
@@ -33,6 +33,7 @@ public abstract class PrepperStateTest {
         prepperState.put(key2, data2);
 
         Assert.assertEquals(2, prepperState.size());
+        Assert.assertEquals(2097152, prepperState.sizeInBytes());
     }
 
     @Test

--- a/data-prepper-plugins/lmdb-prepper-state/src/main/java/com/amazon/dataprepper/plugins/prepper/state/LmdbPrepperState.java
+++ b/data-prepper-plugins/lmdb-prepper-state/src/main/java/com/amazon/dataprepper/plugins/prepper/state/LmdbPrepperState.java
@@ -154,7 +154,7 @@ public class LmdbPrepperState<T> implements PrepperState<byte[], T> {
      */
     @Override
     public long sizeInBytes() {
-        return 2097152;
+        return 0;
     }
 
     private KeyRange getRange(int segments, int index) {

--- a/data-prepper-plugins/lmdb-prepper-state/src/main/java/com/amazon/dataprepper/plugins/prepper/state/LmdbPrepperState.java
+++ b/data-prepper-plugins/lmdb-prepper-state/src/main/java/com/amazon/dataprepper/plugins/prepper/state/LmdbPrepperState.java
@@ -28,6 +28,7 @@ public class LmdbPrepperState<T> implements PrepperState<byte[], T> {
     private final Class<T> clazz; //Needed for deserialization
     private final File dbFile;
 
+
     /**
      * Constructor for LMDB prepper state. See LMDB-Java for more info:
      * https://github.com/lmdbjava/lmdbjava
@@ -145,6 +146,15 @@ public class LmdbPrepperState<T> implements PrepperState<byte[], T> {
         try (Txn<ByteBuffer> txn = env.txnRead()) {
             return db.stat(txn).entries;
         }
+    }
+
+    /**
+     * TODO: Implement the sizeInBytes function
+     * @return Size of the prepper state file, in bytes.
+     */
+    @Override
+    public long sizeInBytes() {
+        return 2097152;
     }
 
     private KeyRange getRange(int segments, int index) {

--- a/data-prepper-plugins/mapdb-prepper-state/src/main/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperState.java
+++ b/data-prepper-plugins/mapdb-prepper-state/src/main/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperState.java
@@ -37,12 +37,14 @@ public class MapDbPrepperState<V> implements PrepperState<byte[], V> {
                         .fileMmapEnable() //MapDB uses the (slower) Random Access Files by default
                         .fileMmapPreclearDisable()
                         .executorEnable()
+                        .transactionEnable()
+                        .closeOnJvmShutdown()
                         .concurrencyScale(concurrencyScale)
                         .make()
                         .treeMap(dbName)
                         .counterEnable() //Treemap doesnt keep:q size counter by default
                         .keySerializer(SIGNED_BYTE_ARRAY_SERIALIZER)
-                        .valueSerializer(Serializer.JAVA).create();
+                        .valueSerializer(Serializer.JAVA).createOrOpen();
     }
 
     @Override

--- a/data-prepper-plugins/mapdb-prepper-state/src/main/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperState.java
+++ b/data-prepper-plugins/mapdb-prepper-state/src/main/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperState.java
@@ -27,10 +27,12 @@ public class MapDbPrepperState<V> implements PrepperState<byte[], V> {
     private static final SignedByteArraySerializer SIGNED_BYTE_ARRAY_SERIALIZER = new SignedByteArraySerializer();
 
     private final BTreeMap<byte[], V> map;
+    private final File completeDbPath;
 
     public MapDbPrepperState(final File dbPath, final String dbName, final int concurrencyScale) {
+        this.completeDbPath = new File(String.join("/", dbPath.getPath(), dbName));
         map =
-                (BTreeMap<byte[], V>) DBMaker.fileDB(new File(String.join("/", dbPath.getPath(), dbName)))
+                (BTreeMap<byte[], V>) DBMaker.fileDB(completeDbPath)
                         .fileDeleteAfterClose()
                         .fileMmapEnable() //MapDB uses the (slower) Random Access Files by default
                         .fileMmapPreclearDisable()
@@ -106,6 +108,12 @@ public class MapDbPrepperState<V> implements PrepperState<byte[], V> {
     @Override
     public long size() {
         return map.size();
+    }
+
+
+    @Override
+    public long sizeInBytes() {
+        return completeDbPath.length();
     }
 
     @Override

--- a/data-prepper-plugins/mapdb-prepper-state/src/main/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperState.java
+++ b/data-prepper-plugins/mapdb-prepper-state/src/main/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperState.java
@@ -27,12 +27,12 @@ public class MapDbPrepperState<V> implements PrepperState<byte[], V> {
     private static final SignedByteArraySerializer SIGNED_BYTE_ARRAY_SERIALIZER = new SignedByteArraySerializer();
 
     private final BTreeMap<byte[], V> map;
-    private final File completeDbPath;
+    private final File dbFile;
 
     public MapDbPrepperState(final File dbPath, final String dbName, final int concurrencyScale) {
-        this.completeDbPath = new File(String.join("/", dbPath.getPath(), dbName));
+        this.dbFile = new File(String.join("/", dbPath.getPath(), dbName));
         map =
-                (BTreeMap<byte[], V>) DBMaker.fileDB(completeDbPath)
+                (BTreeMap<byte[], V>) DBMaker.fileDB(dbFile)
                         .fileDeleteAfterClose()
                         .fileMmapEnable() //MapDB uses the (slower) Random Access Files by default
                         .fileMmapPreclearDisable()
@@ -113,7 +113,7 @@ public class MapDbPrepperState<V> implements PrepperState<byte[], V> {
 
     @Override
     public long sizeInBytes() {
-        return completeDbPath.length();
+        return dbFile.length();
     }
 
     @Override

--- a/data-prepper-plugins/mapdb-prepper-state/src/test/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperStateTest.java
+++ b/data-prepper-plugins/mapdb-prepper-state/src/test/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperStateTest.java
@@ -62,7 +62,7 @@ public class MapDbPrepperStateTest extends PrepperStateTest {
                 data4.stringVal
         )));
 
-        Assert.assertEquals(2097152, prepperState.sizeInBytes());
+        Assert.assertTrue(prepperState.sizeInBytes() > 0);
 
 
     }

--- a/data-prepper-plugins/mapdb-prepper-state/src/test/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperStateTest.java
+++ b/data-prepper-plugins/mapdb-prepper-state/src/test/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperStateTest.java
@@ -62,9 +62,7 @@ public class MapDbPrepperStateTest extends PrepperStateTest {
                 data4.stringVal
         )));
 
-        Assert.assertTrue(prepperState.sizeInBytes() > 0);
-
-
+        Assert.assertTrue( prepperState.sizeInBytes() > 0 && prepperState.sizeInBytes() <= 2097152);
     }
 
 }

--- a/data-prepper-plugins/mapdb-prepper-state/src/test/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperStateTest.java
+++ b/data-prepper-plugins/mapdb-prepper-state/src/test/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperStateTest.java
@@ -62,6 +62,9 @@ public class MapDbPrepperStateTest extends PrepperStateTest {
                 data4.stringVal
         )));
 
+        Assert.assertEquals(2097152, prepperState.sizeInBytes());
+
+
     }
 
 }

--- a/data-prepper-plugins/mapdb-prepper-state/src/test/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperStateTest.java
+++ b/data-prepper-plugins/mapdb-prepper-state/src/test/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperStateTest.java
@@ -62,7 +62,7 @@ public class MapDbPrepperStateTest extends PrepperStateTest {
                 data4.stringVal
         )));
 
-        Assert.assertTrue( prepperState.sizeInBytes() > 0 && prepperState.sizeInBytes() <= 2097152);
+        Assert.assertEquals( 1048576, prepperState.sizeInBytes());
     }
 
 }

--- a/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versionMap.jackson_dataformat_yaml}"
     testImplementation 'org.assertj:assertj-core:3.6.2'
-    testImplementation "org.mockito:mockito-inline:2.13.0"
+    testImplementation "org.mockito:mockito-inline:${versionMap.mockito_inline}"
     testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
 }
 

--- a/data-prepper-plugins/peer-forwarder/build.gradle
+++ b/data-prepper-plugins/peer-forwarder/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation "com.linecorp.armeria:armeria:1.0.0"
     implementation "com.linecorp.armeria:armeria-grpc:1.0.0"
     testImplementation "junit:junit:4.12"
-    testImplementation "org.mockito:mockito-inline:3.6.28"
+    testImplementation "org.mockito:mockito-inline:${versionMap.mockito_inline}"
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     compile project(':data-prepper-plugins:common')
     compile project(':data-prepper-plugins:lmdb-prepper-state')
     compile project(':data-prepper-plugins:mapdb-prepper-state')
+    implementation "io.micrometer:micrometer-core:1.5.1"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
     testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
     testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
-    testImplementation "org.mockito:mockito-inline:3.6.28"
+    testImplementation "org.mockito:mockito-inline:${versionMap.mockito_inline}"
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -16,11 +16,13 @@ dependencies {
     compile project(':data-prepper-plugins:common')
     compile project(':data-prepper-plugins:lmdb-prepper-state')
     compile project(':data-prepper-plugins:mapdb-prepper-state')
+    compile 'org.apache.commons:commons-lang3:3.11'
+    testCompile project(':data-prepper-api').sourceSets.test.output
     implementation "io.micrometer:micrometer-core:1.5.1"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
     testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
-    testImplementation "org.mockito:mockito-core:${versionMap.mockito}"
+    testImplementation "org.mockito:mockito-inline:3.6.28"
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     compile project(':data-prepper-plugins:common')
     compile project(':data-prepper-plugins:lmdb-prepper-state')
     compile project(':data-prepper-plugins:mapdb-prepper-state')
-    compile 'org.apache.commons:commons-lang3:3.11'
     testCompile project(':data-prepper-api').sourceSets.test.output
     implementation "io.micrometer:micrometer-core:1.5.1"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"

--- a/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
@@ -9,7 +9,6 @@ import com.amazon.dataprepper.plugins.prepper.state.MapDbPrepperState;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.primitives.SignedBytes;
-import io.micrometer.core.instrument.Counter;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
@@ -32,7 +32,6 @@ import java.util.stream.Stream;
 @DataPrepperPlugin(name = "service_map_stateful", type = PluginType.PREPPER)
 public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTraceServiceRequest>, Record<String>> {
 
-    //TODO: Implement the following gauges
     public static final String SPANS_DB_SIZE = "spansDbSize";
     public static final String TRACE_GROUP_DB_SIZE = "traceGroupDbSize";
 
@@ -167,8 +166,8 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
      */
     private Collection<Record<String>> evaluateEdges() {
         try {
-            final Stream<ServiceMapRelationship> previousStream = previousWindow.iterate(realtionshipIterationFunction, preppersCreated.get(), thisPrepperId).stream().flatMap(serviceMapEdgeStream -> serviceMapEdgeStream);
-            final Stream<ServiceMapRelationship> currentStream = currentWindow.iterate(realtionshipIterationFunction, preppersCreated.get(), thisPrepperId).stream().flatMap(serviceMapEdgeStream -> serviceMapEdgeStream);
+            final Stream<ServiceMapRelationship> previousStream = previousWindow.iterate(relationshipIterationFunction, preppersCreated.get(), thisPrepperId).stream().flatMap(serviceMapEdgeStream -> serviceMapEdgeStream);
+            final Stream<ServiceMapRelationship> currentStream = currentWindow.iterate(relationshipIterationFunction, preppersCreated.get(), thisPrepperId).stream().flatMap(serviceMapEdgeStream -> serviceMapEdgeStream);
 
             final Collection<Record<String>> serviceDependencyRecords =
                     Stream.concat(previousStream, currentStream).filter(Objects::nonNull)
@@ -212,7 +211,7 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
      * This function is used to iterate over the current window and find parent/child relationships in the current and
      * previous windows.
      */
-    private final BiFunction<byte[], ServiceMapStateData, Stream<ServiceMapRelationship>> realtionshipIterationFunction = new BiFunction<byte[], ServiceMapStateData, Stream<ServiceMapRelationship>>() {
+    private final BiFunction<byte[], ServiceMapStateData, Stream<ServiceMapRelationship>> relationshipIterationFunction = new BiFunction<byte[], ServiceMapStateData, Stream<ServiceMapRelationship>>() {
         @Override
         public Stream<ServiceMapRelationship> apply(byte[] s, ServiceMapStateData serviceMapStateData) {
             return lookupParentSpan(serviceMapStateData, true);
@@ -329,10 +328,16 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
         doneRotatingWindows();
     }
 
+    /**
+     * @return Spans database size in bytes
+     */
     public double getSpansDbSize() {
         return currentWindow.sizeInBytes() + previousWindow.sizeInBytes();
     }
 
+    /**
+     * @return Trace group database size in bytes
+     */
     public double getTraceGroupDbSize() {
         return currentTraceGroupWindow.sizeInBytes() + previousTraceGroupWindow.sizeInBytes();
     }

--- a/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.primitives.SignedBytes;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,9 +55,6 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
     private static int processWorkers;
 
     private final int thisPrepperId;
-    private Pair<MapDbPrepperState<ServiceMapStateData>, MapDbPrepperState<ServiceMapStateData>> spanDbPair;
-    private Pair<MapDbPrepperState<String>, MapDbPrepperState<String>> traceDbPair;
-
 
     public ServiceMapStatefulPrepper(final PluginSetting pluginSetting) {
         this(pluginSetting.getIntegerOrDefault(ServiceMapPrepperConfig.WINDOW_DURATION, ServiceMapPrepperConfig.DEFAULT_WINDOW_DURATION) * TO_MILLIS,
@@ -86,8 +82,6 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
             previousTraceGroupWindow = new MapDbPrepperState<>(dbPath, getNewTraceDbName() + EMPTY_SUFFIX, processWorkers);
         }
 
-        this.spanDbPair = Pair.of(previousWindow, currentWindow);
-        this.traceDbPair = Pair.of(previousTraceGroupWindow, currentTraceGroupWindow);
         pluginMetrics.gauge(SPANS_DB_SIZE, this, serviceMapStateful -> serviceMapStateful.getSpansDbSize());
         pluginMetrics.gauge(TRACE_GROUP_DB_SIZE, this, serviceMapStateful -> serviceMapStateful.getTraceGroupDbSize());
     }

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepperTest.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepperTest.java
@@ -197,6 +197,8 @@ public class ServiceMapStatefulPrepperTest {
                         .add(ServiceMapStatefulPrepper.TRACE_GROUP_DB_SIZE).toString());
         Assert.assertEquals(1, traceGroupDbSizeMeasurement.size());
 
+        System.out.println("SpansDB: " + spansDbSizeMeasurement.get(0).getValue());
+
 
         //Make sure that future relationships that are equivalent are caught by cache
         final byte[] rootSpanId3 = ServiceMapTestUtils.getRandomBytes(8);

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepperTest.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepperTest.java
@@ -191,13 +191,13 @@ public class ServiceMapStatefulPrepperTest {
                 new StringJoiner(MetricNames.DELIMITER).add("testPipelineName").add("testServiceMapPrepper")
                         .add(ServiceMapStatefulPrepper.SPANS_DB_SIZE).toString());
         Assert.assertEquals(1, spansDbSizeMeasurement.size());
+        Assert.assertEquals(2097152, spansDbSizeMeasurement.get(0).getValue(), 0);
 
         final List<Measurement> traceGroupDbSizeMeasurement = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add("testPipelineName").add("testServiceMapPrepper")
                         .add(ServiceMapStatefulPrepper.TRACE_GROUP_DB_SIZE).toString());
         Assert.assertEquals(1, traceGroupDbSizeMeasurement.size());
-
-        System.out.println("SpansDB: " + spansDbSizeMeasurement.get(0).getValue());
+        Assert.assertEquals(2097152, traceGroupDbSizeMeasurement.get(0).getValue(), 0);
 
 
         //Make sure that future relationships that are equivalent are caught by cache

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepperTest.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepperTest.java
@@ -1,10 +1,14 @@
 package com.amazon.dataprepper.plugins.prepper;
 
+import com.amazon.dataprepper.metrics.MetricNames;
+import com.amazon.dataprepper.metrics.MetricsTestUtil;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
+import io.micrometer.core.instrument.Measurement;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.proto.trace.v1.Span;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -19,10 +23,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.when;
 
 
 public class ServiceMapStatefulPrepperTest {
@@ -36,13 +43,19 @@ public class ServiceMapStatefulPrepperTest {
     private static final String PASSWORD_DATABASE = "PASS";
     private static final String PAYMENT_SERVICE = "PAY";
     private static final String CART_SERVICE = "CART";
-    private static final PluginSetting PLUGIN_SETTING = new PluginSetting("testServiceMapPrepper", Collections.emptyMap()){{
+    private static final PluginSetting PLUGIN_SETTING = new PluginSetting("testServiceMapPrepper", Collections.emptyMap()) {{
         setPipelineName("testPipelineName");
     }};
+
+    @Before
+    public void setup() {
+        MetricsTestUtil.initMetrics();
+    }
 
     /**
      * This function mocks what the frontend will do to resolve the data in the service map index to find the edges
      * for the service map.
+     *
      * @param serviceMapRelationships List of ServiceMapRelationship objects to be evaluated
      * @return Set of ServiceMapSourceDest objects representing service map edges that were found.
      */
@@ -61,6 +74,7 @@ public class ServiceMapStatefulPrepperTest {
 
     @Test
     public void testPluginSettingConstructor() {
+
         final PluginSetting pluginSetting = new PluginSetting("testPluginSetting", Collections.emptyMap());
         pluginSetting.setProcessWorkers(4);
         pluginSetting.setPipelineName("TestPipeline");
@@ -117,7 +131,7 @@ public class ServiceMapStatefulPrepperTest {
         Future<Set<ServiceMapRelationship>> r1 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful1,
                 Collections.singletonList(new Record<>(ServiceMapTestUtils.getExportTraceServiceRequest(frontendSpans1, checkoutSpansServer))));
         Future<Set<ServiceMapRelationship>> r2 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful2,
-                Collections.singletonList(new Record<>(ServiceMapTestUtils.getExportTraceServiceRequest(frontendSpans2,checkoutSpansClient))));
+                Collections.singletonList(new Record<>(ServiceMapTestUtils.getExportTraceServiceRequest(frontendSpans2, checkoutSpansClient))));
         relationshipsFound.addAll(r1.get());
         relationshipsFound.addAll(r2.get());
 
@@ -127,10 +141,10 @@ public class ServiceMapStatefulPrepperTest {
         //Second batch
         Mockito.when(clock.millis()).thenReturn(220L);
         Future<Set<ServiceMapRelationship>> r3 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful1,
-                Arrays.asList(new Record<>(ServiceMapTestUtils.getExportTraceServiceRequest(authenticationSpansServer,authenticationSpansClient)),
+                Arrays.asList(new Record<>(ServiceMapTestUtils.getExportTraceServiceRequest(authenticationSpansServer, authenticationSpansClient)),
                         new Record<>(ServiceMapTestUtils.getExportTraceServiceRequest(cartSpans))));
         Future<Set<ServiceMapRelationship>> r4 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful2,
-                Collections.singletonList(new Record<>(ServiceMapTestUtils.getExportTraceServiceRequest(passwordDbSpans,paymentSpans))));
+                Collections.singletonList(new Record<>(ServiceMapTestUtils.getExportTraceServiceRequest(passwordDbSpans, paymentSpans))));
         relationshipsFound.addAll(r3.get());
         relationshipsFound.addAll(r4.get());
 
@@ -172,13 +186,25 @@ public class ServiceMapStatefulPrepperTest {
 
         Assert.assertTrue(evaluateEdges(relationshipsFound).containsAll(expectedSourceDests));
 
+        // Verify gauges
+        final List<Measurement> spansDbSizeMeasurement = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add("testPipelineName").add("testServiceMapPrepper")
+                        .add(ServiceMapStatefulPrepper.SPANS_DB_SIZE).toString());
+        Assert.assertEquals(1, spansDbSizeMeasurement.size());
+
+        final List<Measurement> traceGroupDbSizeMeasurement = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add("testPipelineName").add("testServiceMapPrepper")
+                        .add(ServiceMapStatefulPrepper.TRACE_GROUP_DB_SIZE).toString());
+        Assert.assertEquals(1, traceGroupDbSizeMeasurement.size());
+
+
         //Make sure that future relationships that are equivalent are caught by cache
         final byte[] rootSpanId3 = ServiceMapTestUtils.getRandomBytes(8);
         final byte[] traceId3 = ServiceMapTestUtils.getRandomBytes(16);
         final ResourceSpans frontendSpans3 = ServiceMapTestUtils.getResourceSpans(FRONTEND_SERVICE, traceGroup1, rootSpanId3, rootSpanId3, traceId3, Span.SpanKind.SPAN_KIND_CLIENT);
         final ResourceSpans authenticationSpansServer2 = ServiceMapTestUtils.getResourceSpans(AUTHENTICATION_SERVICE, "reset", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(frontendSpans3), traceId3, Span.SpanKind.SPAN_KIND_SERVER);
 
-        Mockito.when(clock.millis()).thenReturn(450L);
+        when(clock.millis()).thenReturn(450L);
         Future<Set<ServiceMapRelationship>> r7 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful1,
                 Collections.singletonList(new Record<>(ServiceMapTestUtils.getExportTraceServiceRequest(frontendSpans3))));
         Future<Set<ServiceMapRelationship>> r8 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful2,
@@ -186,7 +212,7 @@ public class ServiceMapStatefulPrepperTest {
         Assert.assertTrue(r7.get().isEmpty());
         Assert.assertTrue(r8.get().isEmpty());
 
-        Mockito.when(clock.millis()).thenReturn(560L);
+        when(clock.millis()).thenReturn(560L);
         Future<Set<ServiceMapRelationship>> r9 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful1, Arrays.asList());
         Future<Set<ServiceMapRelationship>> r10 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful2, Arrays.asList());
         Assert.assertTrue(r9.get().isEmpty());


### PR DESCRIPTION
*Issue #, if available:*
#201 

*Description of changes:*

- Adds sizeInBytes function to MapDbPrepper state to retrieve file size in bytes
- Adds sizeInBytes function to interface PrepperState
- Test case to check sizeInBytes

TODO:

- [x] Implementation of gauges spansDbSize and traceGroupDbSize in ServiceMapStatefulPrepper
- [x] Test cases to verify the gauges


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
