### PR TITLE
ENH: allow confine Prepper plugin instance to thread

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/annotations/SingleThread.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/annotations/SingleThread.java
@@ -1,0 +1,17 @@
+package com.amazon.dataprepper.model.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a Prepper plugin class of which an instance is required to be confined to a single thread.
+ */
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface SingleThread {
+}

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation "org.reflections:reflections:0.9.12"
     implementation "io.micrometer:micrometer-core:1.6.4"
     implementation "io.micrometer:micrometer-registry-prometheus:1.6.4"
+    testCompile project(':data-prepper-plugins:common').sourceSets.test.output
     testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation "org.mockito:mockito-core:3.7.7"
 }

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/PipelineParser.java
@@ -85,14 +85,9 @@ public class PipelineParser {
 
             LOG.info("Building preppers for the pipeline [{}]", pipelineName);
             final int prepperThreads = pipelineConfiguration.getWorkers();
-            final List<List<Prepper>> prepperSets = new ArrayList<>();
-            for (int i = 0; i < prepperThreads; i++) {
-                prepperSets.add(
-                        pipelineConfiguration.getPrepperPluginSettings().stream()
-                                .map(PrepperFactory::newPrepper)
-                                .collect(Collectors.toList())
-                );
-            }
+            final List<List<Prepper>> prepperSets = pipelineConfiguration.getPrepperPluginSettings().stream()
+                    .map(PrepperFactory::newPreppers)
+                    .collect(Collectors.toList());
             final int readBatchDelay = pipelineConfiguration.getReadBatchDelay();
 
             LOG.info("Building sinks for the pipeline [{}]", pipelineName);

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/PipelineParser.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,10 +84,15 @@ public class PipelineParser {
             final Buffer buffer = BufferFactory.newBuffer(pipelineConfiguration.getBufferPluginSetting());
 
             LOG.info("Building preppers for the pipeline [{}]", pipelineName);
-            final List<Prepper> preppers = pipelineConfiguration.getPrepperPluginSettings().stream()
-                    .map(PrepperFactory::newPrepper)
-                    .collect(Collectors.toList());
             final int prepperThreads = pipelineConfiguration.getWorkers();
+            final List<List<Prepper>> prepperSets = new ArrayList<>();
+            for (int i = 0; i < prepperThreads; i++) {
+                prepperSets.add(
+                        pipelineConfiguration.getPrepperPluginSettings().stream()
+                                .map(PrepperFactory::newPrepper)
+                                .collect(Collectors.toList())
+                );
+            }
             final int readBatchDelay = pipelineConfiguration.getReadBatchDelay();
 
             LOG.info("Building sinks for the pipeline [{}]", pipelineName);
@@ -94,7 +100,7 @@ public class PipelineParser {
                     .map(this::buildSinkOrConnector)
                     .collect(Collectors.toList());
 
-            final Pipeline pipeline = new Pipeline(pipelineName, source, buffer, preppers, sinks, prepperThreads, readBatchDelay);
+            final Pipeline pipeline = new Pipeline(pipelineName, source, buffer, prepperSets, sinks, prepperThreads, readBatchDelay);
             pipelineMap.put(pipelineName, pipeline);
         } catch (Exception ex) {
             //If pipeline construction errors out, we will skip that pipeline and proceed

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/Pipeline.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/Pipeline.java
@@ -53,7 +53,8 @@ public class Pipeline {
      * @param name                     name of the pipeline
      * @param source                   source from where the pipeline reads the records
      * @param buffer                   buffer for the source to queue records
-     * @param prepperSets               prepper that is applied to records
+     * @param prepperSets               prepper sets that will be applied to records. Each set includes either a single shared prepper instance
+     *                                  or multiple instances with each to be accessed only by a single {@link ProcessWorker}.
      * @param sinks                    sink to which the transformed records are posted
      * @param prepperThreads         configured or default threads to parallelize prepper work
      * @param readBatchTimeoutInMillis configured or default timeout for reading batch of records from buffer

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/Pipeline.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/Pipeline.java
@@ -8,6 +8,7 @@ import com.amazon.dataprepper.model.source.Source;
 import com.amazon.dataprepper.pipeline.common.PipelineThreadFactory;
 import com.amazon.dataprepper.pipeline.common.PipelineThreadPoolExecutor;
 import com.amazon.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
+import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,6 +16,7 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -28,37 +30,17 @@ import static java.lang.String.format;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class Pipeline {
     private static final Logger LOG = LoggerFactory.getLogger(Pipeline.class);
-    private static final List<Prepper> EMPTY_PREPPER_LIST = new ArrayList<>(0);
     private static final int PREPPER_DEFAULT_TERMINATION_IN_MILLISECONDS = 5000;
     private boolean stopRequested;
 
     private final String name;
     private final Source source;
     private final Buffer buffer;
-    private final List<Prepper> preppers;
+    private final List<List<Prepper>> prepperSets;
     private final List<Sink> sinks;
     private final int prepperThreads;
     private final int readBatchTimeoutInMillis;
     private final ExecutorService prepperSinkExecutorService;
-
-    /**
-     * Constructs a {@link Pipeline} object with provided {@link #name}, {@link Source}, {@link Collection} of
-     * {@link Sink}, prepperThreads, readBatchTimeout and default {@link Buffer}, {@link Prepper}.
-     *
-     * @param name                     name of the pipeline
-     * @param source                   source from where the pipeline reads the records
-     * @param sinks                    collection of sink's to which the transformed records need to be posted
-     * @param prepperThreads         configured or default threads to parallelize prepper work
-     * @param readBatchTimeoutInMillis configured or default timeout for reading batch of records from buffer
-     */
-    public Pipeline(
-            @Nonnull final String name,
-            @Nonnull final Source source,
-            @Nonnull final List<Sink> sinks,
-            final int prepperThreads,
-            final int readBatchTimeoutInMillis) {
-        this(name, source, new BlockingBuffer(name), EMPTY_PREPPER_LIST, sinks, prepperThreads, readBatchTimeoutInMillis);
-    }
 
     /**
      * Constructs a {@link Pipeline} object with provided {@link Source}, {@link #name}, {@link Collection} of
@@ -70,7 +52,7 @@ public class Pipeline {
      * @param name                     name of the pipeline
      * @param source                   source from where the pipeline reads the records
      * @param buffer                   buffer for the source to queue records
-     * @param preppers               prepper that is applied to records
+     * @param prepperSets               prepper that is applied to records
      * @param sinks                    sink to which the transformed records are posted
      * @param prepperThreads         configured or default threads to parallelize prepper work
      * @param readBatchTimeoutInMillis configured or default timeout for reading batch of records from buffer
@@ -79,14 +61,16 @@ public class Pipeline {
             @Nonnull final String name,
             @Nonnull final Source source,
             @Nonnull final Buffer buffer,
-            @Nonnull final List<Prepper> preppers,
+            @Nonnull final List<List<Prepper>> prepperSets,
             @Nonnull final List<Sink> sinks,
             final int prepperThreads,
             final int readBatchTimeoutInMillis) {
+        Preconditions.checkArgument(prepperSets.size() == prepperThreads);
+        Preconditions.checkArgument(prepperSets.stream().allMatch(Objects::nonNull));
         this.name = name;
         this.source = source;
         this.buffer = buffer;
-        this.preppers = preppers;
+        this.prepperSets = prepperSets;
         this.sinks = sinks;
         this.prepperThreads = prepperThreads;
         this.readBatchTimeoutInMillis = readBatchTimeoutInMillis;
@@ -132,8 +116,8 @@ public class Pipeline {
     /**
      * @return a list of {@link Prepper} of this pipeline or an empty list .
      */
-    List<Prepper> getPreppers() {
-        return preppers;
+    List<List<Prepper>> getPrepperSets() {
+        return prepperSets;
     }
 
     public int getReadBatchTimeoutInMillis() {
@@ -150,6 +134,7 @@ public class Pipeline {
             source.start(buffer);
             LOG.info("Pipeline [{}] - Submitting request to initiate the pipeline processing", name);
             for (int i = 0; i < prepperThreads; i++) {
+                final List<Prepper> preppers = prepperSets.get(i);
                 prepperSinkExecutorService.submit(new ProcessWorker(buffer, preppers, sinks, this));
             }
         } catch (Exception ex) {
@@ -176,7 +161,7 @@ public class Pipeline {
         try {
             source.stop();
             stopRequested = true;
-            preppers.forEach(Prepper::shutdown);
+            prepperSets.forEach(preppers -> { preppers.forEach(Prepper::shutdown); });
             sinks.forEach(Sink::shutdown);
         } catch (Exception ex) {
             LOG.error("Pipeline [{}] - Encountered exception while stopping the source, " +

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/PrepperFactory.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/PrepperFactory.java
@@ -1,14 +1,28 @@
 package com.amazon.dataprepper.plugins.prepper;
 
+import com.amazon.dataprepper.model.annotations.SingleThread;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.plugins.PluginFactory;
 import com.amazon.dataprepper.plugins.PluginRepository;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 @SuppressWarnings({"rawtypes"})
 public class PrepperFactory extends PluginFactory {
 
-    public static Prepper newPrepper(final PluginSetting pluginSetting) {
-        return (Prepper) newPlugin(pluginSetting, PluginRepository.getPrepperClass(pluginSetting.getName()));
+    public static List<Prepper> newPreppers(final PluginSetting pluginSetting) {
+        final Class<Prepper> clazz = PluginRepository.getPrepperClass(pluginSetting.getName());
+        if (clazz.isAnnotationPresent(SingleThread.class)) {
+            final List<Prepper> preppers = new ArrayList<>();
+            for (int i = 0; i < pluginSetting.getNumberOfProcessWorkers(); i++) {
+                preppers.add((Prepper) newPlugin(pluginSetting, clazz));
+            }
+            return preppers;
+        } else {
+            return Collections.singletonList((Prepper) newPlugin(pluginSetting, clazz));
+        }
     }
 }

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/PrepperFactoryTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/PrepperFactoryTests.java
@@ -7,12 +7,14 @@ import com.amazon.dataprepper.plugins.sink.SinkFactory;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.List;
 
 import static com.amazon.dataprepper.plugins.PluginFactoryTests.NON_EXISTENT_EMPTY_CONFIGURATION;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 @SuppressWarnings("rawtypes")
@@ -22,20 +24,35 @@ public class PrepperFactoryTests {
      * Tests if PrepperFactory is able to retrieve default Source plugins by name
      */
     @Test
-    public void testNewSinkClassByNameThatExists() {
+    public void testNewSingletonPrepperClassByNameThatExists() {
         final PluginSetting noOpPrepperConfiguration = new PluginSetting("no-op", new HashMap<>());
         noOpPrepperConfiguration.setPipelineName(TEST_PIPELINE);
-        final Prepper actualPrepper = PrepperFactory.newPrepper(noOpPrepperConfiguration);
+        final List<Prepper> actualPrepperSets = PrepperFactory.newPreppers(noOpPrepperConfiguration);
+        assertEquals(1, actualPrepperSets.size());
+        final Prepper actualPrepper = actualPrepperSets.get(0);
         final Prepper expectedPrepper = new NoOpPrepper();
         assertThat(actualPrepper, notNullValue());
         assertThat(actualPrepper.getClass().getSimpleName(), is(equalTo(expectedPrepper.getClass().getSimpleName())));
+    }
+
+    @Test
+    public void testNewMultiInstancePrepperClassByNameThatExists() {
+        final PluginSetting testPrepperConfiguration = new PluginSetting("test_prepper", new HashMap<>()){{setProcessWorkers(2);}};
+        testPrepperConfiguration.setPipelineName(TEST_PIPELINE);
+        final List<Prepper> actualPrepperSets = PrepperFactory.newPreppers(testPrepperConfiguration);
+        assertEquals(2, actualPrepperSets.size());
+        final Prepper expectedPrepper = new TestPrepper(testPrepperConfiguration);
+        assertThat(actualPrepperSets.get(0), notNullValue());
+        assertThat(actualPrepperSets.get(0).getClass().getSimpleName(), is(equalTo(expectedPrepper.getClass().getSimpleName())));
+        assertThat(actualPrepperSets.get(1), notNullValue());
+        assertThat(actualPrepperSets.get(1).getClass().getSimpleName(), is(equalTo(expectedPrepper.getClass().getSimpleName())));
     }
 
     /**
      * Tests if PrepperFactory fails with correct Exception when queried for a non-existent plugin
      */
     @Test
-    public void testNonExistentSinkRetrieval() {
+    public void testNonExistentPrepperRetrieval() {
         assertThrows(PluginException.class, () -> SinkFactory.newSink(NON_EXISTENT_EMPTY_CONFIGURATION));
     }
 }

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/TestPrepper.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/TestPrepper.java
@@ -1,11 +1,19 @@
-package com.amazon.dataprepper.plugins;
+package com.amazon.dataprepper.plugins.prepper;
 
+import com.amazon.dataprepper.model.PluginType;
+import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
+import com.amazon.dataprepper.model.annotations.SingleThread;
+import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.model.record.Record;
 import java.util.Collection;
 
+@SingleThread
+@DataPrepperPlugin(name = "test_prepper", type = PluginType.PREPPER)
 public class TestPrepper implements Prepper<Record<String>, Record<String>> {
     public boolean isShutdown = false;
+
+    public TestPrepper(final PluginSetting pluginSetting) {}
 
     @Override
     public Collection<Record<String>> execute(Collection<Record<String>> records) {

--- a/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
@@ -2,6 +2,7 @@ package com.amazon.dataprepper.plugins.prepper;
 
 import com.amazon.dataprepper.model.PluginType;
 import com.amazon.dataprepper.model.annotations.DataPrepperPlugin;
+import com.amazon.dataprepper.model.annotations.SingleThread;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.prepper.AbstractPrepper;
 import com.amazon.dataprepper.model.record.Record;
@@ -28,6 +29,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@SingleThread
 @DataPrepperPlugin(name = "service_map_stateful", type = PluginType.PREPPER)
 public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTraceServiceRequest>, Record<String>> {
 


### PR DESCRIPTION
*Issue #, if available:*
#320 

*Description of changes:*
This PR 

(1) Introduces a @SingleThread annotation for Prepper plugin to allow confinement of prepper instance to a single ProcessWorker.
(2) Modified `PrepperFactory` to return appropriately based on the @SingleThread.
(3) Modified `Pipeline` and `PipelineParser` correspondingly.
(4) Refactored some relevant test cases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
