### PR TITLE
Switching to log4j2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ subprojects {
         implementation "com.google.guava:guava:29.0-jre"
         implementation "org.apache.logging.log4j:log4j-core:2.11.1"
         implementation "org.slf4j:slf4j-api:1.7.30"
-        implementation "org.slf4j:slf4j-log4j12:1.7.30"
+        implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.14.0"
         testImplementation("junit:junit:4.13") {
             exclude group: 'org.hamcrest' // workaround for jarHell
         }
@@ -25,6 +25,8 @@ subprojects {
     jacocoTestReport {
         dependsOn test // tests are required to run before generating the report
     }
+
+    task allDeps(type: DependencyReportTask) {}
 }
 
 configure(coreProjects) {

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
@@ -14,7 +14,8 @@ import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
-import org.apache.log4j.PropertyConfigurator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +52,12 @@ public class DataPrepper {
     public static void configure(final String configurationFile) {
         final DataPrepperConfiguration dataPrepperConfiguration =
                 DataPrepperConfiguration.fromFile(new File(configurationFile));
-        PropertyConfigurator.configure(dataPrepperConfiguration.getLog4JConfiguration().getProperties());
+
+        File file = new File(configurationFile);
+
+        LoggerContext context = (org.apache.logging.log4j.core.LoggerContext) LogManager.getContext(false);
+        context.setConfigLocation(file.toURI());
+
         configuration = dataPrepperConfiguration;
     }
 

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/Log4JConfiguration.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/Log4JConfiguration.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.Properties;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.log4j.Level;
+import org.apache.logging.log4j.Level;
 
 /**
  * Class to hold Log4J properties

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/DataPrepperTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/DataPrepperTests.java
@@ -2,7 +2,7 @@ package com.amazon.dataprepper;
 
 import com.amazon.dataprepper.parser.model.DataPrepperConfiguration;
 import io.micrometer.core.instrument.Measurement;
-import org.apache.log4j.Level;
+import org.apache.logging.log4j.Level;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/model/DataPrepperConfigurationTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/model/DataPrepperConfigurationTests.java
@@ -1,7 +1,8 @@
 package com.amazon.dataprepper.parser.model;
 
 import java.io.File;
-import org.apache.log4j.Level;
+
+import org.apache.logging.log4j.Level;
 import org.junit.Assert;
 import org.junit.Test;
 import static com.amazon.dataprepper.TestDataProvider.VALID_DATA_PREPPER_CONFIG_FILE;

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/model/Log4JConfigurationTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/parser/model/Log4JConfigurationTests.java
@@ -2,7 +2,8 @@ package com.amazon.dataprepper.parser.model;
 
 import java.util.Properties;
 import java.util.UUID;
-import org.apache.log4j.Level;
+
+import org.apache.logging.log4j.Level;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/data-prepper-plugins/elasticsearch/build.gradle
+++ b/data-prepper-plugins/elasticsearch/build.gradle
@@ -63,6 +63,9 @@ configurations.all {
         force 'org.yaml:snakeyaml:1.28'
         force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.12.1'
         force 'junit:junit:4.13'
+        force "org.slf4j:slf4j-api:1.7.30"
+        force "org.apache.logging.log4j:log4j-api:2.14.0"
+        force "org.apache.logging.log4j:log4j-core:2.14.0"
     }
 }
 

--- a/examples/dev/trace-analytics-sample-app/docker-compose.yml
+++ b/examples/dev/trace-analytics-sample-app/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     volumes:
       - ./resources/data-prepper-wait-for-odfe-and-start.sh:/usr/share/data-prepper/data-prepper-wait-for-odfe-and-start.sh
       - ./resources/trace_analytics_no_ssl.yml:/usr/share/data-prepper/data-prepper.yml
-      - ../../../shared-config/log4j.properties:/usr/share/data-prepper/log4j.properties
+      - ../../../shared-config/log4j2.properties:/usr/share/data-prepper/log4j.properties
       - ../../demo/root-ca.pem:/usr/share/data-prepper/root-ca.pem
     ports:
       - "4900:4900" # DataPrepperServer port

--- a/shared-config/log4j2.properties
+++ b/shared-config/log4j2.properties
@@ -1,0 +1,38 @@
+status = error
+dest = err
+name = PropertiesConfig
+ 
+property.filename = logs/data-prepper.log
+ 
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ISO8601} [%t] %-5p %40C - %m%n
+
+appender.rolling.type = RollingFile
+appender.rolling.name = RollingFile
+appender.rolling.fileName = ${filename}
+appender.rolling.filePattern = logs/data-prepper.log.%d{MM-dd-yy-HH}-%i.gz
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = %d{ISO8601} [%t] %-5p %40C - %m%n
+appender.rolling.policies.type = Policies
+appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.rolling.policies.time.interval = 1
+appender.rolling.policies.time.modulate = true
+appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.rolling.policies.size.size=100MB
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.max = 168
+ 
+rootLogger.level = warn
+rootLogger.appenderRef.stdout.ref = STDOUT
+rootLogger.appenderRef.file.ref = RollingFile
+
+logger.pipeline.name = com.amazon.dataprepper.pipeline
+logger.pipeline.level = info
+
+logger.parser.name = com.amazon.dataprepper.parser
+logger.parser.level = info
+
+logger.plugins.name = com.amazon.dataprepper.plugins
+logger.plugins.level = info


### PR DESCRIPTION
*Description of changes:*
* Switching the logging backend from log4j to log4j2
* Had to include a new log4j2.properties file as the upgrade isn't 100% backwards compatible

I also had a question as to if we should keep the log4j runtime configuration stuff via DP config, as it seems we're already passing in a log4j.properties file as part of the startup command - figured we can discuss that here.

I'll go back and clean up some of the docs around the old log4j stuff once this is merged. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
