### PR TITLE
Added Jaeger HotROD on EC2 setup script.

### DIFF
--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -1,0 +1,2 @@
+## AWS Examples
+This directory contains AWS-specific sample content (e.g. running on EC2).

--- a/examples/aws/jaeger-hotrod-on-ec2/README.md
+++ b/examples/aws/jaeger-hotrod-on-ec2/README.md
@@ -1,0 +1,8 @@
+## Jaeger Hot R.O.D. on EC2
+This directory contains a script to setup install and run the Jaeger Hot R.O.D. sample application
+using [Docker](https://docs.docker.com/) and [Docker Compose](https://docs.docker.com/compose/).
+
+The script downloads/installs Docker and Docker Compose, writes necessary application configuration files, then creates the following containers:
+1. [Jaeger HotROD](https://github.com/jaegertracing/jaeger/tree/master/examples/hotrod) - the example application to generate trace data
+2. [Jaeger Agent](https://www.jaegertracing.io/docs/1.21/architecture/#agent) - a network daemon which batches trace spans and sends to the collector
+3. [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) - a vendor-agnostic implementation on how to receive, process and export telemetry data

--- a/examples/aws/jaeger-hotrod-on-ec2/setup-jaeger-hotrod.sh
+++ b/examples/aws/jaeger-hotrod-on-ec2/setup-jaeger-hotrod.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Script to install and run the Jaeger Hot R.O.D. sample application.
+# Installs docker, docker-compose, writes configuration files, then runs 'docker-compose up'
+
+sudo yum install docker -y
+sudo usermod -aG docker $USER
+sudo systemctl start docker
+sudo curl -L "https://github.com/docker/compose/releases/download/1.28.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+
+cat <<EOT >> otel-collector-config.yml
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+
+exporters:
+  otlp/2:
+    endpoint: localhost:21890
+    insecure: true
+  logging:
+
+service:
+  pipelines:
+    traces:
+      receivers: [jaeger]
+      exporters: [logging, otlp/2]
+
+EOT
+
+cat <<EOT >> docker-compose.yml
+version: "3.7"
+services:
+  otel-collector:
+    container_name: otel-collector
+    network_mode: host
+    image: otel/opentelemetry-collector:0.14.0
+    command: [ "--config=/etc/otel-collector-config.yml" ]
+    volumes:
+      - ./otel-collector-config.yml:/etc/otel-collector-config.yml
+  jaeger-agent:
+    container_name: jaeger-agent
+    network_mode: host
+    image: jaegertracing/jaeger-agent:latest
+    command: [ "--reporter.grpc.host-port=localhost:14250" ]
+  jaeger-hot-rod:
+    container_name: jaeger-hotrod
+    image: jaegertracing/example-hotrod:latest
+    network_mode: host
+    command: [ "all" ]
+    environment:
+      - JAEGER_AGENT_HOST=localhost
+      - JAEGER_AGENT_PORT=6831
+    depends_on:
+      - jaeger-agent
+
+EOT
+
+sudo /usr/local/bin/docker-compose up -d

--- a/examples/aws/jaeger-hotrod-on-ec2/setup-jaeger-hotrod.sh
+++ b/examples/aws/jaeger-hotrod-on-ec2/setup-jaeger-hotrod.sh
@@ -68,4 +68,6 @@ services:
 
 EOT
 
+# Run Docker compose to start the HotROD application
+# The application can be shut down and cleaned up later by running `sudo /usr/local/bin/docker-compose down`
 sudo /usr/local/bin/docker-compose up -d

--- a/examples/aws/jaeger-hotrod-on-ec2/setup-jaeger-hotrod.sh
+++ b/examples/aws/jaeger-hotrod-on-ec2/setup-jaeger-hotrod.sh
@@ -2,12 +2,21 @@
 # Script to install and run the Jaeger Hot R.O.D. sample application.
 # Installs docker, docker-compose, writes configuration files, then runs 'docker-compose up'
 
+# Install Docker
 sudo yum install docker -y
+
+# Remove need for sudo when running docker commands
 sudo usermod -aG docker $USER
+
+# Start the docker dameon
 sudo systemctl start docker
+
+# Download docker-compose 1.28.2 and make it executable
 sudo curl -L "https://github.com/docker/compose/releases/download/1.28.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 
+# Write an OpenTelemetry Collector configuration file to receive from Jaeger and export to Data Prepper
+# See more documentation at https://opentelemetry.io/docs/collector/configuration/
 cat <<EOT >> otel-collector-config.yml
 receivers:
   jaeger:
@@ -28,6 +37,9 @@ service:
 
 EOT
 
+# Write a Docker Compose file necessary to stand up the HotROD application, a Jaeger agent,
+# and an OpenTelemetry Collector.
+# See more HotROD documentation at https://github.com/jaegertracing/jaeger/tree/master/examples/hotrod
 cat <<EOT >> docker-compose.yml
 version: "3.7"
 services:


### PR DESCRIPTION
*Description of changes:*
We want to allow users to quickly setup a sample Jaeger app to emit trace data for Data Prepper to consume so they can try out the new trace analytics plugin.

* Added an /examples/aws directory for AWS-specific content
* Added a single bash script to install necessary components for running the HotROD app via docker-compose
  * Users will run `sh setup-jaeger-hotrod.sh` to stand up a working application
* I'll add readme's to the new aws and jaeger directories in a follow-up. 


The alternative to a setup script is giving the user a series of steps like:
1. Install Docker
1. Install Docker Compose
1. Clone this repo
1. Navigate to /examples/aws/<something>
1. Run `docker-compose up -d`

This setup script is extremely focused and hides the technical details, but I think that's ok for this usecase. Open to thoughts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
