### PR TITLE
ENH: metrics in AbstractBuffer

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
@@ -46,6 +46,11 @@ public class MetricNames {
     public static final String READ_TIME_ELAPSED = "readTimeElapsed";
 
     /**
+     * Metric representing the time elapsed while checkpointing
+     */
+    public static final String CHECKPOINT_TIME_ELAPSED = "checkpointTimeElapsed";
+
+    /**
      * Metric representing the count of write timeouts to a Buffer
      */
     public static final String WRITE_TIMEOUTS = "writeTimeouts";

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
@@ -26,7 +26,7 @@ public class MetricNames {
     public static final String RECORDS_WRITTEN = "recordsWritten";
 
     /**
-     * Metric representing the number of records read from a buffer
+     * Metric representing the number of records read from a buffer.
      */
     public static final String RECORDS_READ = "recordsRead";
 

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
@@ -26,6 +26,11 @@ public class MetricNames {
     public static final String RECORDS_WRITTEN = "recordsWritten";
 
     /**
+     * Metric representing the number of records read from a buffer.
+     */
+    public static final String RECORDS_READ = "recordsRead";
+
+    /**
      * Metric representing the number of records read from a buffer but unchecked.
      */
     public static final String RECORDS_INFLIGHT = "recordsInflight";

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
@@ -33,12 +33,12 @@ public class MetricNames {
     /**
      * Metric representing the number of records read from a buffer but unchecked.
      */
-    public static final String RECORDS_INFLIGHT = "recordsInflight";
+    public static final String RECORDS_INFLIGHT = "recordsInFlight";
 
     /**
-     * Metric representing the number of records read from a buffer and checked.
+     * Metric representing the number of records read from a buffer and processed by the pipeline.
      */
-    public static final String RECORDS_CHECKED = "recordsChecked";
+    public static final String RECORDS_PROCESSED = "recordsProcessed";
 
     /**
      * Metric representing the time elapsed while writing to a Buffer

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
@@ -38,7 +38,7 @@ public class MetricNames {
     /**
      * Metric representing the number of records read from a buffer and checked.
      */
-    public static final String RECORDS_PROCESSED = "recordsProcessed";
+    public static final String RECORDS_CHECKED = "recordsChecked";
 
     /**
      * Metric representing the time elapsed while writing to a Buffer

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
@@ -26,7 +26,7 @@ public class MetricNames {
     public static final String RECORDS_WRITTEN = "recordsWritten";
 
     /**
-     * Metric representing the number of records read from a buffer.
+     * Metric representing the number of records read from a buffer
      */
     public static final String RECORDS_READ = "recordsRead";
 

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
@@ -26,9 +26,14 @@ public class MetricNames {
     public static final String RECORDS_WRITTEN = "recordsWritten";
 
     /**
-     * Metric representing the number of records read from a buffer
+     * Metric representing the number of records read from a buffer but unchecked.
      */
-    public static final String RECORDS_READ = "recordsRead";
+    public static final String RECORDS_INFLIGHT = "recordsInflight";
+
+    /**
+     * Metric representing the number of records read from a buffer and checked.
+     */
+    public static final String RECORDS_PROCESSED = "recordsProcessed";
 
     /**
      * Metric representing the time elapsed while writing to a Buffer

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/PluginMetrics.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/PluginMetrics.java
@@ -38,8 +38,8 @@ public class PluginMetrics {
         return Metrics.counter(getMeterName(name));
     }
 
-    public Counter counter(final String name, final String pipelineName) {
-        return Metrics.counter(new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(name).toString());
+    public Counter counter(final String name, final String metricsPrefix) {
+        return Metrics.counter(new StringJoiner(MetricNames.DELIMITER).add(metricsPrefix).add(name).toString());
     }
 
     public Timer timer(final String name) {

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/PluginMetrics.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/PluginMetrics.java
@@ -38,6 +38,10 @@ public class PluginMetrics {
         return Metrics.counter(getMeterName(name));
     }
 
+    public Counter counter(final String name, final String pipelineName) {
+        return Metrics.counter(new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(name).toString());
+    }
+
     public Timer timer(final String name) {
         return Metrics.timer(getMeterName(name));
     }

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/CheckpointState.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/CheckpointState.java
@@ -4,13 +4,13 @@ package com.amazon.dataprepper.model;
  * CheckpointState keeps track of a summary of records processed by a data-prepper worker thread.
  */
 public class CheckpointState {
-    private final int numCheckedRecords;
+    private final int numRecordsToBeChecked;
 
-    public CheckpointState(final int numCheckedRecords) {
-        this.numCheckedRecords = numCheckedRecords;
+    public CheckpointState(final int numRecordsToBeChecked) {
+        this.numRecordsToBeChecked = numRecordsToBeChecked;
     }
 
-    public int getNumCheckedRecords() {
-        return numCheckedRecords;
+    public int getNumRecordsToBeChecked() {
+        return numRecordsToBeChecked;
     }
 }

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
@@ -21,7 +21,7 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
     private final Counter recordsWrittenCounter;
     private final Counter recordsReadCounter;
     private final AtomicLong recordsInflight;
-    private final Counter recordsProcessedCounter;
+    private final Counter recordsCheckedCounter;
     private final Counter writeTimeoutCounter;
     private final Timer writeTimer;
     private final Timer readTimer;
@@ -40,7 +40,7 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
         this.recordsWrittenCounter = pluginMetrics.counter(MetricNames.RECORDS_WRITTEN);
         this.recordsReadCounter = pluginMetrics.counter(MetricNames.RECORDS_READ);
         this.recordsInflight = pluginMetrics.gauge(MetricNames.RECORDS_INFLIGHT, new AtomicLong());
-        this.recordsProcessedCounter = pluginMetrics.counter(MetricNames.RECORDS_PROCESSED);
+        this.recordsCheckedCounter = pluginMetrics.counter(MetricNames.RECORDS_CHECKED);
         this.writeTimeoutCounter = pluginMetrics.counter(MetricNames.WRITE_TIMEOUTS);
         this.writeTimer = pluginMetrics.timer(MetricNames.WRITE_TIME_ELAPSED);
         this.readTimer = pluginMetrics.timer(MetricNames.READ_TIME_ELAPSED);
@@ -94,7 +94,7 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
         checkpointTimer.record(() -> doCheckpoint(checkpointState));
         final int numRecordsToBeChecked = checkpointState.getNumRecordsToBeChecked();
         recordsInflight.addAndGet(-numRecordsToBeChecked);
-        recordsProcessedCounter.increment(numRecordsToBeChecked);
+        recordsCheckedCounter.increment(numRecordsToBeChecked);
     }
 
     /**

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
@@ -78,15 +78,16 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
     @Override
     public Map.Entry<Collection<T>, CheckpointState> read(int timeoutInMillis) {
         final Map.Entry<Collection<T>, CheckpointState> readResult = readTimer.record(() -> doRead(timeoutInMillis));
-        recordsInflightCounter.increment(readResult.getValue().getNumCheckedRecords()*1.0);
+        recordsInflightCounter.increment(readResult.getValue().getNumRecordsToBeChecked()*1.0);
         return readResult;
     }
 
     @Override
     public void checkpoint(final CheckpointState checkpointState) {
         doCheckpoint(checkpointState);
-        recordsInflightCounter.increment(-checkpointState.getNumCheckedRecords());
-        recordsProcessedCounter.increment(checkpointState.getNumCheckedRecords());
+        final int numRecordsToBeChecked = checkpointState.getNumRecordsToBeChecked();
+        recordsInflightCounter.increment(-numRecordsToBeChecked);
+        recordsProcessedCounter.increment(numRecordsToBeChecked);
     }
 
     /**

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
@@ -22,6 +22,7 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
     private final Counter writeTimeoutCounter;
     private final Timer writeTimer;
     private final Timer readTimer;
+    private final Timer checkpointTimer;
 
     public AbstractBuffer(final PluginSetting pluginSetting) {
         this(PluginMetrics.fromPluginSetting(pluginSetting));
@@ -39,6 +40,7 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
         this.writeTimeoutCounter = pluginMetrics.counter(MetricNames.WRITE_TIMEOUTS);
         this.writeTimer = pluginMetrics.timer(MetricNames.WRITE_TIME_ELAPSED);
         this.readTimer = pluginMetrics.timer(MetricNames.READ_TIME_ELAPSED);
+        this.checkpointTimer = pluginMetrics.timer(MetricNames.CHECKPOINT_TIME_ELAPSED);
     }
 
     /**
@@ -84,7 +86,7 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
 
     @Override
     public void checkpoint(final CheckpointState checkpointState) {
-        doCheckpoint(checkpointState);
+        checkpointTimer.record(() -> doCheckpoint(checkpointState));
         final int numRecordsToBeChecked = checkpointState.getNumRecordsToBeChecked();
         recordsInflightCounter.increment(-numRecordsToBeChecked);
         recordsProcessedCounter.increment(numRecordsToBeChecked);

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
@@ -28,19 +28,19 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
     private final Timer checkpointTimer;
 
     public AbstractBuffer(final PluginSetting pluginSetting) {
-        this(PluginMetrics.fromPluginSetting(pluginSetting));
+        this(PluginMetrics.fromPluginSetting(pluginSetting), pluginSetting.getPipelineName());
     }
 
     public AbstractBuffer(final String bufferName, final String pipelineName) {
-        this(PluginMetrics.fromNames(bufferName, pipelineName));
+        this(PluginMetrics.fromNames(bufferName, pipelineName), pipelineName);
     }
 
-    private AbstractBuffer(final PluginMetrics pluginMetrics) {
+    private AbstractBuffer(final PluginMetrics pluginMetrics, final String pipelineName) {
         this.pluginMetrics = pluginMetrics;
         this.recordsWrittenCounter = pluginMetrics.counter(MetricNames.RECORDS_WRITTEN);
         this.recordsReadCounter = pluginMetrics.counter(MetricNames.RECORDS_READ);
         this.recordsInflight = pluginMetrics.gauge(MetricNames.RECORDS_INFLIGHT, new AtomicLong());
-        this.recordsCheckedCounter = pluginMetrics.counter(MetricNames.RECORDS_CHECKED);
+        this.recordsCheckedCounter = pluginMetrics.counter(MetricNames.RECORDS_CHECKED, pipelineName);
         this.writeTimeoutCounter = pluginMetrics.counter(MetricNames.WRITE_TIMEOUTS);
         this.writeTimer = pluginMetrics.timer(MetricNames.WRITE_TIME_ELAPSED);
         this.readTimer = pluginMetrics.timer(MetricNames.READ_TIME_ELAPSED);

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/metrics/PluginMetricsTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/metrics/PluginMetricsTest.java
@@ -30,6 +30,15 @@ public class PluginMetricsTest {
     }
 
     @Test
+    public void testPipelineLevelCounter() {
+        final Counter counter = PLUGIN_METRICS.counter("counter", PIPELINE_NAME);
+        Assert.assertEquals(
+                new StringJoiner(MetricNames.DELIMITER)
+                        .add(PIPELINE_NAME).add("counter").toString(),
+                counter.getId().getName());
+    }
+
+    @Test
     public void testTimer() {
         final Timer counter = PLUGIN_METRICS.timer("timer");
         Assert.assertEquals(

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/metrics/PluginMetricsTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/metrics/PluginMetricsTest.java
@@ -30,7 +30,7 @@ public class PluginMetricsTest {
     }
 
     @Test
-    public void testPipelineLevelCounter() {
+    public void testCustomMetricsPrefixCounter() {
         final Counter counter = PLUGIN_METRICS.counter("counter", PIPELINE_NAME);
         Assert.assertEquals(
                 new StringJoiner(MetricNames.DELIMITER)

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/CheckpointStateTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/CheckpointStateTest.java
@@ -10,6 +10,6 @@ public class CheckpointStateTest {
     @Test
     public void testSimple() {
         final CheckpointState checkpointState = new CheckpointState(TEST_NUM_CHECKED_RECORDS);
-        assertEquals(TEST_NUM_CHECKED_RECORDS, checkpointState.getNumCheckedRecords());
+        assertEquals(TEST_NUM_CHECKED_RECORDS, checkpointState.getNumRecordsToBeChecked());
     }
 }

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
@@ -43,6 +43,8 @@ public class AbstractBufferTest {
         // Then
         final List<Measurement> recordsWrittenMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_WRITTEN).toString());
+        final List<Measurement> recordsReadMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_READ).toString());
         final List<Measurement> recordsInflightMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_INFLIGHT).toString());
         final List<Measurement> recordsProcessedMeasurements = MetricsTestUtil.getMeasurementList(
@@ -55,6 +57,8 @@ public class AbstractBufferTest {
                 new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.CHECKPOINT_TIME_ELAPSED).toString());
         Assert.assertEquals(1, recordsWrittenMeasurements.size());
         Assert.assertEquals(5.0, recordsWrittenMeasurements.get(0).getValue(), 0);
+        Assert.assertEquals(1, recordsReadMeasurements.size());
+        Assert.assertEquals(5.0, recordsReadMeasurements.get(0).getValue(), 0);
         Assert.assertEquals(1, recordsInflightMeasurements.size());
         final Measurement recordsInflightMeasurement = recordsInflightMeasurements.get(0);
         Assert.assertEquals(5.0, recordsInflightMeasurement.getValue(), 0);

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
@@ -48,7 +48,7 @@ public class AbstractBufferTest {
         final List<Measurement> recordsInflightMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_INFLIGHT).toString());
         final List<Measurement> recordsCheckedMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_CHECKED).toString());
+                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(MetricNames.RECORDS_CHECKED).toString());
         final List<Measurement> writeTimeMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.WRITE_TIME_ELAPSED).toString());
         final List<Measurement> readTimeMeasurements = MetricsTestUtil.getMeasurementList(

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
@@ -51,6 +51,8 @@ public class AbstractBufferTest {
                 new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.WRITE_TIME_ELAPSED).toString());
         final List<Measurement> readTimeMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.READ_TIME_ELAPSED).toString());
+        final List<Measurement> checkpointTimeMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.CHECKPOINT_TIME_ELAPSED).toString());
         Assert.assertEquals(1, recordsWrittenMeasurements.size());
         Assert.assertEquals(5.0, recordsWrittenMeasurements.get(0).getValue(), 0);
         Assert.assertEquals(1, recordsInflightMeasurements.size());
@@ -70,6 +72,8 @@ public class AbstractBufferTest {
                 MetricsTestUtil.getMeasurementFromList(readTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
                 0.1,
                 0.2));
+        Assert.assertEquals(0.0, MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.COUNT).getValue(), 0);
+        Assert.assertEquals(0.0, MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.TOTAL_TIME).getValue(), 0);
 
         // When
         abstractBuffer.checkpoint(readResult.getValue());
@@ -77,6 +81,11 @@ public class AbstractBufferTest {
         // Then
         Assert.assertEquals(0.0, recordsInflightMeasurement.getValue(), 0);
         Assert.assertEquals(5.0, recordsProcessedMeasurement.getValue(), 0);
+        Assert.assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.COUNT).getValue(), 0);
+        Assert.assertTrue(MetricsTestUtil.isBetween(
+                MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.TOTAL_TIME).getValue(),
+                0.0,
+                0.001));
     }
 
     @Test

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
@@ -45,10 +45,10 @@ public class AbstractBufferTest {
                 new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_WRITTEN).toString());
         final List<Measurement> recordsReadMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_READ).toString());
-        final List<Measurement> recordsInflightMeasurements = MetricsTestUtil.getMeasurementList(
+        final List<Measurement> recordsInFlightMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_INFLIGHT).toString());
-        final List<Measurement> recordsCheckedMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(MetricNames.RECORDS_CHECKED).toString());
+        final List<Measurement> recordsProcessedMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(MetricNames.RECORDS_PROCESSED).toString());
         final List<Measurement> writeTimeMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.WRITE_TIME_ELAPSED).toString());
         final List<Measurement> readTimeMeasurements = MetricsTestUtil.getMeasurementList(
@@ -59,12 +59,12 @@ public class AbstractBufferTest {
         Assert.assertEquals(5.0, recordsWrittenMeasurements.get(0).getValue(), 0);
         Assert.assertEquals(1, recordsReadMeasurements.size());
         Assert.assertEquals(5.0, recordsReadMeasurements.get(0).getValue(), 0);
-        Assert.assertEquals(1, recordsInflightMeasurements.size());
-        final Measurement recordsInflightMeasurement = recordsInflightMeasurements.get(0);
-        Assert.assertEquals(5.0, recordsInflightMeasurement.getValue(), 0);
-        Assert.assertEquals(1, recordsCheckedMeasurements.size());
-        final Measurement recordsCheckedMeasurement = recordsCheckedMeasurements.get(0);
-        Assert.assertEquals(0.0, recordsCheckedMeasurement.getValue(), 0);
+        Assert.assertEquals(1, recordsInFlightMeasurements.size());
+        final Measurement recordsInFlightMeasurement = recordsInFlightMeasurements.get(0);
+        Assert.assertEquals(5.0, recordsInFlightMeasurement.getValue(), 0);
+        Assert.assertEquals(1, recordsProcessedMeasurements.size());
+        final Measurement recordsProcessedMeasurement = recordsProcessedMeasurements.get(0);
+        Assert.assertEquals(0.0, recordsProcessedMeasurement.getValue(), 0);
         Assert.assertEquals(5.0, MetricsTestUtil.getMeasurementFromList(writeTimeMeasurements, Statistic.COUNT).getValue(), 0);
         Assert.assertTrue(
                 MetricsTestUtil.isBetween(
@@ -83,8 +83,8 @@ public class AbstractBufferTest {
         abstractBuffer.checkpoint(readResult.getValue());
 
         // Then
-        Assert.assertEquals(0.0, recordsInflightMeasurement.getValue(), 0);
-        Assert.assertEquals(5.0, recordsCheckedMeasurement.getValue(), 0);
+        Assert.assertEquals(0.0, recordsInFlightMeasurement.getValue(), 0);
+        Assert.assertEquals(5.0, recordsProcessedMeasurement.getValue(), 0);
         Assert.assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.COUNT).getValue(), 0);
         Assert.assertTrue(MetricsTestUtil.isBetween(
                 MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.TOTAL_TIME).getValue(),

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
@@ -47,8 +47,8 @@ public class AbstractBufferTest {
                 new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_READ).toString());
         final List<Measurement> recordsInflightMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_INFLIGHT).toString());
-        final List<Measurement> recordsProcessedMeasurements = MetricsTestUtil.getMeasurementList(
-                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_PROCESSED).toString());
+        final List<Measurement> recordsCheckedMeasurements = MetricsTestUtil.getMeasurementList(
+                new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.RECORDS_CHECKED).toString());
         final List<Measurement> writeTimeMeasurements = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add(pipelineName).add(bufferName).add(MetricNames.WRITE_TIME_ELAPSED).toString());
         final List<Measurement> readTimeMeasurements = MetricsTestUtil.getMeasurementList(
@@ -62,9 +62,9 @@ public class AbstractBufferTest {
         Assert.assertEquals(1, recordsInflightMeasurements.size());
         final Measurement recordsInflightMeasurement = recordsInflightMeasurements.get(0);
         Assert.assertEquals(5.0, recordsInflightMeasurement.getValue(), 0);
-        Assert.assertEquals(1, recordsProcessedMeasurements.size());
-        final Measurement recordsProcessedMeasurement = recordsProcessedMeasurements.get(0);
-        Assert.assertEquals(0.0, recordsProcessedMeasurement.getValue(), 0);
+        Assert.assertEquals(1, recordsCheckedMeasurements.size());
+        final Measurement recordsCheckedMeasurement = recordsCheckedMeasurements.get(0);
+        Assert.assertEquals(0.0, recordsCheckedMeasurement.getValue(), 0);
         Assert.assertEquals(5.0, MetricsTestUtil.getMeasurementFromList(writeTimeMeasurements, Statistic.COUNT).getValue(), 0);
         Assert.assertTrue(
                 MetricsTestUtil.isBetween(
@@ -84,7 +84,7 @@ public class AbstractBufferTest {
 
         // Then
         Assert.assertEquals(0.0, recordsInflightMeasurement.getValue(), 0);
-        Assert.assertEquals(5.0, recordsProcessedMeasurement.getValue(), 0);
+        Assert.assertEquals(5.0, recordsCheckedMeasurement.getValue(), 0);
         Assert.assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.COUNT).getValue(), 0);
         Assert.assertTrue(MetricsTestUtil.isBetween(
                 MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.TOTAL_TIME).getValue(),

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/buffer/BlockingBuffer.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/buffer/BlockingBuffer.java
@@ -141,7 +141,7 @@ public class BlockingBuffer<T extends Record<?>> extends AbstractBuffer<T> {
     }
 
     @Override
-    public void checkpoint(final CheckpointState checkpointState) {
+    public void doCheckpoint(final CheckpointState checkpointState) {
         final int numCheckedRecords = checkpointState.getNumCheckedRecords();
         capacitySemaphore.release(numCheckedRecords);
     }

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/buffer/BlockingBuffer.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/buffer/BlockingBuffer.java
@@ -142,7 +142,7 @@ public class BlockingBuffer<T extends Record<?>> extends AbstractBuffer<T> {
 
     @Override
     public void doCheckpoint(final CheckpointState checkpointState) {
-        final int numCheckedRecords = checkpointState.getNumCheckedRecords();
+        final int numCheckedRecords = checkpointState.getNumRecordsToBeChecked();
         capacitySemaphore.release(numCheckedRecords);
     }
 }

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/buffer/BlockingBufferTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/buffer/BlockingBufferTests.java
@@ -127,7 +127,7 @@ public class BlockingBufferTests {
         final CheckpointState partialCheckpointState = partialReadResult.getValue();
         final int expectedBatchSize = (Integer) completePluginSetting.getAttributeFromSettings(ATTRIBUTE_BATCH_SIZE);
         assertThat(partialRecords.size(), is(expectedBatchSize));
-        assertEquals(expectedBatchSize, partialCheckpointState.getNumCheckedRecords());
+        assertEquals(expectedBatchSize, partialCheckpointState.getNumRecordsToBeChecked());
         int i = 0;
         for (Record<String> record : partialRecords) {
             assertThat(record.getData(), equalTo("TEST" + i));
@@ -137,7 +137,7 @@ public class BlockingBufferTests {
         final Collection<Record<String>> finalBatch = finalReadResult.getKey();
         final CheckpointState finalCheckpointState = finalReadResult.getValue();
         assertThat(finalBatch.size(), is(testSize - expectedBatchSize));
-        assertEquals(testSize - expectedBatchSize, finalCheckpointState.getNumCheckedRecords());
+        assertEquals(testSize - expectedBatchSize, finalCheckpointState.getNumRecordsToBeChecked());
         for (Record<String> record : finalBatch) {
             assertThat(record.getData(), equalTo("TEST" + i));
             i++;

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -121,7 +121,7 @@ public class OTelTraceSourceTest {
         CheckpointState checkpointState = drainedBufferResult.getValue();
         assertThat(drainedBuffer.size()).isEqualTo(1);
         assertThat(drainedBuffer.get(0).getData()).isEqualTo(SUCCESS_REQUEST);
-        assertEquals(1, checkpointState.getNumCheckedRecords());
+        assertEquals(1, checkpointState.getNumRecordsToBeChecked());
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR introduces the following metrics in AbstractBuffer

- recordsInflightCounter
- recordsProcessedCounter (checkpointed records)
- checkpointTimer

and removes the recordsReadCounter as now it breaks down into recordsInflightCount + recordsProcessedCount

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
