### PR TITLE
dependabot.yml: explicitly listing out plugin directories.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,24 +4,54 @@ updates:
 - package-ecosystem: gradle
   directory: "/data-prepper-api"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 3
-
-- package-ecosystem: gradle
-  directory: "/data-prepper-benchmarks"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 3
+    interval: weekly
 
 - package-ecosystem: gradle
   directory: "/data-prepper-core"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 3
+    interval: weekly
 
 - package-ecosystem: gradle
-  directory: "/data-prepper-plugins"
+  directory: "/data-prepper-plugins/blocking-buffer"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 3
+    interval: weekly
 
+- package-ecosystem: gradle
+  directory: "/data-prepper-plugins/common"
+  schedule:
+    interval: weekly
+
+- package-ecosystem: gradle
+  directory: "/data-prepper-plugins/elasticsearch"
+  schedule:
+    interval: weekly
+
+- package-ecosystem: gradle
+  directory: "/data-prepper-plugins/lmdb-prepper-state"
+  schedule:
+    interval: weekly
+
+- package-ecosystem: gradle
+  directory: "/data-prepper-plugins/mapdb-prepper-state"
+  schedule:
+    interval: weekly
+
+- package-ecosystem: gradle
+  directory: "/data-prepper-plugins/otel-trace-raw-prepper"
+  schedule:
+    interval: weekly
+
+- package-ecosystem: gradle
+  directory: "/data-prepper-plugins/otel-trace-source"
+  schedule:
+    interval: weekly
+
+- package-ecosystem: gradle
+  directory: "/data-prepper-plugins/peer-forwarder"
+  schedule:
+    interval: weekly
+
+- package-ecosystem: gradle
+  directory: "/data-prepper-plugins/service-map-stateful"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
*Description of changes:*
* Noticed we weren't getting any pull requests for projects in the _plugins_ directory, so will attempt to fix by listing them all out.
* Also changing the schedule to "weekly" because we can trigger on-demand scans with https://github.com/opendistro-for-elasticsearch/data-prepper/network/updates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
