### PR TITLE
#443: PipelineConnector no longer throws exception on timeout.

### DIFF
--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/PipelineConnector.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/PipelineConnector.java
@@ -49,14 +49,16 @@ public final class PipelineConnector<T extends Record<?>> implements Source<T>, 
     public void output(final Collection<T> records) {
         if (buffer != null && !isStopRequested.get()) {
             for (T record : records) {
-                try {
-                    buffer.write(record, DEFAULT_WRITE_TIMEOUT);
-                } catch (TimeoutException ex) {
-                    LOG.error("PipelineConnector [{}-{}]: Timed out writing to pipeline [{}]",
-                            sinkPipelineName, sourcePipelineName, sourcePipelineName, ex);
-                    throw new RuntimeException(format("PipelineConnector [%s-%s]: Timed out writing to pipeline [%s]'s " +
-                                    "buffer", sinkPipelineName, sourcePipelineName, sourcePipelineName), ex);
+                while (true) {
+                    try {
+                        buffer.write(record, DEFAULT_WRITE_TIMEOUT);
+                        break;
+                    } catch (TimeoutException ex) {
+                        LOG.error("PipelineConnector [{}-{}]: Timed out writing to pipeline [{}]",
+                                sinkPipelineName, sourcePipelineName, sourcePipelineName, ex);
+                    }
                 }
+
             }
         } else {
             LOG.error("PipelineConnector [{}-{}]: Pipeline [{}] is currently not initialized or has been halted",

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/pipeline/PipelineConnectorTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/pipeline/PipelineConnectorTest.java
@@ -17,6 +17,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -52,13 +53,15 @@ public class PipelineConnectorTest {
         sut.output(recordList);
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testOutputBufferTimesOut() throws Exception {
-        doThrow(new TimeoutException()).when(buffer).write(any(), anyInt());
+    @Test
+    public void testOutputBufferTimesOutThenSucceeds() throws Exception {
+        doThrow(new TimeoutException()).doNothing().when(buffer).write(any(), anyInt());
 
         sut.start(buffer);
 
         sut.output(recordList);
+
+        verify(buffer, times(2)).write(eq(RECORD), anyInt());
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:* #443

*Description of changes:*
* Changing PipelineConnector to continuously retry writing to the buffer, instead of crashing if MAX_INT has somehow elapsed.
-----

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
