### PR TITLE
Enabling dependabot on more directories, removing most of versionMap.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,27 @@
+# Docs: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
+- package-ecosystem: gradle
+  directory: "/data-prepper-api"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 3
+
+- package-ecosystem: gradle
+  directory: "/data-prepper-benchmarks"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 3
+
 - package-ecosystem: gradle
   directory: "/data-prepper-core"
   schedule:
     interval: daily
   open-pull-requests-limit: 3
+
+- package-ecosystem: gradle
+  directory: "/data-prepper-plugins"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 3
+

--- a/build-resources.gradle
+++ b/build-resources.gradle
@@ -1,20 +1,6 @@
 //preferably try to main the alphabetical order
 ext.versionMap = [
-        bval_extras            : '2.0.4',
-        bval_jsr               : '2.0.4',
-        guava                  : '29.0-jre',
-        hamcrest               : '2.2',
-        jackson_databind       : '2.10.0',
-        jackson_dataformat_yaml: '2.11.1',
-        junit                  : '4.13',
-        log4j_core             : '2.11.1',
-        reflections            : '0.9.11',
-        slf4j_api              : '1.7.30',
-        slf4j_log4j12          : '1.7.30',
-        validation_api         : '2.0.1.Final',
-        opentelemetry_proto    : '0.10.0',
-        mockito                : '2.1.0',
-        mockito_inline         : '3.6.28'
+        opentelemetry_proto    : '0.10.0'
 ]
 
 ext.coreProjects = [project(':data-prepper-api'), project(':data-prepper-core'), project('data-prepper-plugins:common')]

--- a/build.gradle
+++ b/build.gradle
@@ -13,11 +13,11 @@ subprojects {
     apply plugin: 'jacoco'
     sourceCompatibility = '1.8'
     dependencies {
-        implementation "com.google.guava:guava:${versionMap.guava}"
-        implementation "org.apache.logging.log4j:log4j-core:${versionMap.log4j_core}"
-        implementation "org.slf4j:slf4j-api:${versionMap.slf4j_api}"
-        implementation "org.slf4j:slf4j-log4j12:${versionMap.slf4j_log4j12}"
-        testImplementation("junit:junit:${versionMap.junit}") {
+        implementation "com.google.guava:guava:29.0-jre"
+        implementation "org.apache.logging.log4j:log4j-core:2.11.1"
+        implementation "org.slf4j:slf4j-api:1.7.30"
+        implementation "org.slf4j:slf4j-log4j12:1.7.30"
+        testImplementation("junit:junit:4.13") {
             exclude group: 'org.hamcrest' // workaround for jarHell
         }
     }

--- a/data-prepper-api/build.gradle
+++ b/data-prepper-api/build.gradle
@@ -2,8 +2,9 @@ plugins {
 
 }
 dependencies {
-    implementation "io.micrometer:micrometer-core:1.5.1"
-    testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
+    implementation "io.micrometer:micrometer-core:1.5.5"
+
+    testImplementation "org.hamcrest:hamcrest:2.2"
 }
 jacocoTestCoverageVerification {
     dependsOn jacocoTestReport

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -16,13 +16,19 @@ dependencies {
     compile project(':data-prepper-api')
     compile project(':data-prepper-plugins')
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.1"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1"
     implementation "javax.validation:validation-api:2.0.1.Final"
     implementation "org.apache.bval:bval-extras:2.0.5"
     implementation "org.apache.bval:bval-jsr:2.0.5"
     implementation "org.reflections:reflections:0.9.12"
-    implementation "io.micrometer:micrometer-core:1.6.4"
-    implementation "io.micrometer:micrometer-registry-prometheus:1.6.4"
+
+    // Micrometer versions greater than 1.5.5 compile and target JDK 15 (even though build.gradle specifies
+    // compatibility with JDK 8). Our GitHub actions workflow uses JDK 14, which causes Elasticsearch jarhell to complain about
+    // the latest micrometer version requiring JDK 15. Jacoco doesn't support 15 yet,
+    // so this is why we're currently stuck on micrometer 1.5.5.
+    implementation "io.micrometer:micrometer-core:1.5.5"
+    implementation "io.micrometer:micrometer-registry-prometheus:1.5.5"
+
     testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation "org.mockito:mockito-core:3.7.7"
 }

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -25,7 +25,7 @@ sourceSets {
 }
 
 dependencies {
-    integrationTestCompile("junit:junit:${versionMap.junit}")
+    integrationTestCompile("junit:junit:4.13")
     integrationTestCompile project(':data-prepper-plugins:elasticsearch')
     integrationTestImplementation "org.awaitility:awaitility:4.0.3"
     integrationTestImplementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"

--- a/data-prepper-plugins/blocking-buffer/build.gradle
+++ b/data-prepper-plugins/blocking-buffer/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 dependencies {
     compile project(':data-prepper-api')
-    testImplementation "junit:junit:${versionMap.junit}"
+    testImplementation "junit:junit:4.13"
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/common/build.gradle
+++ b/data-prepper-plugins/common/build.gradle
@@ -3,10 +3,10 @@ plugins {
 }
 dependencies {
     compile project(':data-prepper-api')
-    implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versionMap.jackson_dataformat_yaml}"
-    implementation "org.reflections:reflections:${versionMap.reflections}"
-    testImplementation "junit:junit:${versionMap.junit}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1"
+    implementation "org.reflections:reflections:0.9.12"
+    testImplementation "junit:junit:4.13"
     testImplementation "commons-io:commons-io:2.8.0"
 }
 

--- a/data-prepper-plugins/elasticsearch/build.gradle
+++ b/data-prepper-plugins/elasticsearch/build.gradle
@@ -32,13 +32,13 @@ dependencies {
     testCompile project(':data-prepper-api').sourceSets.test.output
     compile project(':data-prepper-plugins:common')
     implementation "org.elasticsearch.client:elasticsearch-rest-high-level-client:${es_version}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versionMap.jackson_dataformat_yaml}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1"
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     implementation "com.amazonaws:aws-java-sdk-core:1.11.452"
     implementation "com.github.awslabs:aws-request-signing-apache-interceptor:b3772780da"
-    implementation "io.micrometer:micrometer-core:1.5.1"
-    testImplementation("junit:junit:${versionMap.junit}") {
+    implementation "io.micrometer:micrometer-core:1.5.5"
+    testImplementation("junit:junit:4.13") {
         exclude group:'org.hamcrest' // workaround for jarHell
     }
     testImplementation "org.elasticsearch.test:framework:${es_version}"
@@ -52,17 +52,17 @@ compileJava.options.warnings = false
 configurations.all {
     resolutionStrategy {
         force 'com.amazonaws:aws-java-sdk-core:1.11.452'
-        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.1'
-        force 'com.fasterxml.jackson.core:jackson-databind:2.11.1'
-        force 'com.fasterxml.jackson.core:jackson-core:2.11.1'
-        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.4'
-        force 'com.google.guava:guava:29.0-jre'
+        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1'
+        force 'com.fasterxml.jackson.core:jackson-databind:2.12.1'
+        force 'com.fasterxml.jackson.core:jackson-core:2.12.1'
+        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1'
         force 'commons-logging:commons-logging:1.2'
-        force 'org.apache.bval:bval-jsr:2.0.4'
         force 'org.apache.httpcomponents:httpclient:4.5.10'
-        force 'junit:junit:4.13'
         force "org.hdrhistogram:HdrHistogram:2.1.12"
         force 'joda-time:joda-time:2.10.4'
+        force 'org.yaml:snakeyaml:1.27'
+        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.12.1'
+        force 'junit:junit:4.13'
     }
 }
 

--- a/data-prepper-plugins/lmdb-prepper-state/build.gradle
+++ b/data-prepper-plugins/lmdb-prepper-state/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     compile project(':data-prepper-api')
     compile project(':data-prepper-plugins:common')
     implementation 'org.lmdbjava:lmdbjava:0.8.1'
-    implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
     testCompile project(':data-prepper-plugins:common').sourceSets.test.output
-    testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
+    testImplementation "org.hamcrest:hamcrest:2.2"
 }

--- a/data-prepper-plugins/mapdb-prepper-state/build.gradle
+++ b/data-prepper-plugins/mapdb-prepper-state/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     compile project(':data-prepper-plugins:common')
     compile 'org.mapdb:mapdb:3.0.8'
     testCompile project(':data-prepper-plugins:common').sourceSets.test.output
-    testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
+    testImplementation "org.hamcrest:hamcrest:2.2"
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
@@ -11,11 +11,11 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-java-util:3.13.0'
     implementation "com.linecorp.armeria:armeria:1.0.0"
     implementation "com.linecorp.armeria:armeria-grpc:1.0.0"
-    implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versionMap.jackson_dataformat_yaml}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1"
     testImplementation 'org.assertj:assertj-core:3.6.2'
-    testImplementation "org.mockito:mockito-inline:${versionMap.mockito_inline}"
-    testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
+    testImplementation "org.mockito:mockito-inline:3.6.28"
+    testImplementation "org.hamcrest:hamcrest:2.2"
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/otel-trace-source/build.gradle
+++ b/data-prepper-plugins/otel-trace-source/build.gradle
@@ -11,11 +11,11 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-java-util:3.13.0'
     implementation "com.linecorp.armeria:armeria:1.0.0"
     implementation "com.linecorp.armeria:armeria-grpc:1.0.0"
-    implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versionMap.jackson_dataformat_yaml}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1"
     testImplementation 'org.assertj:assertj-core:3.6.2'
     testImplementation "org.mockito:mockito-inline:2.13.0"
-    testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
+    testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation(platform('org.junit:junit-bom:5.7.0'))
     testImplementation('org.junit.jupiter:junit-jupiter')
     // TODO: update versionMap to use a higher version of mockito for all subprojects

--- a/data-prepper-plugins/peer-forwarder/build.gradle
+++ b/data-prepper-plugins/peer-forwarder/build.gradle
@@ -12,11 +12,11 @@ repositories {
 dependencies {
     compile project(':data-prepper-api')
     testCompile project(':data-prepper-api').sourceSets.test.output
-    implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
+    implementation "io.opentelemetry:opentelemetry-proto:0.10.0"
     implementation "com.linecorp.armeria:armeria:1.0.0"
     implementation "com.linecorp.armeria:armeria-grpc:1.0.0"
-    testImplementation "junit:junit:4.12"
-    testImplementation "org.mockito:mockito-inline:${versionMap.mockito_inline}"
+    testImplementation "junit:junit:4.13"
+    testImplementation "org.mockito:mockito-inline:3.6.28"
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -17,11 +17,11 @@ dependencies {
     compile project(':data-prepper-plugins:lmdb-prepper-state')
     compile project(':data-prepper-plugins:mapdb-prepper-state')
     testCompile project(':data-prepper-api').sourceSets.test.output
-    implementation "io.micrometer:micrometer-core:1.5.1"
-    implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
+    implementation "io.micrometer:micrometer-core:1.5.5"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
-    testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
-    testImplementation "org.mockito:mockito-inline:${versionMap.mockito_inline}"
+    testImplementation "org.hamcrest:hamcrest:2.2"
+    testImplementation "org.mockito:mockito-inline:3.6.28"
 }
 
 jacocoTestCoverageVerification {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Removed version map (except for opentelemetry_proto for now)
* Enabled dependabot on remaining packages
* Included a lengthy comment as to why we're not using the latest micrometer release. 
  * Will open an issue on the micrometer repo asking why the maven artifact are showing as targeting Java 15 even though build.gradle specifies Java 8
    * Edit: PR to micrometer: https://github.com/micrometer-metrics/micrometer/pull/2471
  * Will also close/ignore dependabot upgrades for micrometer if they are opened until this is figured out

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
