### PR TITLE
Added debug code around the failing testBufferFull() test.

### DIFF
--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -114,7 +114,14 @@ public class OTelTraceSourceTest {
 
     @Test
     void testBufferFull() {
-        CLIENT.export(SUCCESS_REQUEST);
+        try {
+            // Debugging a recurring issue with this particular test
+            CLIENT.export(SUCCESS_REQUEST);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+
         try {
             CLIENT.export(ExportTraceServiceRequest.newBuilder().build());
         } catch (RuntimeException ex) {


### PR DESCRIPTION
*Description of changes:*
Still seeing a failing test during GitHub builds, difficult to reproduce. Adding a print statement to hopefully help debug.

Example failure: https://github.com/opendistro-for-elasticsearch/data-prepper/pull/496/checks?check_run_id=2321506008



-----

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
