### PR TITLE
adding deployment template for kubernetes environment for data-prepper.

### DIFF
--- a/deployment-template/k8s/data-prepper-k8s-deployment.yaml
+++ b/deployment-template/k8s/data-prepper-k8s-deployment.yaml
@@ -1,0 +1,126 @@
+apiVersion: v1
+data:
+  data-prepper-wait-for-odfe-and-start.sh: |-
+    !/bin/bash
+
+    until [[ $(curl --write-out %{http_code} --output /dev/null --silent --head --fail https://opendistro-for-elasticsearch:9200 --insecure) == 200 ]]; do
+      echo "Waiting for ODFE to be ready"
+      sleep 1
+    done
+
+    java -Xms128m -Xmx128m -jar /usr/share/data-prepper/data-prepper.jar /appconfig/data-prepper.yml
+
+  data-prepper.yml: |
+    entry-pipeline:
+      delay: "100"
+      source:
+        otel_trace_source:
+          ssl: false
+      sink:
+        - pipeline:
+            name: "raw-pipeline"
+        - pipeline:
+            name: "service-map-pipeline"
+    raw-pipeline:
+      source:
+        pipeline:
+          name: "entry-pipeline"
+      processor:
+        - otel_trace_raw_processor:
+      sink:
+        - elasticsearch:
+            hosts: [ "https://opendistro-for-elasticsearch:9200" ]
+            insecure: true
+            aws_region: "us-east-1"
+            username: "admin"
+            password: "admin"
+            trace_analytics_raw: true
+    service-map-pipeline:
+      delay: "100"
+      source:
+        pipeline:
+          name: "entry-pipeline"
+      processor:
+        - service_map_stateful:
+      sink:
+        - elasticsearch:
+            hosts: ["https://opendistro-for-elasticsearch:9200"]
+            insecure: true
+            aws_region: "us-east-1"
+            username: "admin"
+            password: "admin"
+            trace_analytics_service_map: true
+kind: ConfigMap
+metadata:
+  name: data-prepper-config
+  namespace: tracing
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: data-prepper
+  name: data-prepper
+  namespace: tracing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: data-prepper
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.network/my-network: "true"
+        app: data-prepper
+    spec:
+      containers:
+      - args:
+        - sh
+        - /appconfig/data-prepper-wait-for-odfe-and-start.sh
+        image: amazon/opendistro-for-elasticsearch-data-prepper:latest
+        name: data-prepper
+        securityContext:
+          runAsUser: 0
+        ports:
+        - containerPort: 21890
+        volumeMounts:
+        - mountPath: /appconfig
+          name: prepper-configmap-claim
+      restartPolicy: Always
+      volumes:
+      - name: prepper-configmap-claim
+        configMap:
+          name: data-prepper-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: data-prepper
+  name: data-prepper
+  namespace: tracing
+spec:
+  ports:
+  - name: "21890"
+    port: 21890
+    targetPort: 21890
+  selector:
+    app: data-prepper
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: data-prepper
+  name: data-prepper-headless
+spec:
+  clusterIP: None
+  ports:
+  - name: "21890"
+    port: 21890
+    targetPort: 21890
+  selector:
+    app: data-prepper
+---


### PR DESCRIPTION
*Description of changes:*

Could not find any deployment template that works in k8s environment and did not want to run data-prepper in EC2. Heres a template that works in k8s and taken in part from your dev env. 