### PR TITLE
Revised shutdown behavior to limit data loss.

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
@@ -97,6 +97,10 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
         recordsProcessedCounter.increment(numRecordsToBeChecked);
     }
 
+    protected int getRecordsInFlight() {
+        return recordsInFlight.intValue();
+    }
+
     /**
      * This method should implement the logic for writing to the  buffer
      * @param record Record to write to buffer
@@ -113,4 +117,6 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
     public abstract Map.Entry<Collection<T>, CheckpointState> doRead(int timeoutInMillis);
 
     public abstract void doCheckpoint(CheckpointState checkpointState);
+
+    public abstract boolean isEmpty();
 }

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/Buffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/Buffer.java
@@ -35,4 +35,6 @@ public interface Buffer<T extends Record<?>> {
      * @param checkpointState the summary object of checkpoint variables
      */
     void checkpoint(CheckpointState checkpointState);
+
+    boolean isEmpty();
 }

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/Prepper.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/Prepper.java
@@ -20,7 +20,20 @@ public interface Prepper<InputRecord extends Record<?>, OutputRecord extends Rec
     Collection<OutputRecord> execute(Collection<InputRecord> records);
 
     /**
-     * Prepare prepper for shutdown, by cleaning up resources and threads.
+     * Indicates to the Prepper that shutdown is imminent and any data currently held by the Prepper
+     * should be flushed downstream.
+     */
+    void prepareForShutdown();
+
+    /**
+     * Returns true if the Prepper's internal state is safe to be shutdown.
+     *
+     * @return shutdown readiness status
+     */
+    boolean isReadyForShutdown();
+
+    /**
+     * Final shutdown call to clean up any resources that need to be closed.
      */
     void shutdown();
 }

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/buffer/AbstractBufferTest.java
@@ -60,6 +60,7 @@ public class AbstractBufferTest {
         Assert.assertEquals(1, recordsReadMeasurements.size());
         Assert.assertEquals(5.0, recordsReadMeasurements.get(0).getValue(), 0);
         Assert.assertEquals(1, recordsInFlightMeasurements.size());
+        Assert.assertEquals(5, abstractBuffer.getRecordsInFlight());
         final Measurement recordsInFlightMeasurement = recordsInFlightMeasurements.get(0);
         Assert.assertEquals(5.0, recordsInFlightMeasurement.getValue(), 0);
         Assert.assertEquals(1, recordsProcessedMeasurements.size());
@@ -83,6 +84,7 @@ public class AbstractBufferTest {
         abstractBuffer.checkpoint(readResult.getValue());
 
         // Then
+        Assert.assertEquals(0, abstractBuffer.getRecordsInFlight());
         Assert.assertEquals(0.0, recordsInFlightMeasurement.getValue(), 0);
         Assert.assertEquals(5.0, recordsProcessedMeasurement.getValue(), 0);
         Assert.assertEquals(1.0, MetricsTestUtil.getMeasurementFromList(checkpointTimeMeasurements, Statistic.COUNT).getValue(), 0);
@@ -159,6 +161,11 @@ public class AbstractBufferTest {
         @Override
         public void doCheckpoint(final CheckpointState checkpointState) {
 
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
         }
     }
 

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/prepper/AbstractPrepperTest.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/prepper/AbstractPrepperTest.java
@@ -69,6 +69,16 @@ public class AbstractPrepperTest {
         }
 
         @Override
+        public void prepareForShutdown() {
+
+        }
+
+        @Override
+        public boolean isReadyForShutdown() {
+            return true;
+        }
+
+        @Override
         public void shutdown() {
 
         }

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -81,7 +81,7 @@ def createDataPrepperDockerContainer(final String taskBaseName, final String dat
         dependsOn buildDataPrepperDockerImage
         dependsOn createDataPrepperNetwork
         containerName = dataPrepperName
-        hostConfig.portBindings = ['%d:21890'.formatted(grpcPort), '%d:4900'.formatted(serverPort)]
+        hostConfig.portBindings = [String.format('%d:21890', grpcPort), String.format('%d:4900', serverPort)]
         hostConfig.network = createDataPrepperNetwork.getNetworkName()
         cmd = ["java", "-jar", "data-prepper.jar", pipelineConfigYAML, "/app/data_prepper.yml"]
         targetImageId buildDataPrepperDockerImage.getImageId()

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
@@ -106,9 +106,10 @@ public class DataPrepper {
      * Triggers the shutdown of all configured valid pipelines.
      */
     public void shutdown() {
-        transformationPipelines.forEach((name, pipeline) -> {
+        for (final Pipeline pipeline : transformationPipelines.values()) {
+            LOG.info("Shutting down pipeline: {}", pipeline.getName());
             pipeline.shutdown();
-        });
+        }
     }
 
     /**

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/PipelineParser.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/PipelineParser.java
@@ -21,8 +21,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -54,7 +54,9 @@ public class PipelineParser {
                     new TypeReference<Map<String, PipelineConfiguration>>() {
                     });
             final List<String> allPipelineNames = PipelineConfigurationValidator.validateAndGetPipelineNames(pipelineConfigurationMap);
-            final Map<String, Pipeline> pipelineMap = new HashMap<>();
+
+            // LinkedHashMap to preserve insertion order
+            final Map<String, Pipeline> pipelineMap = new LinkedHashMap<>();
             pipelineConfigurationMap.forEach((pipelineName, configuration) ->
                     configuration.updateCommonPipelineConfiguration(pipelineName));
             for (String pipelineName : allPipelineNames) {

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/Pipeline.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/Pipeline.java
@@ -77,10 +77,10 @@ public class Pipeline {
         this.prepperThreads = prepperThreads;
         this.readBatchTimeoutInMillis = readBatchTimeoutInMillis;
         this.prepperExecutorService = PipelineThreadPoolExecutor.newFixedThreadPool(prepperThreads,
-                new PipelineThreadFactory(format("%s-process-worker", name)), this);
+                new PipelineThreadFactory(format("%s-prepper-worker", name)), this);
 
         this.sinkExecutorService = PipelineThreadPoolExecutor.newFixedThreadPool(sinks.size(),
-                new PipelineThreadFactory(format("%s-process-worker", name)), this);
+                new PipelineThreadFactory(format("%s-sink-worker", name)), this);
 
         stopRequested = false;
     }

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/ProcessWorker.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/ProcessWorker.java
@@ -1,12 +1,12 @@
 package com.amazon.dataprepper.pipeline;
 
+import com.amazon.dataprepper.model.CheckpointState;
 import com.amazon.dataprepper.model.buffer.Buffer;
 import com.amazon.dataprepper.model.prepper.Prepper;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.model.sink.Sink;
 import com.amazon.dataprepper.pipeline.common.FutureHelper;
 import com.amazon.dataprepper.pipeline.common.FutureHelperResult;
-import com.amazon.dataprepper.model.CheckpointState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,8 +62,8 @@ public class ProcessWorker implements Runnable {
                 // Checkpoint the current batch read from the buffer after being processed by prepper and sinks.
                 readBuffer.checkpoint(checkpointState);
             } while (!shouldStop());
-        } catch (final Exception ex) {
-            LOG.error("Encountered exception during pipeline processing", ex); //do not halt the execution
+        } catch (final Exception e) {
+            LOG.error("Encountered exception during pipeline {} processing", pipeline.getName(), e);
         }
     }
 
@@ -73,16 +73,13 @@ public class ProcessWorker implements Runnable {
      * @return
      */
     private boolean shouldStop() {
-        return pipeline.isStopRequested() && isBufferEmpty();
+        return pipeline.isStopRequested() && areComponentsReadyForShutdown();
     }
 
-    /**
-     * TODO Implement this from Buffer [Probably AtomicBoolean], for now we will return true
-     *
-     * @return
-     */
-    private boolean isBufferEmpty() {
-        return true;
+    private boolean areComponentsReadyForShutdown() {
+        return readBuffer.isEmpty() && preppers.stream()
+                .map(Prepper::isReadyForShutdown)
+                .allMatch(result -> result == true);
     }
 
     /**

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/pipeline/PipelineTests.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/pipeline/PipelineTests.java
@@ -113,6 +113,16 @@ public class PipelineTests {
             }
 
             @Override
+            public void prepareForShutdown() {
+
+            }
+
+            @Override
+            public boolean isReadyForShutdown() {
+                return true;
+            }
+
+            @Override
             public void shutdown() {
 
             }

--- a/data-prepper-plugins/blocking-buffer/src/main/java/com/amazon/dataprepper/plugins/buffer/blockingbuffer/BlockingBuffer.java
+++ b/data-prepper-plugins/blocking-buffer/src/main/java/com/amazon/dataprepper/plugins/buffer/blockingbuffer/BlockingBuffer.java
@@ -122,8 +122,8 @@ public class BlockingBuffer<T extends Record<?>> extends AbstractBuffer<T> {
                 }
             }
         } catch (InterruptedException ex) {
-            LOG.warn("Pipeline [{}] - Retrieving records from buffer to batch size timed out, returning already " +
-                    "retrieved records", pipelineName, ex);
+            LOG.info("Pipeline [{}] - Interrupt received while reading from buffer", pipelineName);
+            throw new RuntimeException(ex);
         }
         final CheckpointState checkpointState = new CheckpointState(records.size());
         return new AbstractMap.SimpleEntry<>(records, checkpointState);
@@ -144,5 +144,10 @@ public class BlockingBuffer<T extends Record<?>> extends AbstractBuffer<T> {
     public void doCheckpoint(final CheckpointState checkpointState) {
         final int numCheckedRecords = checkpointState.getNumRecordsToBeChecked();
         capacitySemaphore.release(numCheckedRecords);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return blockingQueue.isEmpty() && getRecordsInFlight() == 0;
     }
 }

--- a/data-prepper-plugins/blocking-buffer/src/test/java/com/amazon/dataprepper/plugins/buffer/blockingbuffer/BlockingBufferTests.java
+++ b/data-prepper-plugins/blocking-buffer/src/test/java/com/amazon/dataprepper/plugins/buffer/blockingbuffer/BlockingBufferTests.java
@@ -15,7 +15,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class BlockingBufferTests {
     private static final String ATTRIBUTE_BATCH_SIZE = "batch_size";
@@ -142,6 +144,25 @@ public class BlockingBufferTests {
             assertThat(record.getData(), equalTo("TEST" + i));
             i++;
         }
+    }
+
+    @Test
+    public void testBufferIsEmpty() {
+        final PluginSetting completePluginSetting = completePluginSettingForBlockingBuffer();
+        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(completePluginSetting);
+
+        assertTrue(blockingBuffer.isEmpty());
+    }
+
+    @Test
+    public void testBufferIsNotEmpty() throws Exception {
+        final PluginSetting completePluginSetting = completePluginSettingForBlockingBuffer();
+        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(completePluginSetting);
+
+        Record<String> record = new Record<>("TEST");
+        blockingBuffer.write(record, TEST_WRITE_TIMEOUT);
+
+        assertFalse(blockingBuffer.isEmpty());
     }
 
     private PluginSetting completePluginSettingForBlockingBuffer() {

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/NoOpPrepper.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/NoOpPrepper.java
@@ -33,6 +33,17 @@ public class NoOpPrepper<InputT extends Record<?>> implements Prepper<InputT, In
     }
 
     @Override
+    public void prepareForShutdown() {
+
+    }
+
+    @Override
+    public boolean isReadyForShutdown() {
+        return true;
+    }
+
+
+    @Override
     public void shutdown() {
 
     }

--- a/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/StringPrepper.java
+++ b/data-prepper-plugins/common/src/main/java/com/amazon/dataprepper/plugins/prepper/StringPrepper.java
@@ -44,6 +44,17 @@ public class StringPrepper implements Prepper<Record<String>, Record<String>> {
     }
 
     @Override
+    public void prepareForShutdown() {
+
+    }
+
+    @Override
+    public boolean isReadyForShutdown() {
+        return true;
+    }
+
+
+    @Override
     public void shutdown() {
 
     }

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/buffer/TestBuffer.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/buffer/TestBuffer.java
@@ -73,6 +73,11 @@ public class TestBuffer implements Buffer<Record<String>> {
 
     }
 
+    @Override
+    public boolean isEmpty() {
+        return buffer.isEmpty();
+    }
+
     public int size() {
         return buffer.size();
     }

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/StringPrepperTests.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/StringPrepperTests.java
@@ -48,6 +48,15 @@ public class StringPrepperTests {
         assertTrue(expectedRecordData.containsAll(modifiedRecordData));
     }
 
+    @Test
+    public void testPrepareForShutdown() {
+        final StringPrepper stringPrepper = new StringPrepper(new PluginSetting(PLUGIN_NAME, new HashMap<>()));
+
+        stringPrepper.prepareForShutdown();
+
+        assertTrue(stringPrepper.isReadyForShutdown());
+    }
+
     private PluginSetting completePluginSettingForStringPrepper(final boolean upperCase) {
         final Map<String, Object> settings = new HashMap<>();
         settings.put(StringPrepper.UPPER_CASE, upperCase);

--- a/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/TestPrepper.java
+++ b/data-prepper-plugins/common/src/test/java/com/amazon/dataprepper/plugins/prepper/TestPrepper.java
@@ -17,7 +17,17 @@ public class TestPrepper implements Prepper<Record<String>, Record<String>> {
 
     @Override
     public Collection<Record<String>> execute(Collection<Record<String>> records) {
-        return null;
+        return records;
+    }
+
+    @Override
+    public void prepareForShutdown() {
+
+    }
+
+    @Override
+    public boolean isReadyForShutdown() {
+        return true;
     }
 
     @Override

--- a/data-prepper-plugins/mapdb-prepper-state/src/main/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperState.java
+++ b/data-prepper-plugins/mapdb-prepper-state/src/main/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperState.java
@@ -76,7 +76,7 @@ public class MapDbPrepperState<V> implements PrepperState<byte[], V> {
     }
 
     public <R> List<R> iterate(BiFunction<byte[], V, R> fn, final int segments, final int index) {
-        if(map.size() == 0) {
+        if (map.isEmpty()) {
             return Collections.EMPTY_LIST;
         }
         final KeyRange iterationEndpoints = getIterationEndpoints(segments, index);

--- a/data-prepper-plugins/otel-trace-group-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltracegroup/OTelTraceGroupPrepper.java
+++ b/data-prepper-plugins/otel-trace-group-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltracegroup/OTelTraceGroupPrepper.java
@@ -150,6 +150,17 @@ public class OTelTraceGroupPrepper extends AbstractPrepper<Record<String>, Recor
         return searchRequest;
     }
 
+
+    @Override
+    public void prepareForShutdown() {
+
+    }
+
+    @Override
+    public boolean isReadyForShutdown() {
+        return true;
+    }
+
     @Override
     public void shutdown() {
         try {

--- a/data-prepper-plugins/otel-trace-group-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/oteltracegroup/OTelTraceGroupPrepperTests.java
+++ b/data-prepper-plugins/otel-trace-group-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/oteltracegroup/OTelTraceGroupPrepperTests.java
@@ -46,6 +46,7 @@ import java.util.concurrent.Future;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
@@ -233,6 +234,13 @@ public class OTelTraceGroupPrepperTests {
         for (Record<String> record: processedRecords) {
             assertNotNull(extractTraceGroupFromRecord(record));
         }
+    }
+
+    @Test
+    public void testPrepareForShutdown() {
+        otelTraceGroupPrepper.prepareForShutdown();
+
+        assertTrue(otelTraceGroupPrepper.isReadyForShutdown());
     }
 
     private Record<String> buildRawSpanRecord(String rawSpanJsonFileName) throws IOException {

--- a/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OTelTraceRawPrepper.java
+++ b/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OTelTraceRawPrepper.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 import io.micrometer.core.instrument.Counter;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
@@ -40,7 +41,7 @@ import java.util.concurrent.locks.ReentrantLock;
 public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServiceRequest>, Record<String>> {
 
     private static final long SEC_TO_MILLIS = 1_000L;
-    private static final Logger log = LoggerFactory.getLogger(OTelTraceRawPrepper.class);
+    private static final Logger LOG = LoggerFactory.getLogger(OTelTraceRawPrepper.class);
 
     public static final String SPAN_PROCESSING_ERRORS = "spanProcessingErrors";
     public static final String RESOURCE_SPANS_PROCESSING_ERRORS = "resourceSpansProcessingErrors";
@@ -65,6 +66,7 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServi
     private long lastTraceFlushTime = 0L;
 
     private final ReentrantLock traceFlushLock = new ReentrantLock();
+    private final ReentrantLock prepareForShutdownLock = new ReentrantLock();
 
     //TODO: https://github.com/opendistro-for-elasticsearch/simple-ingest-transformation-utility-pipeline/issues/66
     public OTelTraceRawPrepper(final PluginSetting pluginSetting) {
@@ -109,7 +111,7 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServi
                         }
                     }
                 } catch (Exception ex) {
-                    log.error("Unable to process invalid ResourceSpan {} :", rs, ex);
+                    LOG.error("Unable to process invalid ResourceSpan {} :", rs, ex);
                     resourceSpanErrorsCounter.increment();
                     totalProcessingErrorsCounter.increment();
                 }
@@ -159,7 +161,7 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServi
             try {
                 rawSpanJson = rawSpan.toJson();
             } catch (JsonProcessingException e) {
-                log.error("Unable to process invalid Span {}:", rawSpan, e);
+                LOG.error("Unable to process invalid Span {}:", rawSpan, e);
                 spanErrorsCounter.increment();
                 totalProcessingErrorsCounter.increment();
                 continue;
@@ -224,7 +226,7 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServi
                             } else {
                                 rawSpans.forEach(rawSpan -> {
                                     recordsToFlush.add(rawSpan);
-                                    log.warn("Missing trace group for SpanId: {}", rawSpan.getSpanId());
+                                    LOG.warn("Missing trace group for SpanId: {}", rawSpan.getSpanId());
                                 });
                             }
 
@@ -232,7 +234,7 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServi
                         }
                     }
                     if (recordsToFlush.size() > 0) {
-                        log.info("Flushing {} records due to GC", recordsToFlush.size());
+                        LOG.info("Flushing {} records due to GC", recordsToFlush.size());
                     }
                 } finally {
                     traceFlushLock.unlock();
@@ -245,6 +247,37 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServi
 
     private boolean shouldGarbageCollect() {
         return System.currentTimeMillis() - lastTraceFlushTime >= traceFlushInterval;
+    }
+
+    /**
+     * Re-enqueues all spans with time "0" so that all will be available for consumption.
+     */
+    @Override
+    public void prepareForShutdown() {
+        boolean isLockAcquired = prepareForShutdownLock.tryLock();
+
+        if (isLockAcquired) {
+            try {
+                LOG.info("Preparing for shutdown, re-enqueueing {} spans", delayedParentSpanQueue.size());
+                Iterator iterator = delayedParentSpanQueue.iterator();
+                List<DelayedParentSpan> delayedParentSpanList = ImmutableList.copyOf(iterator);
+
+                delayedParentSpanQueue.clear();
+
+                for (final DelayedParentSpan delayedParentSpan : delayedParentSpanList) {
+                    final DelayedParentSpan newSpan = new DelayedParentSpan(delayedParentSpan.getRawSpan(), 0L);
+                    delayedParentSpanQueue.add(newSpan);
+                }
+            } finally {
+                prepareForShutdownLock.unlock();
+            }
+        }
+    }
+
+    @Override
+    public boolean isReadyForShutdown() {
+        return delayedParentSpanQueue.isEmpty()
+                && traceIdRawSpanSetMap.isEmpty();
     }
 
     @Override

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarder.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarder.java
@@ -163,6 +163,17 @@ public class PeerForwarder extends AbstractPrepper<Record<ExportTraceServiceRequ
         }
     }
 
+
+    @Override
+    public void prepareForShutdown() {
+
+    }
+
+    @Override
+    public boolean isReadyForShutdown() {
+        return true;
+    }
+
     @Override
     public void shutdown() {
         //TODO: cleanup resources

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -103,7 +104,7 @@ public class PeerForwarderTest {
         final PeerForwarder testPeerForwarder = generatePeerForwarder(Collections.singletonList(LOCAL_IP), 2);
         final List<Record<ExportTraceServiceRequest>> exportedRecords =
                 testPeerForwarder.doExecute(Arrays.asList(new Record<>(REQUEST_1), new Record<>(REQUEST_2)));
-        Assert.assertTrue(exportedRecords.size() >= 3);
+        assertTrue(exportedRecords.size() >= 3);
         final List<ResourceSpans> exportedResourceSpans = new ArrayList<>();
         for (final Record<ExportTraceServiceRequest> record: exportedRecords) {
             exportedResourceSpans.addAll(record.getData().getResourceSpansList());
@@ -114,8 +115,8 @@ public class PeerForwarderTest {
                 generateResourceSpans(SPAN_4),
                 generateResourceSpans(SPAN_5, SPAN_6)
         );
-        Assert.assertTrue(exportedResourceSpans.containsAll(expectedResourceSpans));
-        Assert.assertTrue(expectedResourceSpans.containsAll(exportedResourceSpans));
+        assertTrue(exportedResourceSpans.containsAll(expectedResourceSpans));
+        assertTrue(expectedResourceSpans.containsAll(exportedResourceSpans));
     }
 
     @Test
@@ -151,13 +152,13 @@ public class PeerForwarderTest {
         Assert.assertEquals(1, exportedRecords.size());
         final ExportTraceServiceRequest localRequest = exportedRecords.get(0).getData();
         final List<ResourceSpans> localResourceSpans = localRequest.getResourceSpansList();
-        Assert.assertTrue(localResourceSpans.containsAll(expectedLocalResourceSpans));
-        Assert.assertTrue(expectedLocalResourceSpans.containsAll(localResourceSpans));
+        assertTrue(localResourceSpans.containsAll(expectedLocalResourceSpans));
+        assertTrue(expectedLocalResourceSpans.containsAll(localResourceSpans));
         Assert.assertEquals(1, requestsByIp.get(peerIp).size());
         final ExportTraceServiceRequest forwardedRequest = requestsByIp.get(peerIp).get(0);
         final List<ResourceSpans> forwardedResourceSpans = forwardedRequest.getResourceSpansList();
-        Assert.assertTrue(forwardedResourceSpans.containsAll(expectedForwardedResourceSpans));
-        Assert.assertTrue(expectedForwardedResourceSpans.containsAll(forwardedResourceSpans));
+        assertTrue(forwardedResourceSpans.containsAll(expectedForwardedResourceSpans));
+        assertTrue(expectedForwardedResourceSpans.containsAll(forwardedResourceSpans));
     }
 
     @Test
@@ -173,8 +174,8 @@ public class PeerForwarderTest {
         Assert.assertEquals(1, exportedRecords.size());
         final ExportTraceServiceRequest localRequest = exportedRecords.get(0).getData();
         final List<ResourceSpans> localResourceSpans = localRequest.getResourceSpansList();
-        Assert.assertTrue(localResourceSpans.containsAll(expectedLocalResourceSpans));
-        Assert.assertTrue(expectedLocalResourceSpans.containsAll(localResourceSpans));
+        assertTrue(localResourceSpans.containsAll(expectedLocalResourceSpans));
+        assertTrue(expectedLocalResourceSpans.containsAll(localResourceSpans));
     }
 
     @Test
@@ -205,8 +206,8 @@ public class PeerForwarderTest {
         Assert.assertEquals(1, requestsByIp.get(peerIp).size());
         final ExportTraceServiceRequest forwardedRequest = requestsByIp.get(peerIp).get(0);
         final List<ResourceSpans> forwardedResourceSpans = forwardedRequest.getResourceSpansList();
-        Assert.assertTrue(forwardedResourceSpans.containsAll(expectedForwardedResourceSpans));
-        Assert.assertTrue(expectedForwardedResourceSpans.containsAll(forwardedResourceSpans));
+        assertTrue(forwardedResourceSpans.containsAll(expectedForwardedResourceSpans));
+        assertTrue(expectedForwardedResourceSpans.containsAll(forwardedResourceSpans));
         Assert.assertEquals(0, exportedRecords.size());
 
         // Verify metrics
@@ -227,9 +228,9 @@ public class PeerForwarderTest {
         // COUNT
         Assert.assertEquals(1.0, forwardRequestLatencyMeasurements.get(0).getValue(), 0);
         // TOTAL_TIME
-        Assert.assertTrue(forwardRequestLatencyMeasurements.get(1).getValue() > 0.0);
+        assertTrue(forwardRequestLatencyMeasurements.get(1).getValue() > 0.0);
         // MAX
-        Assert.assertTrue(forwardRequestLatencyMeasurements.get(2).getValue() > 0.0);
+        assertTrue(forwardRequestLatencyMeasurements.get(2).getValue() > 0.0);
     }
 
     @Test
@@ -254,8 +255,8 @@ public class PeerForwarderTest {
         Assert.assertEquals(1, exportedRecords.size());
         final ExportTraceServiceRequest exportedRequest = exportedRecords.get(0).getData();
         final List<ResourceSpans> forwardedResourceSpans = exportedRequest.getResourceSpansList();
-        Assert.assertTrue(forwardedResourceSpans.containsAll(expectedLocalResourceSpans));
-        Assert.assertTrue(expectedLocalResourceSpans.containsAll(forwardedResourceSpans));
+        assertTrue(forwardedResourceSpans.containsAll(expectedLocalResourceSpans));
+        assertTrue(expectedLocalResourceSpans.containsAll(forwardedResourceSpans));
 
         // Verify metrics
         final List<Measurement> forwardRequestErrorMeasurements = MetricsTestUtil.getMeasurementList(
@@ -275,9 +276,18 @@ public class PeerForwarderTest {
         // COUNT
         Assert.assertEquals(1.0, forwardRequestLatencyMeasurements.get(0).getValue(), 0);
         // TOTAL_TIME
-        Assert.assertTrue(forwardRequestLatencyMeasurements.get(1).getValue() > 0.0);
+        assertTrue(forwardRequestLatencyMeasurements.get(1).getValue() > 0.0);
         // MAX
-        Assert.assertTrue(forwardRequestLatencyMeasurements.get(2).getValue() > 0.0);
+        assertTrue(forwardRequestLatencyMeasurements.get(2).getValue() > 0.0);
+    }
+
+    @Test
+    public void testPrepareForShutdown() {
+        final PeerForwarder peerForwarder = generatePeerForwarder(Collections.singletonList(LOCAL_IP), 2);
+
+        peerForwarder.prepareForShutdown();
+
+        assertTrue(peerForwarder.isReadyForShutdown());
     }
 
     /**

--- a/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
@@ -41,6 +41,8 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Collection<Record<String>> EMPTY_COLLECTION = Collections.emptySet();
     private static final Integer TO_MILLIS = 1_000;
+
+    // TODO: This should not be tracked in this class, move it up to the creator
     private static final AtomicInteger preppersCreated = new AtomicInteger(0);
     private static long previousTimestamp;
     private static long windowDurationMillis;
@@ -61,7 +63,9 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
     public ServiceMapStatefulPrepper(final PluginSetting pluginSetting) {
         this(pluginSetting.getIntegerOrDefault(ServiceMapPrepperConfig.WINDOW_DURATION, ServiceMapPrepperConfig.DEFAULT_WINDOW_DURATION) * TO_MILLIS,
                 new File(ServiceMapPrepperConfig.DEFAULT_DB_PATH),
-                Clock.systemUTC(), pluginSetting.getNumberOfProcessWorkers(), pluginSetting);
+                Clock.systemUTC(),
+                pluginSetting.getNumberOfProcessWorkers(),
+                pluginSetting);
     }
 
     public ServiceMapStatefulPrepper(final long windowDurationMillis,
@@ -261,12 +265,29 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
         }
     }
 
+
+    @Override
+    public void prepareForShutdown() {
+        previousTimestamp = 0L;
+    }
+
+    @Override
+    public boolean isReadyForShutdown() {
+        return currentWindow.size() == 0;
+    }
+
     @Override
     public void shutdown() {
         previousWindow.delete();
         currentWindow.delete();
         previousTraceGroupWindow.delete();
         currentTraceGroupWindow.delete();
+    }
+
+    // TODO: Temp code, complex instance creation logic should be moved to a separate class
+    static void resetStaticCounters() {
+        preppersCreated.set(0);
+        edgeEvaluationLatch = null;
     }
 
     /**

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepperTest.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepperTest.java
@@ -29,6 +29,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 
@@ -49,6 +51,7 @@ public class ServiceMapStatefulPrepperTest {
 
     @Before
     public void setup() {
+        ServiceMapStatefulPrepper.resetStaticCounters();
         MetricsTestUtil.initMetrics();
     }
 
@@ -150,7 +153,7 @@ public class ServiceMapStatefulPrepperTest {
 
         //Should find the frontend->checkout relationship indicated in the first batch
         Assert.assertEquals(2, relationshipsFound.size());
-        Assert.assertTrue(relationshipsFound.containsAll(Arrays.asList(
+        assertTrue(relationshipsFound.containsAll(Arrays.asList(
                 frontendCheckout,
                 checkoutTarget
         )));
@@ -164,7 +167,7 @@ public class ServiceMapStatefulPrepperTest {
 
         //Should find the rest of the relationships
         Assert.assertEquals(10, relationshipsFound.size());
-        Assert.assertTrue(relationshipsFound.containsAll(Arrays.asList(
+        assertTrue(relationshipsFound.containsAll(Arrays.asList(
                 frontendAuth,
                 authTarget,
                 authPassword,
@@ -184,7 +187,7 @@ public class ServiceMapStatefulPrepperTest {
                 new ServiceMapSourceDest(CHECKOUT_SERVICE, PAYMENT_SERVICE)
         );
 
-        Assert.assertTrue(evaluateEdges(relationshipsFound).containsAll(expectedSourceDests));
+        assertTrue(evaluateEdges(relationshipsFound).containsAll(expectedSourceDests));
 
         // Verify gauges
         final List<Measurement> spansDbSizeMeasurement = MetricsTestUtil.getMeasurementList(
@@ -211,15 +214,39 @@ public class ServiceMapStatefulPrepperTest {
                 Collections.singletonList(new Record<>(ServiceMapTestUtils.getExportTraceServiceRequest(frontendSpans3))));
         Future<Set<ServiceMapRelationship>> r8 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful2,
                 Collections.singletonList(new Record<>(ServiceMapTestUtils.getExportTraceServiceRequest(authenticationSpansServer2))));
-        Assert.assertTrue(r7.get().isEmpty());
-        Assert.assertTrue(r8.get().isEmpty());
+        assertTrue(r7.get().isEmpty());
+        assertTrue(r8.get().isEmpty());
 
         when(clock.millis()).thenReturn(560L);
         Future<Set<ServiceMapRelationship>> r9 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful1, Arrays.asList());
         Future<Set<ServiceMapRelationship>> r10 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful2, Arrays.asList());
-        Assert.assertTrue(r9.get().isEmpty());
-        Assert.assertTrue(r10.get().isEmpty());
+        assertTrue(r9.get().isEmpty());
+        assertTrue(r10.get().isEmpty());
         serviceMapStateful1.shutdown();
+    }
+
+    @Test
+    public void testPrepareForShutdown() throws Exception {
+        final File path = new File(ServiceMapPrepperConfig.DEFAULT_DB_PATH);
+        final ServiceMapStatefulPrepper serviceMapStateful = new ServiceMapStatefulPrepper(100, path, Clock.systemUTC(), 1, PLUGIN_SETTING);
+
+        final byte[] rootSpanId1 = ServiceMapTestUtils.getRandomBytes(8);
+        final byte[] traceId1 = ServiceMapTestUtils.getRandomBytes(16);
+        final String traceGroup1 = "reset_password";
+
+        final ResourceSpans frontendSpans1 = ServiceMapTestUtils.getResourceSpans(FRONTEND_SERVICE, traceGroup1, rootSpanId1, null, traceId1, Span.SpanKind.SPAN_KIND_CLIENT);
+        final ResourceSpans authenticationSpansServer = ServiceMapTestUtils.getResourceSpans(AUTHENTICATION_SERVICE, "reset", ServiceMapTestUtils.getRandomBytes(8), ServiceMapTestUtils.getSpanId(frontendSpans1), traceId1, Span.SpanKind.SPAN_KIND_SERVER);
+
+        serviceMapStateful.execute(Collections.singletonList(new Record<>(ServiceMapTestUtils.getExportTraceServiceRequest(frontendSpans1, authenticationSpansServer))));
+
+        assertFalse(serviceMapStateful.isReadyForShutdown());
+
+        serviceMapStateful.prepareForShutdown();
+        serviceMapStateful.execute(Collections.emptyList());
+
+        assertTrue(serviceMapStateful.isReadyForShutdown());
+
+        serviceMapStateful.shutdown();
     }
 
     private static class ServiceMapSourceDest {

--- a/shared-config/log4j2.properties
+++ b/shared-config/log4j2.properties
@@ -12,6 +12,9 @@ appender.console.layout.pattern = %d{ISO8601} [%t] %-5p %40C - %m%n
 rootLogger.level = warn
 rootLogger.appenderRef.stdout.ref = STDOUT
 
+logger.core.name = com.amazon.dataprepper
+logger.core.level = info
+
 logger.pipeline.name = com.amazon.dataprepper.pipeline
 logger.pipeline.level = info
 


### PR DESCRIPTION
*Issue #, if available:* #476

*Description of changes:*
Need to ensure pipelines and components are shut down in a graceful manner to prevent data loss (specifically within stateful components). Added 2 new APIs to the Prepper interface: `prepareForShutdown()` and `isReadyForShutdown()`. High level flow:
1. Shutdown API is called on the server
2. `shutdown()` is called on each Pipeline. Pipelines are sorted in a topological order such that shutdown occurs starting upstream and proceeding downstream.
3. Within each pipeline:
    1. The source is stopped to prevent new data from entering
    2. Preppers are notified of the shutdown via `prepareForShutdown()`. This allows them time to clear state by flushing records
        * There's still an improvement here to be made when dealing with long chains of preppers, but it can wait
    3. The pipeline waits for ProcessWorkers to exit their work loop. This happens once the buffer is clear and every prepper returns true when `isReadyForShutdown()` is called.
    4. ProcessWorkers are stopped
    5. Preppers and sinks are `shutdown()` (cleans up any resources)
    6. A new sinkExecutorService is stopped. 
        * Previously a single prepperSinkExecutorService was used for both preppers and sinks, however it had to be split because of a circular dependency. `prepperSinkExecutorService` was used to run ProcessWorkers, but ProcessWorkers also used it to submit sink-write jobs. So "shutting prepperSinkExecutorService down" would wait for ProcessWorkers to exit their loops, but part of exiting their loops included submitting new tasks to the prepperSinkExecutorService when writing to sinks.

Implemented the shutdown flow described above, as well as implemented the new methods and tests in existing preppers. Also misc fixes in the ServiceMap prepper tests.

Testing calling `/shutdown` on the sample app with 4 workers per pipeline:
```
2021-04-13T18:15:50,266 [entry-pipeline-process-worker-1-thread-4] INFO  com.amazon.dataprepper.pipeline.ProcessWorker -  entry-pipeline Worker: Processing 1 records from buffer
2021-04-13T18:15:50,367 [service-map-pipeline-process-worker-3-thread-3] INFO  com.amazon.dataprepper.pipeline.ProcessWorker -  service-map-pipeline Worker: Processing 1 records from buffer
2021-04-13T18:15:51,866 [raw-pipeline-process-worker-5-thread-3] INFO  com.amazon.dataprepper.pipeline.ProcessWorker -  raw-pipeline Worker: Processing 2 records from buffer
2021-04-13T18:15:51,871 [raw-pipeline-process-worker-5-thread-4] INFO  com.amazon.dataprepper.pipeline.ProcessWorker -  raw-pipeline Worker: Processing 2 records from buffer
2021-04-13T18:15:51,873 [raw-pipeline-process-worker-5-thread-1] INFO  com.amazon.dataprepper.pipeline.ProcessWorker -  raw-pipeline Worker: Processing 3 records from buffer
2021-04-13T18:15:53,267 [raw-pipeline-process-worker-5-thread-2] INFO  com.amazon.dataprepper.pipeline.ProcessWorker -  raw-pipeline Worker: Processing 3 records from buffer
2021-04-13T18:15:57,500 [HTTP-Dispatcher] INFO        com.amazon.dataprepper.DataPrepper - Shutting down pipeline: entry-pipeline
2021-04-13T18:15:57,501 [HTTP-Dispatcher] INFO  com.amazon.dataprepper.pipeline.Pipeline - Pipeline [entry-pipeline] - Received shutdown signal with timeout 10000, will initiate the shutdown process
2021-04-13T18:15:59,523 [HTTP-Dispatcher] INFO  com.amazon.dataprepper.plugins.source.oteltrace.OTelTraceSource - Stopped otel_trace_source.
2021-04-13T18:15:59,524 [HTTP-Dispatcher] INFO  com.amazon.dataprepper.pipeline.Pipeline - Pipeline [entry-pipeline] - Shutting down process workers
2021-04-13T18:15:59,582 [HTTP-Dispatcher] INFO  com.amazon.dataprepper.pipeline.Pipeline - Pipeline [entry-pipeline] - Shutting down process workers
2021-04-13T18:15:59,583 [HTTP-Dispatcher] INFO        com.amazon.dataprepper.DataPrepper - Shutting down pipeline: service-map-pipeline
2021-04-13T18:15:59,583 [HTTP-Dispatcher] INFO  com.amazon.dataprepper.pipeline.Pipeline - Pipeline [service-map-pipeline] - Received shutdown signal with timeout 10000, will initiate the shutdown process
2021-04-13T18:15:59,583 [HTTP-Dispatcher] INFO  com.amazon.dataprepper.pipeline.Pipeline - Pipeline [service-map-pipeline] - Shutting down process workers
2021-04-13T18:15:59,775 [HTTP-Dispatcher] INFO  com.amazon.dataprepper.pipeline.Pipeline - Pipeline [service-map-pipeline] - Shutting down process workers
2021-04-13T18:15:59,775 [HTTP-Dispatcher] INFO        com.amazon.dataprepper.DataPrepper - Shutting down pipeline: raw-pipeline
2021-04-13T18:15:59,775 [HTTP-Dispatcher] INFO  com.amazon.dataprepper.pipeline.Pipeline - Pipeline [raw-pipeline] - Received shutdown signal with timeout 10000, will initiate the shutdown process
2021-04-13T18:15:59,775 [HTTP-Dispatcher] INFO  com.amazon.dataprepper.plugins.prepper.oteltrace.OTelTraceRawPrepper - Preparing for shutdown, re-enqueueing 12 spans
2021-04-13T18:15:59,780 [HTTP-Dispatcher] INFO  com.amazon.dataprepper.pipeline.Pipeline - Pipeline [raw-pipeline] - Shutting down process workers
2021-04-13T18:16:02,270 [HTTP-Dispatcher] INFO  com.amazon.dataprepper.pipeline.Pipeline - Pipeline [raw-pipeline] - Shutting down process workers
2021-04-13T18:16:02,271 [HTTP-Dispatcher] INFO  com.amazon.dataprepper.pipeline.server.DataPrepperServer - Data Prepper server stopped

```

-----

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
