### PR TITLE
Enable Unframedrequest for curl health checks

### DIFF
--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
@@ -48,6 +48,7 @@ public class OTelTraceSource implements Source<Record<ExportTraceServiceRequest>
                             pluginMetrics
                     ))
                     .addService(new HealthGrpcService())
+                    .enableUnframedRequests(true)
                     .useClientTimeoutHeader(false);
 
             if (oTelTraceSourceConfig.hasHealthCheck()) {

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -144,7 +144,7 @@ public class OTelTraceSourceTest {
                 HttpData.copyOf(JsonFormat.printer().print(SUCCESS_REQUEST).getBytes()))
                 .aggregate()
                 .whenComplete((i, ex) -> {
-                    assertThat(i.status().code()).isEqualTo(415);
+                    assertThat(i.status().code()).isEqualTo(503);
                 }).join();
         WebClient.of().execute(RequestHeaders.builder()
                         .scheme(SessionProtocol.HTTP)
@@ -156,7 +156,7 @@ public class OTelTraceSourceTest {
                 HttpData.copyOf(JsonFormat.printer().print(FAILURE_REQUEST).getBytes()))
                 .aggregate()
                 .whenComplete((i, ex) -> {
-                    assertThat(i.status().code()).isEqualTo(415);
+                    assertThat(i.status().code()).isEqualTo(503);
                     //validateBuffer();
                 }).join();
 
@@ -174,7 +174,7 @@ public class OTelTraceSourceTest {
                 HttpData.copyOf(SUCCESS_REQUEST.toByteArray()))
                 .aggregate()
                 .whenComplete((i, ex) -> {
-                    assertThat(i.status().code()).isEqualTo(415);
+                    assertThat(i.status().code()).isEqualTo(503);
                 }).join();
         WebClient.of().execute(RequestHeaders.builder()
                         .scheme(SessionProtocol.HTTP)
@@ -186,7 +186,7 @@ public class OTelTraceSourceTest {
                 HttpData.copyOf(FAILURE_REQUEST.toByteArray()))
                 .aggregate()
                 .whenComplete((i, ex) -> {
-                    assertThat(i.status().code()).isEqualTo(415);
+                    assertThat(i.status().code()).isEqualTo(503);
                     //validateBuffer();
                 }).join();
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Enable UnframedRequests for OtelTraceSource - _This will enable curl health checks if we use LB_

```
byadav$ ./gradlew :data-prepper-plugins:otel-trace-source:build
byadav$ ./gradlew build
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 6.5
  OS Info               : Mac OS X 10.15.7 (x86_64)
  JDK Version           : 14 (Oracle JDK)
  Random Testing Seed   : BC66D52477A14198
  In FIPS 140 mode      : false
=======================================

> Task :data-prepper-core:test
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended

> Task :data-prepper-plugins:elasticsearch:checkstyleMain
Checkstyle violations by severity: [error:3]


> Task :data-prepper-plugins:elasticsearch:checkstyleTest
Checkstyle files with violations: 3
Checkstyle violations by severity: [error:8]


> Task :data-prepper-plugins:elasticsearch:forbiddenApisMain
> Task :data-prepper-plugins:elasticsearch:forbiddenApisTest
> Task :data-prepper-plugins:lmdb-prepper-state:compileTestJava
Note: /Users/byadav/workplace/DataPrepper/data-prepper/data-prepper-plugins/lmdb-prepper-state/src/test/java/com/amazon/dataprepper/plugins/prepper/state/LmdbPrepperStateTest.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :data-prepper-plugins:lmdb-prepper-state:test

> Task :data-prepper-plugins:otel-trace-raw-prepper:compileTestJava
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :data-prepper-plugins:otel-trace-raw-prepper:test
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended

> Task :data-prepper-plugins:peer-forwarder:compileTestJava
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :data-prepper-plugins:peer-forwarder:test
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended

> Task :data-prepper-plugins:service-map-stateful:test
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 2m 57s
86 actionable tasks: 54 executed, 32 up-to-date
```

-----

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
