### PR TITLE
Added initial EC2 CFN template.

### DIFF
--- a/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
+++ b/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
@@ -5,30 +5,30 @@ Parameters:
   AWSElasticsearchEndpoint:
     Description: Endpoint of the AWS Elasticsearch Service domain (including https://)
     Type: String
-    AllowedPattern: .+
-    ConstraintDescription: cannot be empty
+    AllowedPattern: https:\/\/[a-z0-9-\.]+(es.amazonaws.com)
+    ConstraintDescription: must be a valid Amazon Elasticsearch Service domain endpoint starting with https://
   AWSElasticsearchRegion:
     Description: Region of the AWS Elasticsearch Service domain
     Type: String
-    AllowedPattern: .+
+    AllowedPattern: "[a-z]+-[a-z]+-[0-9]+"
     Default: us-east-1
-    ConstraintDescription: cannot be empty
+    ConstraintDescription: must be a valid AWS region (e.g. us-west-2)
   DataPrepperVersion:
     Description: Version of Data Prepper to download and run
     Type: String
-    AllowedPattern: .+
+    AllowedPattern: "[0-9]+\\.[0-9]+\\.[0-9]+[a-z-]*"
     Default: 0.7.1-alpha
-    ConstraintDescription: cannot be empty
+    ConstraintDescription: must be a valid release number
   IAMRole:
     Description: Pre-existing IAM Role to associate with the EC2 instance, to be used for authentication when calling Elasticsearch
     Type: String
-    AllowedPattern: .+
+    AllowedPattern: "[a-zA-Z0-9+=,\\.@\\-_]+"
     Default: DataPrepperRole
-    ConstraintDescription: cannot be empty
+    ConstraintDescription: must be a valid IAM role name
   InstanceType:
     Description: EC2 instance type
     Type: String
-    AllowedPattern: .+
+    AllowedPattern: "[a-z0-9]+\\.[a-z0-9]+"
     Default: t2.medium
     ConstraintDescription: cannot be empty
   KeyName:

--- a/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
+++ b/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
@@ -1,0 +1,134 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Template to install Data Prepper on a single EC2 instance"
+Parameters:
+  AWSElasticsearchEndpoint:
+    Description: Endpoint of the AWS Elasticsearch Service domain (including https://)
+    Type: String
+    AllowedPattern: .+
+    ConstraintDescription: cannot be empty
+  AWSElasticsearchRegion:
+    Description: Region of the AWS Elasticsearch Service domain
+    Type: String
+    AllowedPattern: .+
+    Default: us-east-1
+    ConstraintDescription: cannot be empty
+  DataPrepperVersion:
+    Description: Version of Data Prepper to download and run
+    Type: String
+    AllowedPattern: .+
+    Default: 0.7.1-alpha
+    ConstraintDescription: cannot be empty
+  IAMRole:
+    Description: Pre-existing IAM Role to associate with the EC2 instance, to be used for authentication when calling Elasticsearch
+    Type: String
+    AllowedPattern: .+
+    Default: DataPrepperRole
+    ConstraintDescription: cannot be empty
+  InstanceType:
+    Description: EC2 instance type
+    Type: String
+    AllowedPattern: .+
+    Default: t2.medium
+    ConstraintDescription: cannot be empty
+  KeyName:
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
+    Type: AWS::EC2::KeyPair::KeyName
+    ConstraintDescription: cannot be empty
+  LatestAmi:
+    Description: AMI to deploy to EC2, defaults to Amazon Linux 2
+    Type: "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
+    Default: "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-ebs"
+  SSHLocation:
+    Description: The IP address range that can be used to SSH to the EC2 instances
+    Type: String
+    MinLength: "9"
+    MaxLength: "18"
+    Default: 0.0.0.0/0
+    AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
+    ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
+Resources:
+  EC2Instance:
+    Type: AWS::EC2::Instance
+    Metadata:
+      AWS::CloudFormation::Init:
+        configSets:
+          default:
+            - 01_config-data-prepper
+        01_config-data-prepper:
+          files:
+            "/etc/data-prepper/config.yaml":
+              content: !Sub |
+                entry-pipeline:
+                  delay: "100"
+                  source:
+                    otel_trace_source:
+                  sink:
+                    - pipeline:
+                        name: "raw-pipeline"
+                    - pipeline:
+                        name: "service-map-pipeline"
+                raw-pipeline:
+                  source:
+                    pipeline:
+                      name: "entry-pipeline"
+                  processor:
+                    - otel_trace_raw_processor:
+                  sink:
+                    - elasticsearch:
+                        hosts: [ "${AWSElasticsearchEndpoint}" ]
+                        aws_sigv4: true
+                        aws_region: "${AWSElasticsearchRegion}"
+                        trace_analytics_raw: true
+                service-map-pipeline:
+                  delay: "100"
+                  source:
+                    pipeline:
+                      name: "entry-pipeline"
+                  processor:
+                    - service_map_stateful:
+                  sink:
+                    - elasticsearch:
+                        hosts: [ "${AWSElasticsearchEndpoint}" ]
+                        aws_sigv4: true
+                        aws_region: "${AWSElasticsearchRegion}"
+                        trace_analytics_service_map: true
+              mode: "000400"
+              owner: root
+              group: root
+    Properties:
+      InstanceType:
+        Ref: InstanceType
+      IamInstanceProfile:
+        Ref: IAMRole
+      KeyName:
+        Ref: KeyName
+      ImageId:
+        Ref: LatestAmi
+      SecurityGroups:
+        - Ref: InstanceSecurityGroup
+      UserData:
+        # Script to download and run Data Prepper
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          export RELEASE=opendistroforelasticsearch-data-prepper-${DataPrepperVersion}-linux-x64
+          yum install java-11-amazon-corretto-headless -y
+          wget https://github.com/opendistro-for-elasticsearch/data-prepper/releases/download/${DataPrepperVersion}/$RELEASE.tar.gz -O /tmp/$RELEASE.tar.gz
+          tar -xzf /tmp/$RELEASE.tar.gz --directory /usr/local/bin
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
+          nohup /usr/local/bin/$RELEASE/data-prepper-tar-install.sh /etc/data-prepper/config.yaml > /var/log/data-prepper.out &
+          /opt/aws/bin/cfn-signal --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+    CreationPolicy:
+      ResourceSignal:
+        Count: 1
+        Timeout: "PT15M"
+  InstanceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Enable SSH access via port 22
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: "22"
+          ToPort: "22"
+          CidrIp:
+            Ref: SSHLocation


### PR DESCRIPTION
*Description of changes:*

Adding initial CFN template. Tested against a public AWS ES instance with an IAM role access policy. Still need to test w/ VPC, and potentially update the Data Prepper config default values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
