### PR TITLE
ENH: support custom AES endpoint with SSL certificate file

### DIFF
--- a/data-prepper-plugins/elasticsearch/README.md
+++ b/data-prepper-plugins/elasticsearch/README.md
@@ -42,12 +42,35 @@ pipeline:
 
 The elasticsearch sink will reserve `otel-v1-apm-service-map` as index for record ingestion.
 
+### Amazon Elasticsearch Service (AES)
+
+The elasticsearch sink can also be configured for AES domain. See [security](security.md) for details.
+
+```$xslt
+pipeline:
+  ...
+  sink:
+    elasticsearch:
+      hosts: ["https://your-amazon-elasticssearch-service-endpoint"]
+      aws_sigv4: true 
+      cert: path/to/cert
+      insecure: false
+      trace_analytics_service_map: true
+      bulk_size: 4
+```
+
 ## Configuration
 
 - `hosts`: A list of IP addresses of elasticsearch nodes.
 
 - `cert`(optional): CA certificate that is pem encoded. Accepts both .pem or .crt. This enables the client to trust the CA that has signed the certificate that ODFE is using.
 Default is null. 
+
+- `aws_sigv4`: A boolean flag to sign the HTTP request with AWS credentials. Only applies to AES. See [security](security.md) for details. Default to `false`. 
+
+- `aws_region`: A String represents the region of AES domain, e.g. us-west-2. Only applies to AES. Defaults to `us-east-1`.
+
+- `insecure`: A boolean flag to turn off SSL certificate verification. If set to true, CA certificate verification will be turned off and insecure HTTP requests will be sent. Default to `false`.
 
 - `username`(optional): A String of username used in the [internal users](https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/users-roles) of ODFE cluster. Default is null.
 

--- a/data-prepper-plugins/elasticsearch/README.md
+++ b/data-prepper-plugins/elasticsearch/README.md
@@ -42,9 +42,9 @@ pipeline:
 
 The elasticsearch sink will reserve `otel-v1-apm-service-map` as index for record ingestion.
 
-### Amazon Elasticsearch Service (AES)
+### Amazon Elasticsearch Service (Amazon ES)
 
-The elasticsearch sink can also be configured for AES domain. See [security](security.md) for details.
+The elasticsearch sink can also be configured for Amazon ES domain. See [security](security.md) for details.
 
 ```$xslt
 pipeline:
@@ -66,9 +66,9 @@ pipeline:
 - `cert`(optional): CA certificate that is pem encoded. Accepts both .pem or .crt. This enables the client to trust the CA that has signed the certificate that ODFE is using.
 Default is null. 
 
-- `aws_sigv4`: A boolean flag to sign the HTTP request with AWS credentials. Only applies to AES. See [security](security.md) for details. Default to `false`. 
+- `aws_sigv4`: A boolean flag to sign the HTTP request with AWS credentials. Only applies to Amazon ES. See [security](security.md) for details. Default to `false`. 
 
-- `aws_region`: A String represents the region of AES domain, e.g. us-west-2. Only applies to AES. Defaults to `us-east-1`.
+- `aws_region`: A String represents the region of Amazon ES domain, e.g. us-west-2. Only applies to Amazon ES. Defaults to `us-east-1`.
 
 - `insecure`: A boolean flag to turn off SSL certificate verification. If set to true, CA certificate verification will be turned off and insecure HTTP requests will be sent. Default to `false`.
 

--- a/data-prepper-plugins/elasticsearch/README.md
+++ b/data-prepper-plugins/elasticsearch/README.md
@@ -42,9 +42,9 @@ pipeline:
 
 The elasticsearch sink will reserve `otel-v1-apm-service-map` as index for record ingestion.
 
-### Amazon Elasticsearch Service (Amazon ES)
+### Amazon Elasticsearch Service
 
-The elasticsearch sink can also be configured for Amazon ES domain. See [security](security.md) for details.
+The elasticsearch sink can also be configured for Amazon Elasticsearch Service domain. See [security](security.md) for details.
 
 ```$xslt
 pipeline:
@@ -66,9 +66,9 @@ pipeline:
 - `cert`(optional): CA certificate that is pem encoded. Accepts both .pem or .crt. This enables the client to trust the CA that has signed the certificate that ODFE is using.
 Default is null. 
 
-- `aws_sigv4`: A boolean flag to sign the HTTP request with AWS credentials. Only applies to Amazon ES. See [security](security.md) for details. Default to `false`. 
+- `aws_sigv4`: A boolean flag to sign the HTTP request with AWS credentials. Only applies to Amazon Elasticsearch Service. See [security](security.md) for details. Default to `false`. 
 
-- `aws_region`: A String represents the region of Amazon ES domain, e.g. us-west-2. Only applies to Amazon ES. Defaults to `us-east-1`.
+- `aws_region`: A String represents the region of Amazon Elasticsearch Service domain, e.g. us-west-2. Only applies to Amazon Elasticsearch Service. Defaults to `us-east-1`.
 
 - `insecure`: A boolean flag to turn off SSL certificate verification. If set to true, CA certificate verification will be turned off and insecure HTTP requests will be sent. Default to `false`.
 

--- a/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ConnectionConfiguration.java
+++ b/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ConnectionConfiguration.java
@@ -155,9 +155,9 @@ public class ConnectionConfiguration {
      * We will not support FGAC and Custom endpoint domains. This will be followed in the next version.
      */
     if(awsSigv4) {
-      attachAWSSigV4CallbackAndSSLContext(restClientBuilder);
+      attachSigV4(restClientBuilder);
     } else {
-      attachSSLUsernameContext(restClientBuilder);
+      attachUserCredentials(restClientBuilder);
     }
     restClientBuilder.setRequestConfigCallback(
             requestConfigBuilder -> {
@@ -172,7 +172,7 @@ public class ConnectionConfiguration {
     return new RestHighLevelClient(restClientBuilder);
   }
 
-  private void attachAWSSigV4CallbackAndSSLContext(final RestClientBuilder restClientBuilder) {
+  private void attachSigV4(final RestClientBuilder restClientBuilder) {
     //if aws signing is enabled we will add AWSRequestSigningApacheInterceptor interceptor,
     //if not follow regular credentials process
     LOG.info("{} is set, will sign requests using AWSRequestSigningApacheInterceptor", AWS_SIGV4);
@@ -189,7 +189,7 @@ public class ConnectionConfiguration {
     });
   }
 
-  private void attachSSLUsernameContext(final RestClientBuilder restClientBuilder) {
+  private void attachUserCredentials(final RestClientBuilder restClientBuilder) {
     final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
     if (username != null) {
       LOG.info("Using the username provided in the config.");

--- a/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ConnectionConfigurationTests.java
+++ b/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ConnectionConfigurationTests.java
@@ -118,6 +118,26 @@ public class ConnectionConfigurationTests {
         assertTrue(connectionConfiguration.isAwsSigv4());;
     }
 
+    @Test
+    public void testCreateClientWithAWSSigV4AndInsecure() throws IOException {
+        final PluginSetting pluginSetting = generatePluginSetting(
+                TEST_HOSTS, null, null, null, null, true, null, null, true);
+        final ConnectionConfiguration connectionConfiguration =
+                ConnectionConfiguration.readConnectionConfiguration(pluginSetting);
+        assertEquals("us-east-1", connectionConfiguration.getAwsRegion());
+        assertTrue(connectionConfiguration.isAwsSigv4());;
+    }
+
+    @Test
+    public void testCreateClientWithAWSSigV4AndCertPath() throws IOException {
+        final PluginSetting pluginSetting = generatePluginSetting(
+                TEST_HOSTS, null, null, null, null, true, null, TEST_CERT_PATH, false);
+        final ConnectionConfiguration connectionConfiguration =
+                ConnectionConfiguration.readConnectionConfiguration(pluginSetting);
+        assertEquals("us-east-1", connectionConfiguration.getAwsRegion());
+        assertTrue(connectionConfiguration.isAwsSigv4());;
+    }
+
     private PluginSetting generatePluginSetting(
             final List<String> hosts, final String username, final String password,
             final Integer connectTimeout, final Integer socketTimeout, final boolean awsSigv4, final String awsRegion,

--- a/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ConnectionConfigurationTests.java
+++ b/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ConnectionConfigurationTests.java
@@ -125,7 +125,7 @@ public class ConnectionConfigurationTests {
         final ConnectionConfiguration connectionConfiguration =
                 ConnectionConfiguration.readConnectionConfiguration(pluginSetting);
         assertEquals("us-east-1", connectionConfiguration.getAwsRegion());
-        assertTrue(connectionConfiguration.isAwsSigv4());;
+        assertTrue(connectionConfiguration.isAwsSigv4());
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
#341 

*Description of changes:*
This PR tackles option 1 in #341 . As discussed offline with @kowshikn , for now we do not need ARN support at the data-prepper level. The data-prepper built from this PR has been run on the VPC EC2 instance that connects with AES configured with custom endpoint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
