### PR TITLE
ENH: peer forwarder domain or ip validator

### DIFF
--- a/data-prepper-plugins/elasticsearch/build.gradle
+++ b/data-prepper-plugins/elasticsearch/build.gradle
@@ -53,6 +53,7 @@ configurations.all {
     resolutionStrategy {
         force 'com.amazonaws:aws-java-sdk-core:1.11.1000'
         force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.2'
+        force 'com.fasterxml.jackson.core:jackson-annotations:2.12.2'
         force 'com.fasterxml.jackson.core:jackson-databind:2.12.2'
         force 'com.fasterxml.jackson.core:jackson-core:2.12.2'
         force 'com.fasterxml.jackson:jackson-bom:2.12.3'

--- a/data-prepper-plugins/peer-forwarder/build.gradle
+++ b/data-prepper-plugins/peer-forwarder/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
     implementation "com.linecorp.armeria:armeria:1.6.0"
     implementation "com.linecorp.armeria:armeria-grpc:1.6.0"
+    implementation "commons-validator:commons-validator:1.7"
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.mockito:mockito-inline:3.9.0"
 }

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/PeerListProviderFactory.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/PeerListProviderFactory.java
@@ -7,16 +7,11 @@ import com.google.common.base.Preconditions;
 import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
 import org.apache.commons.validator.routines.DomainValidator;
 import org.apache.commons.validator.routines.InetAddressValidator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Objects;
 
 public class PeerListProviderFactory {
-
-    private static final Logger LOG = LoggerFactory.getLogger(PeerListProviderFactory.class);
-
     // TODO: Make these configurable?
     private static final int MIN_TTL = 10;
     private static final int MAX_TTL = 20;

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/PeerListProviderFactory.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/PeerListProviderFactory.java
@@ -31,7 +31,7 @@ public class PeerListProviderFactory {
             case DNS:
                 final String domainName = pluginSetting.getStringOrDefault(PeerForwarderConfig.DOMAIN_NAME, null);
                 Objects.requireNonNull(domainName, String.format("Missing '%s' configuration value",PeerForwarderConfig. DOMAIN_NAME));
-                Preconditions.checkArgument(validateEndpoint(domainName), "Invalid domain name: %s", domainName);
+                Preconditions.checkState(validateEndpoint(domainName), "Invalid domain name: %s", domainName);
 
                 final DnsAddressEndpointGroup endpointGroup = DnsAddressEndpointGroup.builder(domainName)
                         .ttl(MIN_TTL, MAX_TTL)
@@ -42,7 +42,7 @@ public class PeerListProviderFactory {
                 final List<String> endpoints = (List<String>) pluginSetting.getAttributeOrDefault(PeerForwarderConfig.STATIC_ENDPOINTS, null);
                 Objects.requireNonNull(endpoints, String.format("Missing '%s' configuration value", PeerForwarderConfig.STATIC_ENDPOINTS));
                 final List<String> invalidEndpoints = endpoints.stream().filter(endpoint -> !this.validateEndpoint(endpoint)).collect(Collectors.toList());
-                Preconditions.checkArgument(invalidEndpoints.size() == 0, "Including invalid endpoints: %s", invalidEndpoints);
+                Preconditions.checkState(invalidEndpoints.isEmpty(), "Including invalid endpoints: %s", invalidEndpoints);
 
                 return new StaticPeerListProvider(endpoints, pluginMetrics);
             default:

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/PeerListProviderFactory.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/PeerListProviderFactory.java
@@ -3,12 +3,20 @@ package com.amazon.dataprepper.plugins.prepper.peerforwarder.discovery;
 import com.amazon.dataprepper.metrics.PluginMetrics;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.plugins.prepper.peerforwarder.PeerForwarderConfig;
+import com.google.common.base.Preconditions;
 import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
+import org.apache.commons.validator.routines.DomainValidator;
+import org.apache.commons.validator.routines.InetAddressValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Objects;
 
 public class PeerListProviderFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PeerListProviderFactory.class);
+
     // TODO: Make these configurable?
     private static final int MIN_TTL = 10;
     private static final int MAX_TTL = 20;
@@ -27,6 +35,7 @@ public class PeerListProviderFactory {
             case DNS:
                 final String domainName = pluginSetting.getStringOrDefault(PeerForwarderConfig.DOMAIN_NAME, null);
                 Objects.requireNonNull(domainName, String.format("Missing '%s' configuration value",PeerForwarderConfig. DOMAIN_NAME));
+                Preconditions.checkArgument(validateEndpoint(domainName), "Invalid domain name: %s", domainName);
 
                 final DnsAddressEndpointGroup endpointGroup = DnsAddressEndpointGroup.builder(domainName)
                         .ttl(MIN_TTL, MAX_TTL)
@@ -36,10 +45,15 @@ public class PeerListProviderFactory {
             case STATIC:
                 final List<String> endpoints = (List<String>) pluginSetting.getAttributeOrDefault(PeerForwarderConfig.STATIC_ENDPOINTS, null);
                 Objects.requireNonNull(endpoints, String.format("Missing '%s' configuration value", PeerForwarderConfig.STATIC_ENDPOINTS));
+                Preconditions.checkArgument(endpoints.stream().allMatch(this::validateEndpoint), "Including invalid endpoints: %s", endpoints);
 
                 return new StaticPeerListProvider(endpoints, pluginMetrics);
             default:
                 throw new UnsupportedOperationException(String.format("Unsupported discovery mode: %s", discoveryMode));
         }
+    }
+
+    private boolean validateEndpoint(final String endpoint) {
+        return DomainValidator.getInstance(true).isValid(endpoint) || InetAddressValidator.getInstance().isValid(endpoint);
     }
 }

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/PeerListProviderFactory.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/PeerListProviderFactory.java
@@ -10,6 +10,7 @@ import org.apache.commons.validator.routines.InetAddressValidator;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class PeerListProviderFactory {
     // TODO: Make these configurable?
@@ -40,7 +41,8 @@ public class PeerListProviderFactory {
             case STATIC:
                 final List<String> endpoints = (List<String>) pluginSetting.getAttributeOrDefault(PeerForwarderConfig.STATIC_ENDPOINTS, null);
                 Objects.requireNonNull(endpoints, String.format("Missing '%s' configuration value", PeerForwarderConfig.STATIC_ENDPOINTS));
-                Preconditions.checkArgument(endpoints.stream().allMatch(this::validateEndpoint), "Including invalid endpoints: %s", endpoints);
+                final List<String> invalidEndpoints = endpoints.stream().filter(endpoint -> !this.validateEndpoint(endpoint)).collect(Collectors.toList());
+                Preconditions.checkArgument(invalidEndpoints.size() == 0, "Including invalid endpoints: %s", invalidEndpoints);
 
                 return new StaticPeerListProvider(endpoints, pluginMetrics);
             default:

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/PeerListProviderFactoryTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/PeerListProviderFactoryTest.java
@@ -86,7 +86,7 @@ public class PeerListProviderFactoryTest {
         assertTrue(result.getPeerList().contains(ENDPOINT));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void testCreateProviderStaticInstanceWithInvalidEndpoints() {
         pluginSetting.getSettings().put(PeerForwarderConfig.DISCOVERY_MODE, DiscoveryMode.STATIC.toString());
         pluginSetting.getSettings().put(PeerForwarderConfig.STATIC_ENDPOINTS, Arrays.asList(ENDPOINT, INVALID_ENDPOINT));
@@ -119,7 +119,7 @@ public class PeerListProviderFactoryTest {
         factory.createProvider(pluginSetting);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void testCreateProviderDnsInstanceWithInvalidDomainName() {
         pluginSetting.getSettings().put(PeerForwarderConfig.DISCOVERY_MODE, DiscoveryMode.DNS.toString());
         pluginSetting.getSettings().put(PeerForwarderConfig.DOMAIN_NAME, INVALID_ENDPOINT);

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/PeerListProviderFactoryTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/discovery/PeerListProviderFactoryTest.java
@@ -12,6 +12,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
@@ -26,6 +27,7 @@ import static org.mockito.Mockito.when;
 public class PeerListProviderFactoryTest {
     private static final String PLUGIN_NAME = "PLUGIN_NAME";
     private static final String ENDPOINT = "ENDPOINT";
+    private static final String INVALID_ENDPOINT = "INVALID_ENDPOINT_";
     private static final String PIPELINE_NAME = "pipelineName";
 
     @Mock
@@ -84,6 +86,14 @@ public class PeerListProviderFactoryTest {
         assertTrue(result.getPeerList().contains(ENDPOINT));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateProviderStaticInstanceWithInvalidEndpoints() {
+        pluginSetting.getSettings().put(PeerForwarderConfig.DISCOVERY_MODE, DiscoveryMode.STATIC.toString());
+        pluginSetting.getSettings().put(PeerForwarderConfig.STATIC_ENDPOINTS, Arrays.asList(ENDPOINT, INVALID_ENDPOINT));
+
+        factory.createProvider(pluginSetting);
+    }
+
     @Test
     public void testCreateProviderDnsInstance() {
         pluginSetting.getSettings().put(PeerForwarderConfig.DISCOVERY_MODE, DiscoveryMode.DNS.toString());
@@ -105,6 +115,14 @@ public class PeerListProviderFactoryTest {
     @Test(expected = NullPointerException.class)
     public void testCreateProviderDnsInstanceWithNoHostname() {
         pluginSetting.getSettings().put(PeerForwarderConfig.DISCOVERY_MODE, DiscoveryMode.DNS.toString());
+
+        factory.createProvider(pluginSetting);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateProviderDnsInstanceWithInvalidDomainName() {
+        pluginSetting.getSettings().put(PeerForwarderConfig.DISCOVERY_MODE, DiscoveryMode.DNS.toString());
+        pluginSetting.getSettings().put(PeerForwarderConfig.DOMAIN_NAME, INVALID_ENDPOINT);
 
         factory.createProvider(pluginSetting);
     }


### PR DESCRIPTION
*Issue #, if available:*
#437 

*Description of changes:*

-----
This PR adds validation before initializing a peer provider. 

Note: I have verified that invalid endpoint in addn-hosts of dnsmasq, e.g.

```
10.10.1.2 prepper-cluster
10_10.1.3 prepper-cluster
```

will not be ack by endpointGroup:

```
2021-04-20T16:33:17,543 [main] INFO  com.amazon.dataprepper.plugins.prepper.peerforwarder.discovery.DnsPeerListProvider - Found endpoints: [Endpoint{prepper-cluster, ipAddr=10.10.1.2, weight=1000}]
```
while valid endpoint:
```
10.10.1.2 prepper-cluster
10.10.1.3 prepper-cluster
```
will still be Ack:
```
2021-04-20T16:30:23,453 [main] INFO  com.amazon.dataprepper.plugins.prepper.peerforwarder.discovery.DnsPeerListProvider - Found endpoints: [Endpoint{prepper-cluster, ipAddr=10.10.1.2, weight=1000}, Endpoint{prepper-cluster, ipAddr=10.10.1.3, weight=1000}]

```
so there is no need to do validity check in `getPeerList()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
