### PR TITLE
ENH: buffer read returns CheckpointState

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/Buffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/Buffer.java
@@ -4,6 +4,7 @@ import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.CheckpointState;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 /**
@@ -24,9 +25,9 @@ public interface Buffer<T extends Record<?>> {
      * Retrieves and removes the batch of records from the head of the queue. The batch size is defined/determined by
      * the configuration attribute "batch_size" or the @param timeoutInMillis
      * @param timeoutInMillis how long to wait before giving up
-     * @return The earliest batch of records in the buffer which are still not read.
+     * @return The earliest batch of records in the buffer which are still not read and its corresponding checkpoint state.
      */
-    Collection<T> read(int timeoutInMillis);
+    Map.Entry<Collection<T>, CheckpointState> read(int timeoutInMillis);
 
     /**
      * Check summary of records processed by data-prepper downstreams(preppers, sinks, pipelines).

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
@@ -5,11 +5,14 @@ import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.metrics.MetricNames;
 import com.amazon.dataprepper.metrics.MetricsTestUtil;
 import com.amazon.dataprepper.model.record.Record;
+
+import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.StringJoiner;
 import java.util.UUID;
@@ -108,7 +111,7 @@ public class AbstractBufferTest {
         }
 
         @Override
-        public Collection<Record<String>> doRead(int timeoutInMillis) {
+        public Map.Entry<Collection<Record<String>>, CheckpointState> doRead(int timeoutInMillis) {
             try {
                 Thread.sleep(100);
             } catch (InterruptedException e) {
@@ -120,7 +123,8 @@ public class AbstractBufferTest {
                     records.add(queue.remove());
                 }
             }
-            return records;
+            final CheckpointState checkpointState = new CheckpointState(records.size());
+            return new AbstractMap.SimpleEntry<>(records, checkpointState);
         }
 
         @Override

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/ProcessWorker.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Future;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
@@ -39,8 +40,9 @@ public class ProcessWorker implements Runnable {
     public void run() {
         try {
             do {
-                Collection records = readBuffer.read(pipeline.getReadBatchTimeoutInMillis());
-                final CheckpointState checkpointState = new CheckpointState(records.size());
+                final Map.Entry<Collection, CheckpointState> readResult = readBuffer.read(pipeline.getReadBatchTimeoutInMillis());
+                Collection records = readResult.getKey();
+                final CheckpointState checkpointState = readResult.getValue();
                 //TODO Hacky way to avoid logging continuously - Will be removed as part of metrics implementation
                 if (records.isEmpty()) {
                     if(!isEmptyRecordsLogged) {

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/ProcessWorker.java
@@ -57,7 +57,7 @@ public class ProcessWorker implements Runnable {
                     records = prepper.execute(records);
                 }
                 if (!records.isEmpty()) {
-                    postToSink(records); //TODO use the response to ack the buffer on failure?
+                    postToSink(records);
                 }
                 // Checkpoint the current batch read from the buffer after being processed by prepper and sinks.
                 readBuffer.checkpoint(checkpointState);

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/buffer/BlockingBuffer.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/buffer/BlockingBuffer.java
@@ -124,8 +124,6 @@ public class BlockingBuffer<T extends Record<?>> extends AbstractBuffer<T> {
         } catch (InterruptedException ex) {
             LOG.warn("Pipeline [{}] - Retrieving records from buffer to batch size timed out, returning already " +
                     "retrieved records", pipelineName, ex);
-            final CheckpointState checkpointState = new CheckpointState(records.size());
-            return new AbstractMap.SimpleEntry<>(records, checkpointState);
         }
         final CheckpointState checkpointState = new CheckpointState(records.size());
         return new AbstractMap.SimpleEntry<>(records, checkpointState);

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/buffer/TestBuffer.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/buffer/TestBuffer.java
@@ -4,9 +4,11 @@ import com.amazon.dataprepper.model.buffer.Buffer;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.CheckpointState;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.TimeoutException;
 
@@ -36,7 +38,7 @@ public class TestBuffer implements Buffer<Record<String>> {
     }
 
     @Override
-    public Collection<Record<String>> read(int timeoutInMillis) {
+    public Map.Entry<Collection<Record<String>>, CheckpointState> read(int timeoutInMillis) {
         final List<Record<String>> records = new ArrayList<>();
         int index = 0;
         Record<String> record;
@@ -44,7 +46,8 @@ public class TestBuffer implements Buffer<Record<String>> {
             records.add(record);
             index++;
         }
-        return records;
+        final CheckpointState checkpointState = new CheckpointState(records.size());
+        return new AbstractMap.SimpleEntry<>(records, checkpointState);
     }
 
     @Override

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/source/FileSourceTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/source/FileSourceTests.java
@@ -1,5 +1,6 @@
 package com.amazon.dataprepper.plugins.source;
 
+import com.amazon.dataprepper.model.CheckpointState;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.buffer.BlockingBuffer;
@@ -111,7 +112,8 @@ public class FileSourceTests {
         assertThat(buffer.size(), is(equalTo(0)));
         fileSource.start(buffer);
         assertThat(buffer.size(), is(equalTo(1)));
-        final Collection<Record<String>> recordsFromBuffer = buffer.read(TEST_WRITE_TIMEOUT);
+        final Map.Entry<Collection<Record<String>>, CheckpointState> readResult = buffer.read(TEST_WRITE_TIMEOUT);
+        final Collection<Record<String>> recordsFromBuffer = readResult.getKey();
         assertThat(recordsFromBuffer.size(), is(equalTo(1)));
         recordsFromBuffer.forEach(actualRecord -> assertThat(actualRecord.getData(), is(equalTo(FILE_CONTENT))));
     }

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/source/StdInSourceTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/source/StdInSourceTests.java
@@ -1,5 +1,6 @@
 package com.amazon.dataprepper.plugins.source;
 
+import com.amazon.dataprepper.model.CheckpointState;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.buffer.TestBuffer;
@@ -12,6 +13,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Queue;
 
 import static java.lang.String.format;
@@ -92,7 +94,8 @@ public class StdInSourceTests {
         assertThat(buffer.size(), is(equalTo(0)));
         stdInSource.start(buffer);
         assertThat(buffer.size(), is(equalTo(1)));
-        final Collection<Record<String>> recordsFromBuffer = buffer.read(TEST_WRITE_TIMEOUT);
+        final Map.Entry<Collection<Record<String>>, CheckpointState> readResult = buffer.read(TEST_WRITE_TIMEOUT);
+        final Collection<Record<String>> recordsFromBuffer = readResult.getKey();
         assertThat(recordsFromBuffer.size(), is(equalTo(1)));
         recordsFromBuffer.forEach(actualRecord -> assertThat(actualRecord.getData(), is(equalTo(READ_CONTENT))));
     }

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -1,5 +1,6 @@
 package com.amazon.dataprepper.plugins.source.oteltrace;
 
+import com.amazon.dataprepper.model.CheckpointState;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.buffer.BlockingBuffer;
@@ -30,8 +31,10 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -113,9 +116,12 @@ public class OTelTraceSourceTest {
     }
 
     private void validateBuffer() {
-        List<Record<ExportTraceServiceRequest>> drainedBuffer = (List<Record<ExportTraceServiceRequest>>) BUFFER.read(100000);
+        Map.Entry<Collection<Record<ExportTraceServiceRequest>>, CheckpointState> drainedBufferResult = BUFFER.read(100000);
+        List<Record<ExportTraceServiceRequest>> drainedBuffer = (List<Record<ExportTraceServiceRequest>>) drainedBufferResult.getKey();
+        CheckpointState checkpointState = drainedBufferResult.getValue();
         assertThat(drainedBuffer.size()).isEqualTo(1);
         assertThat(drainedBuffer.get(0).getData()).isEqualTo(SUCCESS_REQUEST);
+        assertEquals(1, checkpointState.getNumCheckedRecords());
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
#216 

*Description of changes:*
This PR

- Modifies Buffer interface read to return both collection of records and CheckpointState
- Same as above in AbstractBuffer
- Made corresponding implementation change in BlockingBuffer
- Fix ProcessWorker invocation of buffer.read
- Fix all affected test cases


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
