### PR TITLE
ENH: initial checkpoint model and API

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/CheckpointState.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/CheckpointState.java
@@ -1,5 +1,8 @@
 package com.amazon.dataprepper.model;
 
+/**
+ * CheckpointState keeps track of a summary of records processed by a data-prepper worker thread.
+ */
 public class CheckpointState {
     private final int numCheckedRecords;
 

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/CheckpointState.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/CheckpointState.java
@@ -1,0 +1,13 @@
+package com.amazon.dataprepper.model;
+
+public class CheckpointState {
+    private final int numCheckedRecords;
+
+    public CheckpointState(final int numCheckedRecords) {
+        this.numCheckedRecords = numCheckedRecords;
+    }
+
+    public int getNumCheckedRecords() {
+        return numCheckedRecords;
+    }
+}

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/Buffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/Buffer.java
@@ -1,6 +1,7 @@
 package com.amazon.dataprepper.model.buffer;
 
 import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.model.CheckpointState;
 
 import java.util.Collection;
 import java.util.concurrent.TimeoutException;
@@ -27,4 +28,10 @@ public interface Buffer<T extends Record<?>> {
      */
     Collection<T> read(int timeoutInMillis);
 
+    /**
+     * Check summary of records processed by data-prepper downstreams(preppers, sinks, pipelines).
+     *
+     * @param checkpointState the summary object of checkpoint variables
+     */
+    void checkpoint(CheckpointState checkpointState);
 }

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/CheckpointStateTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/CheckpointStateTest.java
@@ -1,0 +1,15 @@
+package com.amazon.dataprepper.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CheckpointStateTest {
+    private static final int TEST_NUM_CHECKED_RECORDS = 3;
+
+    @Test
+    public void testSimple() {
+        final CheckpointState checkpointState = new CheckpointState(TEST_NUM_CHECKED_RECORDS);
+        assertEquals(TEST_NUM_CHECKED_RECORDS, checkpointState.getNumCheckedRecords());
+    }
+}

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
@@ -1,5 +1,6 @@
 package com.amazon.dataprepper.model.buffer;
 
+import com.amazon.dataprepper.model.CheckpointState;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.metrics.MetricNames;
 import com.amazon.dataprepper.metrics.MetricsTestUtil;
@@ -120,6 +121,11 @@ public class AbstractBufferTest {
                 }
             }
             return records;
+        }
+
+        @Override
+        public void checkpoint(final CheckpointState checkpointState) {
+
         }
     }
 

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -46,7 +46,7 @@ jacocoTestCoverageVerification {
     violationRules {
         rule { //in addition to core projects rule
             limit {
-                minimum = 0.89
+                minimum = 0.90
             }
         }
     }

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -46,7 +46,7 @@ jacocoTestCoverageVerification {
     violationRules {
         rule { //in addition to core projects rule
             limit {
-                minimum = 0.90
+                minimum = 0.89
             }
         }
     }

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/ProcessWorker.java
@@ -6,6 +6,7 @@ import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.sink.Sink;
 import com.amazon.dataprepper.pipeline.common.FutureHelper;
 import com.amazon.dataprepper.pipeline.common.FutureHelperResult;
+import com.amazon.dataprepper.model.CheckpointState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +55,7 @@ public class ProcessWorker implements Runnable {
                 }
                 if (!records.isEmpty()) {
                     postToSink(records); //TODO use the response to ack the buffer on failure?
+                    readBuffer.checkpoint(new CheckpointState(records.size()));
                 }
             } while (!shouldStop());
         } catch (final Exception ex) {

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/buffer/BlockingBuffer.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/buffer/BlockingBuffer.java
@@ -21,9 +21,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.ReentrantLock;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/buffer/BlockingBuffer.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/buffer/BlockingBuffer.java
@@ -87,8 +87,8 @@ public class BlockingBuffer<T extends Record<?>> extends AbstractBuffer<T> {
     @Override
     public void doWrite(T record, int timeoutInMillis) throws TimeoutException {
         try {
-            final boolean isSuccess = available.tryAcquire(timeoutInMillis, TimeUnit.MILLISECONDS);
-            if (!isSuccess) {
+            final boolean permitAcquired = available.tryAcquire(timeoutInMillis, TimeUnit.MILLISECONDS);
+            if (!permitAcquired) {
                 throw new TimeoutException(format("Pipeline [%s] - Buffer is full, timed out waiting for a slot",
                         pipelineName));
             }

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/buffer/BlockingBuffer.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/buffer/BlockingBuffer.java
@@ -93,7 +93,6 @@ public class BlockingBuffer<T extends Record<?>> extends AbstractBuffer<T> {
     @Override
     public void doWrite(T record, int timeoutInMillis) throws TimeoutException {
         long nanos = TimeUnit.MILLISECONDS.toNanos(timeoutInMillis);
-        final int c;
         try {
             writeLock.lockInterruptibly();
             final AtomicInteger count = this.numInflightRecords;
@@ -105,7 +104,7 @@ public class BlockingBuffer<T extends Record<?>> extends AbstractBuffer<T> {
                 nanos = notFull.awaitNanos(nanos);
             }
             blockingQueue.offer(record);
-            c = count.incrementAndGet();
+            final int c = count.incrementAndGet();
             if (c < this.bufferCapacity) {
                 // Wake up other doWrite waiting threads due to previous full buffer state.
                 notFull.signal();

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/buffer/BlockingBufferTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/buffer/BlockingBufferTests.java
@@ -77,7 +77,6 @@ public class BlockingBufferTests {
         // Given
         final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(1, TEST_BATCH_SIZE,
                 TEST_PIPELINE_NAME);
-        assertThat(blockingBuffer, notNullValue());
         blockingBuffer.write(new Record<>("FILL_THE_BUFFER"), TEST_WRITE_TIMEOUT);
 
         // When

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/buffer/BlockingBufferTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/buffer/BlockingBufferTests.java
@@ -138,34 +138,6 @@ public class BlockingBufferTests {
         }
     }
 
-    @Test
-    public void testWriteAfterCheckedBatchReads() throws Exception {
-        // Given
-        final PluginSetting completePluginSetting = completePluginSettingForBlockingBuffer();
-        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(completePluginSetting);
-        assertThat(blockingBuffer, notNullValue());
-        for (int i = 0; i < TEST_BUFFER_SIZE; i++) {
-            Record<String> record = new Record<>("TEST" + i);
-            blockingBuffer.write(record, TEST_WRITE_TIMEOUT);
-        }
-
-        // When
-        Collection<Record<String>> partialRecords1 = blockingBuffer.read(TEST_BATCH_READ_TIMEOUT);
-        final int numPartialRecords1 = partialRecords1.size();
-        blockingBuffer.checkpoint(new CheckpointState(numPartialRecords1));
-        Collection<Record<String>> partialRecords2 = blockingBuffer.read(TEST_BATCH_READ_TIMEOUT);
-        final int numPartialRecords2 = partialRecords2.size();
-        blockingBuffer.checkpoint(new CheckpointState(numPartialRecords2));
-
-        // Then
-        for (int i = 0; i < numPartialRecords1 + numPartialRecords2; i++) {
-            Record<String> record = new Record<>("TEST" + i + TEST_BUFFER_SIZE);
-            // Should succeed without exception
-            blockingBuffer.write(record, TEST_WRITE_TIMEOUT);
-        }
-        assertThrows(TimeoutException.class, () -> blockingBuffer.write(new Record<>("TIMEOUT"), TEST_WRITE_TIMEOUT));
-    }
-
     private PluginSetting completePluginSettingForBlockingBuffer() {
         final String pluginName = "bounded_blocking";
         final Map<String, Object> settings = new HashMap<>();

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/buffer/BlockingBufferTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/buffer/BlockingBufferTests.java
@@ -2,6 +2,7 @@ package com.amazon.dataprepper.plugins.buffer;
 
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.model.CheckpointState;
 import org.junit.Test;
 
 import java.util.Collection;
@@ -13,6 +14,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 public class BlockingBufferTests {
     private static final String ATTRIBUTE_BATCH_SIZE = "batch_size";
@@ -62,11 +64,32 @@ public class BlockingBufferTests {
     }
 
     @Test(expected = TimeoutException.class)
-    public void testNoEmptySpace() throws TimeoutException {
+    public void testNoEmptySpaceWriteOnly() throws TimeoutException {
         final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(1, TEST_BATCH_SIZE,
                 TEST_PIPELINE_NAME);
         assertThat(blockingBuffer, notNullValue());
         blockingBuffer.write(new Record<>("FILL_THE_BUFFER"), TEST_WRITE_TIMEOUT);
+        blockingBuffer.write(new Record<>("TIMEOUT"), TEST_WRITE_TIMEOUT);
+    }
+
+    @Test
+    public void testNoEmptySpaceAfterUncheckedRead() throws TimeoutException {
+        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(1, TEST_BATCH_SIZE,
+                TEST_PIPELINE_NAME);
+        assertThat(blockingBuffer, notNullValue());
+        blockingBuffer.write(new Record<>("FILL_THE_BUFFER"), TEST_WRITE_TIMEOUT);
+        blockingBuffer.read(TEST_BATCH_READ_TIMEOUT);
+        assertThrows(TimeoutException.class, () -> blockingBuffer.write(new Record<>("TIMEOUT"), TEST_WRITE_TIMEOUT));
+    }
+
+    @Test
+    public void testWriteIntoEmptySpaceAfterCheckedRead() throws TimeoutException {
+        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(1, TEST_BATCH_SIZE,
+                TEST_PIPELINE_NAME);
+        assertThat(blockingBuffer, notNullValue());
+        blockingBuffer.write(new Record<>("FILL_THE_BUFFER"), TEST_WRITE_TIMEOUT);
+        final Collection<Record<String>> exportedRecords = blockingBuffer.read(TEST_BATCH_READ_TIMEOUT);
+        blockingBuffer.checkpoint(new CheckpointState(exportedRecords.size()));
         blockingBuffer.write(new Record<>("TIMEOUT"), TEST_WRITE_TIMEOUT);
     }
 

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/buffer/TestBuffer.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/buffer/TestBuffer.java
@@ -2,6 +2,7 @@ package com.amazon.dataprepper.plugins.buffer;
 
 import com.amazon.dataprepper.model.buffer.Buffer;
 import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.model.CheckpointState;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -44,6 +45,11 @@ public class TestBuffer implements Buffer<Record<String>> {
             index++;
         }
         return records;
+    }
+
+    @Override
+    public void checkpoint(final CheckpointState checkpointState) {
+
     }
 
     public int size() {


### PR DESCRIPTION
*Issue #, if available:*
#216 

*Description of changes:*
This PR 

1. Draft the initial model of CheckpointStates that takes in the number of records to be checked.
2. Add checkpoint API into Buffer interface and fix relevant places
3. Invoke the checkpoint API in the processWorker.
4. Modified BlockingBuffer to add number of inflight records as state variable.
5. Implemented checkpoint API in BlockingBuffer to keep track of inflight data
6. Modified doWrite API in BlockingBuffer to control inflight data below buffer capacity by introducing lock with explicit condition variable.

Note: Test cases that cover BlockingBuffer are synchronized. I expect async features to be at least partially covered by e2e tests. But if necessary, we should try to device those async tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
