### PR TITLE
308: Enabling TLS by default in OTelTraceSource and PeerForwarder.

### DIFF
--- a/data-prepper-core/src/integrationTest/resources/pipeline.yml
+++ b/data-prepper-core/src/integrationTest/resources/pipeline.yml
@@ -1,10 +1,12 @@
 entry-pipeline:
   source:
     otel_trace_source:
+      ssl: false
   prepper:
     - peer_forwarder:
         discovery_mode: "static"
         static_endpoints: ["data-prepper1", "data-prepper2"]
+        ssl: false
   sink:
     - pipeline:
         name: "raw-pipeline"

--- a/data-prepper-plugins/otel-trace-source/README.md
+++ b/data-prepper-plugins/otel-trace-source/README.md
@@ -13,7 +13,7 @@ source:
 * request_timeout => Default is ```10_000``` millis.
 * health_check_service => This will enable a gRPC health check service under ```grpc.health.v1 / Health / Check```. Default is ```false```.
 * proto_reflection_service => This will enable a reflection service for Protobuf services (see [ProtoReflectionService](https://grpc.github.io/grpc-java/javadoc/io/grpc/protobuf/services/ProtoReflectionService.html) and [gRPC reflection](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md) docs). Default is ```false```.
-* ssl => Default is ```false```.
+* ssl => Default is ```true```.
 * sslKeyCertChainFile => Should be provided if ```ssl``` is set to ```true```
 * sslKeyFile => Should be provided if ```ssl``` is set to ```true```
 * thread_count => the number of threads to keep in the ScheduledThreadPool. Default is `200`

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
@@ -16,7 +16,7 @@ public class OTelTraceSourceConfig {
     static final int DEFAULT_PORT = 21890;
     static final int DEFAULT_THREAD_COUNT = 200;
     static final int DEFAULT_MAX_CONNECTION_COUNT = 500;
-    static final boolean DEFAULT_SSL = false;
+    static final boolean DEFAULT_SSL = true;
     private final int requestTimeoutInMillis;
     private final int port;
     private final boolean healthCheck;
@@ -46,10 +46,10 @@ public class OTelTraceSourceConfig {
         this.threadCount = threadCount;
         this.maxConnectionCount = maxConnectionCount;
         if (ssl && (sslKeyCertChainFile == null || sslKeyCertChainFile.isEmpty())) {
-            throw new IllegalArgumentException(String.format("%s is enable, %s can not be empty or null", SSL, SSL_KEY_CERT_FILE));
+            throw new IllegalArgumentException(String.format("%s is enabled, %s can not be empty or null", SSL, SSL_KEY_CERT_FILE));
         }
         if (ssl && (sslKeyFile == null || sslKeyFile.isEmpty())) {
-            throw new IllegalArgumentException(String.format("%s is enable, %s can not be empty or null", SSL, SSL_KEY_CERT_FILE));
+            throw new IllegalArgumentException(String.format("%s is enabled, %s can not be empty or null", SSL, SSL_KEY_CERT_FILE));
         }
     }
 

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -32,12 +32,14 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import static com.amazon.dataprepper.plugins.source.oteltrace.OTelTraceSourceConfig.SSL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -90,9 +92,10 @@ public class OTelTraceSourceTest {
         lenient().when(serverBuilder.http(anyInt())).thenReturn(serverBuilder);
         lenient().when(serverBuilder.build()).thenReturn(server);
         lenient().when(server.start()).thenReturn(completableFuture);
-        final HashMap<String, Object> integerHashMap = new HashMap<>();
-        integerHashMap.put("request_timeout", 1);
-        pluginSetting = new PluginSetting("otel_trace", integerHashMap);
+        final HashMap<String, Object> settingsMap = new HashMap<>();
+        settingsMap.put("request_timeout", 1);
+        settingsMap.put(SSL, false);
+        pluginSetting = new PluginSetting("otel_trace", settingsMap);
         pluginSetting.setPipelineName("pipeline");
         SOURCE = new OTelTraceSource(pluginSetting);
         SOURCE.start(BUFFER);
@@ -190,7 +193,7 @@ public class OTelTraceSourceTest {
 
     @Test
     public void testRunAnotherSourceWithSamePort() {
-        testPluginSetting = new PluginSetting(null, null);
+        testPluginSetting = new PluginSetting(null, Collections.singletonMap(SSL, false));
         testPluginSetting.setPipelineName("pipeline");
         final OTelTraceSource source = new OTelTraceSource(testPluginSetting);
         //Expect RuntimeException because when port is already in use, BindException is thrown which is not RuntimeException
@@ -199,7 +202,7 @@ public class OTelTraceSourceTest {
 
     @Test
     public void testStartWithEmptyBuffer() {
-        testPluginSetting = new PluginSetting(null, null);
+        testPluginSetting = new PluginSetting(null, Collections.singletonMap(SSL, false));
         testPluginSetting.setPipelineName("pipeline");
         final OTelTraceSource source = new OTelTraceSource(testPluginSetting);
         Assertions.assertThrows(IllegalStateException.class, () -> source.start(null));

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
@@ -3,6 +3,7 @@ package com.amazon.dataprepper.plugins.source.oteltrace;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -10,6 +11,7 @@ import static com.amazon.dataprepper.plugins.source.oteltrace.OTelTraceSourceCon
 import static com.amazon.dataprepper.plugins.source.oteltrace.OTelTraceSourceConfig.DEFAULT_PORT;
 import static com.amazon.dataprepper.plugins.source.oteltrace.OTelTraceSourceConfig.DEFAULT_REQUEST_TIMEOUT_MS;
 import static com.amazon.dataprepper.plugins.source.oteltrace.OTelTraceSourceConfig.DEFAULT_THREAD_COUNT;
+import static com.amazon.dataprepper.plugins.source.oteltrace.OTelTraceSourceConfig.SSL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -29,7 +31,7 @@ public class OtelTraceSourceConfigTests {
     public void testDefault() {
         // Prepare
         final OTelTraceSourceConfig otelTraceSourceConfig = OTelTraceSourceConfig.buildConfig(
-                new PluginSetting(PLUGIN_NAME, new HashMap<>()));
+                new PluginSetting(PLUGIN_NAME, Collections.singletonMap(SSL, false)));
 
         // When/Then
         assertEquals(DEFAULT_REQUEST_TIMEOUT_MS, otelTraceSourceConfig.getRequestTimeoutInMillis());

--- a/data-prepper-plugins/peer-forwarder/README.md
+++ b/data-prepper-plugins/peer-forwarder/README.md
@@ -32,7 +32,7 @@ prepper:
 * `discovery_mode`: peer discovery mode to be used. Allowable values are `static` and `dns`. Defaults to `static`
 * `static_endpoints`: list containing endpoints of all Data Prepper instances.
 * `domain_name`: single domain name to query DNS against. Typically used by creating multiple [DNS A Records](https://www.cloudflare.com/learning/dns/dns-records/dns-a-record/) for the same domain.
-* `ssl` => Default is ```false```.
+* `ssl` => Default is ```true```.
 * `sslKeyCertChainFile` => Should be provided if ```ssl``` is set to ```true```
 
 ## Operating a Cluster with DNS Discovery

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderConfig.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderConfig.java
@@ -19,7 +19,7 @@ public class PeerForwarderConfig {
     public static final String STATIC_ENDPOINTS = "static_endpoints";
     public static final String SSL = "ssl";
     public static final String SSL_KEY_CERT_FILE = "sslKeyCertChainFile";
-    private static final boolean DEFAULT_SSL = false;
+    private static final boolean DEFAULT_SSL = true;
 
     private final HashRing hashRing;
     private final PeerClientPool peerClientPool;
@@ -49,9 +49,9 @@ public class PeerForwarderConfig {
         final File sslKeyCertChainFile;
         if (ssl) {
             if (sslKeyCertChainFilePath == null || sslKeyCertChainFilePath.isEmpty()) {
-                throw new IllegalArgumentException(String.format("%s is enable, %s can not be empty or null", SSL, SSL_KEY_CERT_FILE));
+                throw new IllegalArgumentException(String.format("%s is enabled, %s can not be empty or null", SSL, SSL_KEY_CERT_FILE));
             } else if (!Files.exists(Paths.get(sslKeyCertChainFilePath))) {
-                throw new IllegalArgumentException(String.format("%s is enable, %s does not exist", SSL, SSL_KEY_CERT_FILE));
+                throw new IllegalArgumentException(String.format("%s is enabled, %s does not exist", SSL, SSL_KEY_CERT_FILE));
             } else {
                 sslKeyCertChainFile = new File(sslKeyCertChainFilePath);
             }

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderConfigTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderConfigTest.java
@@ -60,6 +60,7 @@ public class PeerForwarderConfigTest {
         settings.put(PeerForwarderConfig.STATIC_ENDPOINTS, TEST_ENDPOINTS);
         settings.put(PeerForwarderConfig.MAX_NUM_SPANS_PER_REQUEST, testNumSpansPerRequest);
         settings.put(PeerForwarderConfig.TIME_OUT, testTimeout);
+        settings.put(PeerForwarderConfig.SSL, false);
 
         final PeerForwarderConfig peerForwarderConfig = PeerForwarderConfig.buildConfig(
                 new PluginSetting("peer_forwarder", settings){{ setPipelineName(PIPELINE_NAME); }});

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderTest.java
@@ -300,6 +300,7 @@ public class PeerForwarderTest {
         settings.put(PeerForwarderConfig.STATIC_ENDPOINTS, staticEndpoints);
         settings.put(PeerForwarderConfig.MAX_NUM_SPANS_PER_REQUEST, spansPerRequest);
         settings.put(PeerForwarderConfig.TIME_OUT, 300);
+        settings.put(PeerForwarderConfig.SSL, false);
         return new PeerForwarder(new PluginSetting("peer_forwarder", settings) {{setPipelineName(TEST_PIPELINE_NAME);}});
     }
 }

--- a/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
+++ b/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
@@ -69,6 +69,7 @@ Resources:
                   delay: "100"
                   source:
                     otel_trace_source:
+                      ssl: false
                   sink:
                     - pipeline:
                         name: "raw-pipeline"

--- a/docs/readme/trace_overview.md
+++ b/docs/readme/trace_overview.md
@@ -36,6 +36,7 @@ entry-pipeline:
   delay: "100"
   source:
     otel_trace_source:
+      ssl: false
   sink:
     - pipeline:
         name: "raw-pipeline"

--- a/examples/dev/k8s/data-prepper.yaml
+++ b/examples/dev/k8s/data-prepper.yaml
@@ -14,10 +14,12 @@ data:
       delay: "100"
       source:
         otel_trace_source:
+          ssl: false
       prepper:
         - peer_forwarder:
             discovery_mode: "dns"
             domain_name: "data-prepper-headless"
+            ssl: false
       sink:
         - pipeline:
             name: "raw-pipeline"

--- a/examples/dev/trace-analytics-sample-app/resources/trace_analytics_no_ssl.yml
+++ b/examples/dev/trace-analytics-sample-app/resources/trace_analytics_no_ssl.yml
@@ -2,10 +2,12 @@ entry-pipeline:
   delay: "100"
   source:
     otel_trace_source:
+      ssl: false
   prepper:
     - peer_forwarder:
         discovery_mode: "dns"
         domain_name: "prepper-cluster"
+        ssl: false
   sink:
     - pipeline:
         name: "raw-pipeline"

--- a/examples/trace_analytics_no_ssl.yml
+++ b/examples/trace_analytics_no_ssl.yml
@@ -2,6 +2,7 @@ entry-pipeline:
   delay: "100"
   source:
     otel_trace_source:
+      ssl: false
   sink:
     - pipeline:
         name: "raw-pipeline"


### PR DESCRIPTION
*Issue #, if available:* #308

*Description of changes:*
* Switched the `DEFAULT_SSL` boolean from `false` to `true` in OTelTraceSource and PeerForwarder
* Added explicit `falses` to existing unit tests to maintain functionality

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
