### PR TITLE
Fixed minor typo in log4j properties file.

### DIFF
--- a/examples/dev/trace-analytics-sample-app/resources/data-prepper-wait-for-odfe-and-start.sh
+++ b/examples/dev/trace-analytics-sample-app/resources/data-prepper-wait-for-odfe-and-start.sh
@@ -5,4 +5,4 @@ until [[ $(curl --write-out %{http_code} --output /dev/null --silent --head --fa
   sleep 1
 done
 
-java -Xms128m -Xmx128m -jar data-prepper.jar data-prepper.yml
+java -Dlog4j.configurationFile=log4j.properties -Xms128m -Xmx128m -jar data-prepper.jar data-prepper.yml

--- a/shared-config/log4j.properties
+++ b/shared-config/log4j.properties
@@ -1,5 +1,5 @@
 # Logging Level
-log4j.rootLogger=ERROR, CONSOLE
+log4j.rootLogger=WARN, CONSOLE
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.Threshold=INFO
@@ -17,4 +17,4 @@ log4j.appender.file.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %40C - %m%n
 #package specific levels
 log4j.logger.com.amazon.dataprepper.pipeline=INFO
 log4j.logger.com.amazon.dataprepper.parser=INFO
-log4j.logger.com.amazon.dataprepper.plugin=INFO
+log4j.logger.com.amazon.dataprepper.plugins=INFO


### PR DESCRIPTION
*Description of changes:*
1. Fixed typo in log4j properties file (`plugin` to `plugins`)
2. Reduced logging threshold from ERROR to WARN to not hide Armeria warnings
    * I didn't see an increase in log noise, but if it does become too noisy then we can just elevate `com.linecorp.armeria.client` instead
3. Fixed the dev example app not passing in the log4j file on startup


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
