### PR TITLE
#309: Adding Dependabot for automated dependency upgrades. Starting w…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: "/data-prepper-core"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 3

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -15,16 +15,16 @@ apply from: "integrationTest.gradle"
 dependencies {
     compile project(':data-prepper-api')
     compile project(':data-prepper-plugins')
-    implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versionMap.jackson_dataformat_yaml}"
-    implementation "javax.validation:validation-api:${versionMap.validation_api}"
-    implementation "org.apache.bval:bval-extras:${versionMap.bval_extras}"
-    implementation "org.apache.bval:bval-jsr:${versionMap.bval_jsr}"
-    implementation "org.reflections:reflections:${versionMap.reflections}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.10.0"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.1"
+    implementation "javax.validation:validation-api:2.0.1.Final"
+    implementation "org.apache.bval:bval-extras:2.0.4"
+    implementation "org.apache.bval:bval-jsr:2.0.4"
+    implementation "org.reflections:reflections:0.9.11"
     implementation "io.micrometer:micrometer-core:1.5.1"
     implementation "io.micrometer:micrometer-registry-prometheus:1.5.1"
-    testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
-    testImplementation "org.mockito:mockito-core:${versionMap.mockito}"
+    testImplementation "org.hamcrest:hamcrest:2.2"
+    testImplementation "org.mockito:mockito-core:2.1.0"
 }
 
 jar {


### PR DESCRIPTION
…ith just data-prepper-core package.

*Issue #, if available:* #309

*Description of changes:*
Continuation of [pull 310](https://github.com/opendistro-for-elasticsearch/data-prepper/pull/310) which I closed a bit too early. Will add automated scanning to one package at a time, slowly phasing out the dependency version map we were using previously.

[Here](https://github.com/wrijeff/simple-ingest-transformation-utility-pipeline/pulls) are the 3 PRs opened by the bot on my fork for this change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
