### PR TITLE
Small refactor of OTelSource unit tests to remove flaky test.

### DIFF
--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceGrpcServiceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceGrpcServiceTest.java
@@ -8,74 +8,91 @@ import io.grpc.stub.StreamObserver;
 import io.micrometer.core.instrument.Counter;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import io.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.Span;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.concurrent.TimeoutException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-
+@ExtendWith(MockitoExtension.class)
 public class OTelTraceGrpcServiceTest {
+    private static final ExportTraceServiceRequest SUCCESS_REQUEST = ExportTraceServiceRequest.newBuilder()
+            .addResourceSpans(ResourceSpans.newBuilder()
+                    .addInstrumentationLibrarySpans(InstrumentationLibrarySpans.newBuilder()
+                            .addSpans(Span.newBuilder().setTraceState("SUCCESS").build())).build()).build();
 
-    private OTelTraceGrpcService oTelTraceGrpcService;
     private static PluginSetting pluginSetting;
     private final int bufferWriteTimeoutInMillis = 100000;
+
+    @Mock
+    Counter requestsReceivedCounter;
+    @Mock
+    Counter timeoutCounter;
+    @Mock
+    StreamObserver responseObserver;
+    @Mock
+    Buffer buffer;
+
+    @Captor
+    ArgumentCaptor<Record> recordCaptor;
+
+    private OTelTraceGrpcService sut;
 
     @BeforeEach
     public void setup() {
         pluginSetting = new PluginSetting("OTelTraceGrpcService", Collections.EMPTY_MAP);
         pluginSetting.setPipelineName("pipeline");
-    }
-
-    @Test
-    public void testRequestsReceivedCounter() {
 
         PluginMetrics mockPluginMetrics = mock(PluginMetrics.class);
 
-        ExportTraceServiceRequest request = ExportTraceServiceRequest.newBuilder().build();
-        StreamObserver response = mock(StreamObserver.class);
-        Counter mockRequestsReceivedCounter = mock(Counter.class);
-        Counter mockTimeoutCounter = mock(Counter.class);
-        when(mockPluginMetrics.counter(OTelTraceGrpcService.REQUESTS_RECEIVED)).thenReturn(mockRequestsReceivedCounter);
-        when(mockPluginMetrics.counter(OTelTraceGrpcService.REQUEST_TIMEOUTS)).thenReturn(mockTimeoutCounter);
+        when(mockPluginMetrics.counter(OTelTraceGrpcService.REQUESTS_RECEIVED)).thenReturn(requestsReceivedCounter);
+        when(mockPluginMetrics.counter(OTelTraceGrpcService.REQUEST_TIMEOUTS)).thenReturn(timeoutCounter);
 
-        oTelTraceGrpcService = new OTelTraceGrpcService(bufferWriteTimeoutInMillis, mock(Buffer.class), mockPluginMetrics);
-        oTelTraceGrpcService.export(request, response);
-
-        verify(response, times(1)).onNext(ExportTraceServiceResponse.newBuilder().build());
-        verify(response, times(1)).onCompleted();
-        verify(mockRequestsReceivedCounter, times(1)).increment();
-        verifyZeroInteractions(mockTimeoutCounter);
+        sut = new OTelTraceGrpcService(bufferWriteTimeoutInMillis, buffer, mockPluginMetrics);
     }
 
     @Test
-    public void testTimeoutCounter() throws TimeoutException {
+    public void export_Success_responseObserverOnCompleted() throws Exception {
+        sut.export(SUCCESS_REQUEST, responseObserver);
 
-        PluginMetrics mockPluginMetrics = mock(PluginMetrics.class);
-        Buffer mockBuffer = mock(Buffer.class);
-        ExportTraceServiceRequest request = ExportTraceServiceRequest.newBuilder().build();
-        StreamObserver response = mock(StreamObserver.class);
-        Counter mockRequestsReceivedCounter = mock(Counter.class);
-        Counter mockTimeoutCounter = mock(Counter.class);
-        when(mockPluginMetrics.counter(OTelTraceGrpcService.REQUESTS_RECEIVED)).thenReturn(mockRequestsReceivedCounter);
-        doThrow(new TimeoutException()).when(mockBuffer).write(any(Record.class), anyInt());
-        when(mockPluginMetrics.counter(OTelTraceGrpcService.REQUEST_TIMEOUTS)).thenReturn(mockTimeoutCounter);
+        verify(buffer, times(1)).write(recordCaptor.capture(), anyInt());
+        verify(responseObserver, times(1)).onNext(ExportTraceServiceResponse.newBuilder().build());
+        verify(responseObserver, times(1)).onCompleted();
+        verify(requestsReceivedCounter, times(1)).increment();
+        verifyNoInteractions(timeoutCounter);
 
-        oTelTraceGrpcService = new OTelTraceGrpcService(bufferWriteTimeoutInMillis, mockBuffer, mockPluginMetrics);
-        oTelTraceGrpcService.export(request, response);
+        Record capturedRecord = recordCaptor.getValue();
+        assertEquals(SUCCESS_REQUEST, capturedRecord.getData());
+    }
 
-        verify(response, times(0)).onNext(ExportTraceServiceResponse.newBuilder().build());
-        verify(response, times(0)).onCompleted();
-        verify(mockTimeoutCounter, times(1)).increment();
-        verify(mockRequestsReceivedCounter, times(1)).increment();
+    @Test
+    public void export_BufferTimeout_responseObserverOnError() throws Exception {
+        doThrow(new TimeoutException()).when(buffer).write(any(Record.class), anyInt());
+
+        sut.export(SUCCESS_REQUEST, responseObserver);
+
+        verify(buffer, times(1)).write(any(Record.class), anyInt());
+        verify(responseObserver, times(0)).onNext(any());
+        verify(responseObserver, times(0)).onCompleted();
+        verify(timeoutCounter, times(1)).increment();
+        verify(requestsReceivedCounter, times(1)).increment();
     }
 }

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -1,6 +1,5 @@
 package com.amazon.dataprepper.plugins.source.oteltrace;
 
-import com.amazon.dataprepper.model.CheckpointState;
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.buffer.blockingbuffer.BlockingBuffer;
@@ -31,11 +30,8 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -80,7 +76,7 @@ public class OTelTraceSourceTest {
         return "gproto+http://127.0.0.1:" + SOURCE.getoTelTraceSourceConfig().getPort() + '/';
     }
 
-    private static BlockingBuffer<Record<ExportTraceServiceRequest>> getBuffer() {
+    private BlockingBuffer<Record<ExportTraceServiceRequest>> getBuffer() {
         final HashMap<String, Object> integerHashMap = new HashMap<>();
         integerHashMap.put("buffer_size", 1);
         integerHashMap.put("batch_size", 1);
@@ -110,33 +106,6 @@ public class OTelTraceSourceTest {
     @AfterEach
     public void afterEach() {
         SOURCE.stop();
-    }
-
-    @Test
-    void testBufferFull() {
-        try {
-            // Debugging a recurring issue with this particular test
-            CLIENT.export(SUCCESS_REQUEST);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw e;
-        }
-
-        try {
-            CLIENT.export(ExportTraceServiceRequest.newBuilder().build());
-        } catch (RuntimeException ex) {
-            System.out.println("Printing the exception:" + ex);
-        }
-        validateBuffer();
-    }
-
-    private void validateBuffer() {
-        Map.Entry<Collection<Record<ExportTraceServiceRequest>>, CheckpointState> drainedBufferResult = buffer.read(100000);
-        List<Record<ExportTraceServiceRequest>> drainedBuffer = (List<Record<ExportTraceServiceRequest>>) drainedBufferResult.getKey();
-        CheckpointState checkpointState = drainedBufferResult.getValue();
-        assertThat(drainedBuffer.size()).isEqualTo(1);
-        assertThat(drainedBuffer.get(0).getData()).isEqualTo(SUCCESS_REQUEST);
-        assertEquals(1, checkpointState.getNumRecordsToBeChecked());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Jeff Wright <74204404+wrijeff@users.noreply.github.com>

*Issue #, if available:* #221

*Description of changes:*
* Removing flaky test in favor of assertions on mocked objects instead of an actual server
-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
