### PR TITLE
ENH: introduce JVM and sys metrics in DataPrepper

### DIFF
--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation "io.micrometer:micrometer-core:1.5.1"
     implementation "io.micrometer:micrometer-registry-prometheus:1.5.1"
     testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation "org.mockito:mockito-core:2.1.0"
+    testImplementation "org.mockito:mockito-core:3.7.0"
 }
 
 jar {

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 public class DataPrepper {
     private static final Logger LOG = LoggerFactory.getLogger(DataPrepper.class);
 
-    public static final PrometheusMeterRegistry sysJVMMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+    private static final PrometheusMeterRegistry sysJVMMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
 
     private Map<String, Pipeline> transformationPipelines;
 
@@ -71,6 +71,10 @@ public class DataPrepper {
         }
         startPrometheusBackend();
         dataPrepperServer = new DataPrepperServer(this);
+    }
+
+    public static PrometheusMeterRegistry getSysJVMMeterRegistry() {
+        return sysJVMMeterRegistry;
     }
 
     /**

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
@@ -7,6 +7,11 @@ import com.amazon.dataprepper.pipeline.server.DataPrepperServer;
 import java.io.File;
 import java.util.Map;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.apache.log4j.PropertyConfigurator;
@@ -22,12 +27,22 @@ import org.slf4j.LoggerFactory;
 public class DataPrepper {
     private static final Logger LOG = LoggerFactory.getLogger(DataPrepper.class);
 
+    public static final PrometheusMeterRegistry sysJVMMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+
     private Map<String, Pipeline> transformationPipelines;
 
     private static volatile DataPrepper dataPrepper;
 
     private static DataPrepperServer dataPrepperServer;
     private static DataPrepperConfiguration configuration = DataPrepperConfiguration.DEFAULT_CONFIG;
+
+    static {
+        new ClassLoaderMetrics().bindTo(sysJVMMeterRegistry);
+        new JvmMemoryMetrics().bindTo(sysJVMMeterRegistry);
+        new JvmGcMetrics().bindTo(sysJVMMeterRegistry);
+        new ProcessorMetrics().bindTo(sysJVMMeterRegistry);
+        new JvmThreadMetrics().bindTo(sysJVMMeterRegistry);
+    }
 
     /**
      * Set the DataPrepperConfiguration from a file

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
@@ -24,6 +24,7 @@ public class DataPrepperServer {
                     0
             );
             server.createContext("/metrics/prometheus", new PrometheusMetricsHandler());
+            server.createContext("/metrics/sys", new PrometheusMetricsHandler(DataPrepper.sysJVMMeterRegistry));
             server.createContext("/list", new ListPipelinesHandler(dataPrepper));
             server.createContext("/shutdown", new ShutdownHandler(dataPrepper));
 

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/DataPrepperServer.java
@@ -24,7 +24,7 @@ public class DataPrepperServer {
                     0
             );
             server.createContext("/metrics/prometheus", new PrometheusMetricsHandler());
-            server.createContext("/metrics/sys", new PrometheusMetricsHandler(DataPrepper.sysJVMMeterRegistry));
+            server.createContext("/metrics/sys", new PrometheusMetricsHandler(DataPrepper.getSysJVMMeterRegistry()));
             server.createContext("/list", new ListPipelinesHandler(dataPrepper));
             server.createContext("/shutdown", new ShutdownHandler(dataPrepper));
 

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/PrometheusMetricsHandler.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/PrometheusMetricsHandler.java
@@ -21,6 +21,10 @@ public class PrometheusMetricsHandler implements HttpHandler {
         prometheusMeterRegistry = (PrometheusMeterRegistry) Metrics.globalRegistry.getRegistries().iterator().next();
     }
 
+    public PrometheusMetricsHandler(final PrometheusMeterRegistry prometheusMeterRegistry) {
+        this.prometheusMeterRegistry = prometheusMeterRegistry;
+    }
+
     @Override
     public void handle(HttpExchange exchange) throws IOException {
         try {

--- a/data-prepper-core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/data-prepper-core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,3 @@
+# To enable mocking of final classes with vanilla Mockito
+# https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#mock-the-unmockable-opt-in-mocking-of-final-classesmethods
+mock-maker-inline

--- a/examples/dev/trace-analytics-sample-app/prometheus/prometheus.yaml
+++ b/examples/dev/trace-analytics-sample-app/prometheus/prometheus.yaml
@@ -11,3 +11,8 @@ scrape_configs:
     metrics_path: "/metrics/prometheus"
     static_configs:
       - targets: ["data-prepper:4900"]
+
+  - job_name: "sys"
+    metrics_path: "/metrics/sys"
+    static_configs:
+      - targets: ["data-prepper:4900"]


### PR DESCRIPTION
*Issue #, if available:*
#329 

*Description of changes:*
This PR 

(1) Introduced JVM and system metrics into DataPrepper class by a PrometheusMeterRegistry singleton separate from `Metrics.globalRegistry`. 
(2) Added /metrics/sys API path into the DataPrepperServer to query the above metrics.
(3) Added test cases for data prepper and server.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
