### PR TITLE
String attributes for boolean, long, int for pipeline yaml config

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PluginSetting.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PluginSetting.java
@@ -4,6 +4,8 @@ import java.util.Map;
 
 public class PluginSetting {
 
+    private static final String UNEXPECTED_ATTRIBUTE_TYPE_MSG = "Unexpected type [%s] for attribute [%s]";
+
     private final String name;
     private final Map<String, Object> settings;
     private int processWorkers;
@@ -100,7 +102,7 @@ public class PluginSetting {
             return Integer.valueOf(String.valueOf(object));
         }
 
-        throw new IllegalArgumentException("Unexpected type for attribute: " + attribute);
+        throw new IllegalArgumentException(String.format(UNEXPECTED_ATTRIBUTE_TYPE_MSG, object.getClass(), attribute));
     }
 
     /**
@@ -120,7 +122,7 @@ public class PluginSetting {
             return String.valueOf(object);
         }
 
-        throw new IllegalArgumentException("Unexpected type for attribute: " + attribute);
+        throw new IllegalArgumentException(String.format(UNEXPECTED_ATTRIBUTE_TYPE_MSG, object.getClass(), attribute));
     }
 
     /**
@@ -142,7 +144,7 @@ public class PluginSetting {
             return Boolean.valueOf(String.valueOf(object));
         }
 
-        throw new IllegalArgumentException("Unexpected type for attribute: " + attribute);
+        throw new IllegalArgumentException(String.format(UNEXPECTED_ATTRIBUTE_TYPE_MSG, object.getClass(), attribute));
     }
 
     /**
@@ -164,7 +166,7 @@ public class PluginSetting {
             return Long.valueOf(String.valueOf(object));
         }
 
-        throw new IllegalArgumentException("Unexpected type for attribute: " + attribute);
+        throw new IllegalArgumentException(String.format(UNEXPECTED_ATTRIBUTE_TYPE_MSG, object.getClass(), attribute));
     }
 
 }

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PluginSetting.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/configuration/PluginSetting.java
@@ -88,28 +88,44 @@ public class PluginSetting {
      * @param attribute    name of the attribute
      * @param defaultValue default value for the setting
      * @return the value of the specified attribute, or {@code defaultValue} if this settings contains no value for
-     * the attribute
+     * the attribute. If the value is null, null will be returned.
      */
     public Integer getIntegerOrDefault(final String attribute, final int defaultValue) {
-        return ((Number) getAttributeOrDefault(attribute, defaultValue)).intValue();
+        Object object = getAttributeOrDefault(attribute, defaultValue);
+        if (object == null) {
+            return null;
+        } else if (object instanceof Number) {
+            return ((Number) object).intValue();
+        } else if (object instanceof String) {
+            return Integer.valueOf(String.valueOf(object));
+        }
+
+        throw new IllegalArgumentException("Unexpected type for attribute: " + attribute);
     }
 
     /**
      * Returns the value of the specified attribute as String, or {@code defaultValue} if this settings contains no
-     * value for the attribute.
+     * value for the attribute. If the value is null, null will be returned.
      *
      * @param attribute    name of the attribute
      * @param defaultValue default value for the setting
      * @return the value of the specified attribute, or {@code defaultValue} if this settings contains no value for
-     * the attribute
+     * the attribute. If the value is null, null will be returned.
      */
     public String getStringOrDefault(final String attribute, final String defaultValue) {
-        return (String) getAttributeOrDefault(attribute, defaultValue);
+        Object object = getAttributeOrDefault(attribute, defaultValue);
+        if (object == null) {
+            return null;
+        } else if (object instanceof String) {
+            return String.valueOf(object);
+        }
+
+        throw new IllegalArgumentException("Unexpected type for attribute: " + attribute);
     }
 
     /**
      * Returns the value of the specified attribute as boolean, or {@code defaultValue} if this settings contains no
-     * value for the attribute.
+     * value for the attribute. If the value is null, null will be returned.
      *
      * @param attribute    name of the attribute
      * @param defaultValue default value for the setting
@@ -117,12 +133,21 @@ public class PluginSetting {
      * the attribute
      */
     public Boolean getBooleanOrDefault(final String attribute, final boolean defaultValue) {
-        return (Boolean) getAttributeOrDefault(attribute, defaultValue);
+        Object object = getAttributeOrDefault(attribute, defaultValue);
+        if (object == null) {
+            return null;
+        } else if (object instanceof Boolean) {
+            return (Boolean) object;
+        } else if (object instanceof String) {
+            return Boolean.valueOf(String.valueOf(object));
+        }
+
+        throw new IllegalArgumentException("Unexpected type for attribute: " + attribute);
     }
 
     /**
      * Returns the value of the specified attribute as long, or {@code defaultValue} if this settings contains no
-     * value for the attribute.
+     * value for the attribute. If the value is null, null will be returned.
      *
      * @param attribute    name of the attribute
      * @param defaultValue default value for the setting
@@ -130,7 +155,16 @@ public class PluginSetting {
      * the attribute
      */
     public Long getLongOrDefault(final String attribute, final long defaultValue) {
-        return ((Number) getAttributeOrDefault(attribute, defaultValue)).longValue();
+        Object object = getAttributeOrDefault(attribute, defaultValue);
+        if (object == null) {
+            return null;
+        } else if (object instanceof Number) {
+            return ((Number) object).longValue();
+        } else if (object instanceof String) {
+            return Long.valueOf(String.valueOf(object));
+        }
+
+        throw new IllegalArgumentException("Unexpected type for attribute: " + attribute);
     }
 
 }

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PluginSettingsTests.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PluginSettingsTests.java
@@ -19,6 +19,7 @@ public class PluginSettingsTests {
     private static final String TEST_PLUGIN_NAME = "test";
 
     private static final String TEST_STRING_DEFAULT_VALUE = "DEFAULT";
+    private static final String TEST_STRING_VALUE = "TEST";
 
     private static final int TEST_INT_DEFAULT_VALUE = 1000;
     private static final int TEST_INT_VALUE = TEST_INT_DEFAULT_VALUE + 1;
@@ -33,66 +34,110 @@ public class PluginSettingsTests {
     private static final String TEST_STRING_ATTRIBUTE = "string-attribute";
     private static final String TEST_BOOL_ATTRIBUTE = "bool-attribute";
     private static final String TEST_LONG_ATTRIBUTE = "long-attribute";
+    private static final String NOT_PRESENT_ATTRIBUTE = "not-present";
 
 
     @Test
     public void testPluginSetting() {
-        final String TEST_PIPELINE = "test-pipeline";
-        final int TEST_WORKERS = 1;
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, ImmutableMap.of());
 
+        assertThat(pluginSetting, notNullValue());
+    }
+
+    @Test
+    public void testPluginSetting_Name() {
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, ImmutableMap.of());
+
+        assertThat(pluginSetting.getName(), is(TEST_PLUGIN_NAME));
+    }
+
+    @Test
+    public void testPluginSetting_PipelineName() {
+        final String TEST_PIPELINE = "test-pipeline";
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, ImmutableMap.of());
         pluginSetting.setPipelineName(TEST_PIPELINE);
-        pluginSetting.setProcessWorkers(TEST_WORKERS);
-        assertThat(pluginSetting, notNullValue());
-        assertThat(pluginSetting.getName(), is(TEST_PLUGIN_NAME));
+
         assertThat(pluginSetting.getPipelineName(), is(TEST_PIPELINE));
+    }
+
+    @Test
+    public void testPluginSetting_NumberOfProcessWorkers() {
+        final int TEST_WORKERS = 1;
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, ImmutableMap.of());
+        pluginSetting.setProcessWorkers(TEST_WORKERS);
+
         assertThat(pluginSetting.getNumberOfProcessWorkers(), is(TEST_WORKERS));
     }
 
     @Test
-    public void testPluginSettingAttributes() {
-        final String TEST_STRING_VALUE = "TEST";
-
-        final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(
-                TEST_INT_ATTRIBUTE, TEST_INT_VALUE,
-                TEST_STRING_ATTRIBUTE, TEST_STRING_VALUE,
-                TEST_BOOL_ATTRIBUTE, TEST_BOOL_VALUE,
-                TEST_LONG_ATTRIBUTE, TEST_LONG_VALUE);
-
+    public void testGetAttributeFromSettings() {
+        final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_INT_ATTRIBUTE, TEST_INT_VALUE);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
 
         assertThat(pluginSetting.getAttributeFromSettings(TEST_INT_ATTRIBUTE), is(TEST_INT_VALUE));
+    }
 
-        // test attributes that exist when passing in a different default value
+    @Test
+    public void testGetAttributeOrDefault() {
+        final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_INT_ATTRIBUTE, TEST_INT_VALUE);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
+
         assertThat(pluginSetting.getAttributeOrDefault(TEST_INT_ATTRIBUTE, TEST_INT_DEFAULT_VALUE), is(TEST_INT_VALUE));
-        assertThat(pluginSetting.getIntegerOrDefault(TEST_INT_ATTRIBUTE, TEST_INT_DEFAULT_VALUE), is(TEST_INT_VALUE));
+    }
+
+    @Test
+    public void testGetStringOrDefault() {
+        final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_STRING_ATTRIBUTE, TEST_STRING_VALUE);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
+
         assertThat(pluginSetting.getStringOrDefault(TEST_STRING_ATTRIBUTE, TEST_STRING_DEFAULT_VALUE),
                 is(equalTo(TEST_STRING_VALUE)));
+    }
+
+    @Test
+    public void testGetBooleanOrDefault() {
+        final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_BOOL_ATTRIBUTE, TEST_BOOL_VALUE);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
+
         assertThat(pluginSetting.getBooleanOrDefault(TEST_BOOL_ATTRIBUTE, TEST_BOOL_DEFAULT_VALUE), is(equalTo(TEST_BOOL_VALUE)));
+    }
+
+    @Test
+    public void testGetLongOrDefault() {
+        final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_LONG_ATTRIBUTE, TEST_LONG_VALUE);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
+
         assertThat(pluginSetting.getLongOrDefault(TEST_LONG_ATTRIBUTE, TEST_LONG_DEFAULT_VALUE), is(equalTo(TEST_LONG_VALUE)));
     }
 
     @Test
-    public void testPluginSettingAttributesAsString() {
+    public void testGetIntegerOrDefault_AsString() {
         final String TEST_INT_VALUE_STRING = String.valueOf(TEST_INT_VALUE);
-        final String TEST_BOOL_VALUE_STRING = String.valueOf(TEST_BOOL_VALUE);
-        final String TEST_LONG_VALUE_STRING = String.valueOf(TEST_LONG_VALUE);
-
         final String TEST_INT_STRING_ATTRIBUTE = "int-string-attribute";
-        final String TEST_BOOL_STRING_ATTRIBUTE = "bool-string-attribute";
-        final String TEST_LONG_STRING_ATTRIBUTE = "long-string-attribute";
-
-        final Map<String, Object> TEST_SETTINGS_AS_STRINGS = ImmutableMap.of(
-                TEST_INT_STRING_ATTRIBUTE, TEST_INT_VALUE_STRING,
-                TEST_BOOL_STRING_ATTRIBUTE, TEST_BOOL_VALUE_STRING,
-                TEST_LONG_STRING_ATTRIBUTE, TEST_LONG_VALUE_STRING);
-
-
+        final Map<String, Object> TEST_SETTINGS_AS_STRINGS = ImmutableMap.of(TEST_INT_STRING_ATTRIBUTE, TEST_INT_VALUE_STRING);
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_AS_STRINGS);
 
-        // test attributes that exist when passing in a different default value
         assertThat(pluginSetting.getIntegerOrDefault(TEST_INT_STRING_ATTRIBUTE, TEST_INT_DEFAULT_VALUE), is(TEST_INT_VALUE));
+    }
+
+    @Test
+    public void testGetBooleanOrDefault_AsString() {
+        final String TEST_BOOL_VALUE_STRING = String.valueOf(TEST_BOOL_VALUE);
+        final String TEST_BOOL_STRING_ATTRIBUTE = "bool-string-attribute";
+
+        final Map<String, Object> TEST_SETTINGS_AS_STRINGS = ImmutableMap.of(TEST_BOOL_STRING_ATTRIBUTE, TEST_BOOL_VALUE_STRING);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_AS_STRINGS);
+
         assertThat(pluginSetting.getBooleanOrDefault(TEST_BOOL_STRING_ATTRIBUTE, TEST_BOOL_DEFAULT_VALUE), is(equalTo(TEST_BOOL_VALUE)));
+    }
+
+    @Test
+    public void testGetLongOrDefault_AsString() {
+        final String TEST_LONG_VALUE_STRING = String.valueOf(TEST_LONG_VALUE);
+        final String TEST_LONG_STRING_ATTRIBUTE = "long-string-attribute";
+        final Map<String, Object> TEST_SETTINGS_AS_STRINGS = ImmutableMap.of(TEST_LONG_STRING_ATTRIBUTE, TEST_LONG_VALUE_STRING);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_AS_STRINGS);
+
         assertThat(pluginSetting.getLongOrDefault(TEST_LONG_STRING_ATTRIBUTE, TEST_LONG_DEFAULT_VALUE), is(equalTo(TEST_LONG_VALUE)));
     }
 
@@ -100,24 +145,55 @@ public class PluginSettingsTests {
      * Request attributes are present with null values, expect nulls to be returned
      */
     @Test
-    public void testPluginSettingAttributesAsNull() {
+    public void testGetIntegerOrDefault_AsNull() {
         final String TEST_INT_NULL_ATTRIBUTE = "int-null-attribute";
-        final String TEST_STRING_NULL_ATTRIBUTE = "string-null-attribute";
-        final String TEST_BOOL_NULL_ATTRIBUTE = "bool-null-attribute";
-        final String TEST_LONG_NULL_ATTRIBUTE = "long-null-attribute";
-
-        final Map<String, Object> TEST_SETTINGS_AS_STRINGS = new HashMap<>();
-        TEST_SETTINGS_AS_STRINGS.put(TEST_INT_NULL_ATTRIBUTE, null);
-        TEST_SETTINGS_AS_STRINGS.put(TEST_STRING_NULL_ATTRIBUTE, null);
-        TEST_SETTINGS_AS_STRINGS.put(TEST_BOOL_NULL_ATTRIBUTE, null);
-        TEST_SETTINGS_AS_STRINGS.put(TEST_LONG_NULL_ATTRIBUTE, null);
-
-        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_AS_STRINGS);
+        final Map<String, Object> TEST_SETTINGS_AS_NULL = new HashMap<>();
+        TEST_SETTINGS_AS_NULL.put(TEST_INT_NULL_ATTRIBUTE, null);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_AS_NULL);
 
         // test attributes that exist when passing in a different default value
         assertThat(pluginSetting.getIntegerOrDefault(TEST_INT_NULL_ATTRIBUTE, TEST_INT_DEFAULT_VALUE), nullValue());
+    }
+
+    /**
+     * Request attributes are present with null values, expect nulls to be returned
+     */
+    @Test
+    public void testGetStringOrDefault_AsNull() {
+        final String TEST_STRING_NULL_ATTRIBUTE = "string-null-attribute";
+        final Map<String, Object> TEST_SETTINGS_AS_NULL = new HashMap<>();
+        TEST_SETTINGS_AS_NULL.put(TEST_STRING_NULL_ATTRIBUTE, null);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_AS_NULL);
+
+        // test attributes that exist when passing in a different default value
         assertThat(pluginSetting.getStringOrDefault(TEST_STRING_NULL_ATTRIBUTE, TEST_STRING_DEFAULT_VALUE), nullValue());
+    }
+
+    /**
+     * Request attributes are present with null values, expect nulls to be returned
+     */
+    @Test
+    public void testGetBooleanOrDefault_AsNull() {
+        final String TEST_BOOL_NULL_ATTRIBUTE = "bool-null-attribute";
+        final Map<String, Object> TEST_SETTINGS_AS_NULL = new HashMap<>();
+        TEST_SETTINGS_AS_NULL.put(TEST_BOOL_NULL_ATTRIBUTE, null);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_AS_NULL);
+
+        // test attributes that exist when passing in a different default value
         assertThat(pluginSetting.getBooleanOrDefault(TEST_BOOL_NULL_ATTRIBUTE, TEST_BOOL_DEFAULT_VALUE), nullValue());
+    }
+
+    /**
+     * Request attributes are present with null values, expect nulls to be returned
+     */
+    @Test
+    public void testGetLongOrDefault_AsNull() {
+        final String TEST_LONG_NULL_ATTRIBUTE = "long-null-attribute";
+        final Map<String, Object> TEST_SETTINGS_AS_NULL = new HashMap<>();
+        TEST_SETTINGS_AS_NULL.put(TEST_LONG_NULL_ATTRIBUTE, null);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_AS_NULL);
+
+        // test attributes that exist when passing in a different default value
         assertThat(pluginSetting.getLongOrDefault(TEST_LONG_NULL_ATTRIBUTE, TEST_LONG_DEFAULT_VALUE), nullValue());
     }
 
@@ -125,38 +201,107 @@ public class PluginSettingsTests {
      * Requested attributes are not present, expect default values to be returned
      */
     @Test
-    public void testPluginSettingAttributesNotPresent() {
-        final String NOT_PRESENT_ATTRIBUTE = "not-present";
-
+    public void testGetSettings_Null() {
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
 
         assertThat(pluginSetting.getSettings(), nullValue());
+    }
+
+    /**
+     * Requested attributes are not present, expect default values to be returned
+     */
+    @Test
+    public void testGetAttributeFromSettings_NotPresent() {
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
+
         assertThat(pluginSetting.getAttributeFromSettings(NOT_PRESENT_ATTRIBUTE), nullValue());
+    }
+
+    /**
+     * Requested attributes are not present, expect default values to be returned
+     */
+    @Test
+    public void testGetAttributeOrDefault_NotPresent() {
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
 
         assertThat(pluginSetting.getAttributeOrDefault(NOT_PRESENT_ATTRIBUTE, TEST_INT_DEFAULT_VALUE), is(TEST_INT_DEFAULT_VALUE));
+    }
+
+    /**
+     * Requested attributes are not present, expect default values to be returned
+     */
+    @Test
+    public void testGetIntegerOrDefault_NotPresent() {
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
+
         assertThat(pluginSetting.getIntegerOrDefault(NOT_PRESENT_ATTRIBUTE, TEST_INT_DEFAULT_VALUE), is(TEST_INT_DEFAULT_VALUE));
+    }
+
+    /**
+     * Requested attributes are not present, expect default values to be returned
+     */
+    @Test
+    public void testGetStringOrDefault_NotPresent() {
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
+
         assertThat(pluginSetting.getStringOrDefault(NOT_PRESENT_ATTRIBUTE, TEST_STRING_DEFAULT_VALUE),
                 is(equalTo(TEST_STRING_DEFAULT_VALUE)));
+    }
+
+    /**
+     * Requested attributes are not present, expect default values to be returned
+     */
+    @Test
+    public void testGetBooleanOrDefault_NotPresent() {
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
+
         assertThat(pluginSetting.getBooleanOrDefault(NOT_PRESENT_ATTRIBUTE, TEST_BOOL_DEFAULT_VALUE), is(equalTo(TEST_BOOL_DEFAULT_VALUE)));
+    }
+
+    /**
+     * Requested attributes are not present, expect default values to be returned
+     */
+    @Test
+    public void testGetLongOrDefault_NotPresent() {
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
+
         assertThat(pluginSetting.getLongOrDefault(NOT_PRESENT_ATTRIBUTE, TEST_LONG_DEFAULT_VALUE), is(equalTo(TEST_LONG_DEFAULT_VALUE)));
     }
 
     @Test
-    public void testPluginSettingAttributeUnsupportedType() {
+    public void testGetIntegerOrDefault_UnsupportedType() {
         final Object UNSUPPORTED_TYPE = new ArrayList<>();
-
-        final Map<String, Object> TEST_SETTINGS_AS_STRINGS = new HashMap<>();
-        TEST_SETTINGS_AS_STRINGS.put(TEST_INT_ATTRIBUTE, UNSUPPORTED_TYPE);
-        TEST_SETTINGS_AS_STRINGS.put(TEST_STRING_ATTRIBUTE, UNSUPPORTED_TYPE);
-        TEST_SETTINGS_AS_STRINGS.put(TEST_BOOL_ATTRIBUTE, UNSUPPORTED_TYPE);
-        TEST_SETTINGS_AS_STRINGS.put(TEST_LONG_ATTRIBUTE, UNSUPPORTED_TYPE);
-
-        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_AS_STRINGS);
+        final Map<String, Object> TEST_SETTINGS_WITH_UNSUPPORTED_TYPE = ImmutableMap.of(TEST_INT_ATTRIBUTE, UNSUPPORTED_TYPE);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_WITH_UNSUPPORTED_TYPE);
 
         // test attributes that exist when passing in a different default value
         assertThrows(IllegalArgumentException.class, () -> pluginSetting.getIntegerOrDefault(TEST_INT_ATTRIBUTE, TEST_INT_DEFAULT_VALUE));
+    }
+
+    @Test
+    public void testGetStringOrDefault_UnsupportedType() {
+        final Object UNSUPPORTED_TYPE = new ArrayList<>();
+        final Map<String, Object> TEST_SETTINGS_WITH_UNSUPPORTED_TYPE = ImmutableMap.of(TEST_STRING_ATTRIBUTE, UNSUPPORTED_TYPE);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_WITH_UNSUPPORTED_TYPE);
+
         assertThrows(IllegalArgumentException.class, () -> pluginSetting.getStringOrDefault(TEST_STRING_ATTRIBUTE, TEST_STRING_DEFAULT_VALUE));
+    }
+
+    @Test
+    public void testGetBooleanOrDefault_UnsupportedType() {
+        final Object UNSUPPORTED_TYPE = new ArrayList<>();
+        final Map<String, Object> TEST_SETTINGS_WITH_UNSUPPORTED_TYPE = ImmutableMap.of(TEST_BOOL_ATTRIBUTE, UNSUPPORTED_TYPE);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_WITH_UNSUPPORTED_TYPE);
+
         assertThrows(IllegalArgumentException.class, () -> pluginSetting.getBooleanOrDefault(TEST_BOOL_ATTRIBUTE, TEST_BOOL_DEFAULT_VALUE));
+    }
+
+    @Test
+    public void testGetLongOrDefault_UnsupportedType() {
+        final Object UNSUPPORTED_TYPE = new ArrayList<>();
+        final Map<String, Object> TEST_SETTINGS_WITH_UNSUPPORTED_TYPE = ImmutableMap.of(TEST_LONG_ATTRIBUTE, UNSUPPORTED_TYPE);
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_WITH_UNSUPPORTED_TYPE);
+
         assertThrows(IllegalArgumentException.class, () -> pluginSetting.getLongOrDefault(TEST_LONG_ATTRIBUTE, TEST_LONG_DEFAULT_VALUE));
     }
 }

--- a/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PluginSettingsTests.java
+++ b/data-prepper-api/src/test/java/com/amazon/dataprepper/model/configuration/PluginSettingsTests.java
@@ -3,6 +3,9 @@ package com.amazon.dataprepper.model.configuration;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -10,72 +13,150 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-
+import static org.junit.Assert.assertThrows;
 
 public class PluginSettingsTests {
     private static final String TEST_PLUGIN_NAME = "test";
-    private static final String TEST_STRING_VALUE = "TEST";
-    private static final int TEST_INT_VALUE = 1000;
-    private static final boolean TEST_BOOL_VALUE = Boolean.TRUE;
-    private static final long TEST_LONG_VALUE = 1000L;
-    private static final String TEST_ATTRIBUTE_1 = "attribute1";
-    private static final String TEST_ATTRIBUTE_2 = "attribute2";
-    private static final String TEST_ATTRIBUTE_3 = "attribute3";
-    private static final String TEST_ATTRIBUTE_4 = "attribute4";
-    private static final String NOT_PRESENT_ATTRIBUTE = "not-present";
-    private static final String TEST_PIPELINE = "test-pipeline";
-    private static final int TEST_WORKERS = 1;
-    private static final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(TEST_ATTRIBUTE_1, TEST_INT_VALUE,
-            TEST_ATTRIBUTE_2, TEST_STRING_VALUE,
-            TEST_ATTRIBUTE_3, TEST_BOOL_VALUE,
-            TEST_ATTRIBUTE_4, TEST_LONG_VALUE);
+
+    private static final String TEST_STRING_DEFAULT_VALUE = "DEFAULT";
+
+    private static final int TEST_INT_DEFAULT_VALUE = 1000;
+    private static final int TEST_INT_VALUE = TEST_INT_DEFAULT_VALUE + 1;
+
+    private static final boolean TEST_BOOL_DEFAULT_VALUE = Boolean.FALSE;
+    private static final boolean TEST_BOOL_VALUE = !TEST_BOOL_DEFAULT_VALUE;
+
+    private static final long TEST_LONG_DEFAULT_VALUE = 1000L;
+    private static final long TEST_LONG_VALUE = TEST_LONG_DEFAULT_VALUE + 1;
+
+    private static final String TEST_INT_ATTRIBUTE = "int-attribute";
+    private static final String TEST_STRING_ATTRIBUTE = "string-attribute";
+    private static final String TEST_BOOL_ATTRIBUTE = "bool-attribute";
+    private static final String TEST_LONG_ATTRIBUTE = "long-attribute";
+
 
     @Test
-    public void testPluginSettingConstructorGetterSetters() {
-        final PluginSetting pluginSettings = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
-        pluginSettings.setPipelineName(TEST_PIPELINE);
-        pluginSettings.setProcessWorkers(TEST_WORKERS);
-        assertThat(pluginSettings, notNullValue());
-        assertThat(pluginSettings.getName(), is(TEST_PLUGIN_NAME));
-        assertThat(pluginSettings.getSettings(), is(TEST_SETTINGS));
-        assertThat(pluginSettings.getPipelineName(), is(TEST_PIPELINE));
-        assertThat(pluginSettings.getNumberOfProcessWorkers(), is(TEST_WORKERS));
+    public void testPluginSetting() {
+        final String TEST_PIPELINE = "test-pipeline";
+        final int TEST_WORKERS = 1;
 
-        assertThat(pluginSettings.getAttributeFromSettings(TEST_ATTRIBUTE_1), is(TEST_INT_VALUE));
-        assertThat(pluginSettings.getAttributeOrDefault(TEST_ATTRIBUTE_1, 500), is(TEST_INT_VALUE));
-        assertThat(pluginSettings.getIntegerOrDefault(TEST_ATTRIBUTE_1, 500), is(TEST_INT_VALUE));
-        assertThat(pluginSettings.getStringOrDefault(TEST_ATTRIBUTE_2, NOT_PRESENT_ATTRIBUTE),
-                is(equalTo(TEST_STRING_VALUE)));
-        assertThat(pluginSettings.getBooleanOrDefault(TEST_ATTRIBUTE_3, Boolean.FALSE), is(equalTo(TEST_BOOL_VALUE)));
-        assertThat(pluginSettings.getLongOrDefault(TEST_ATTRIBUTE_4, Long.MAX_VALUE), is(equalTo(TEST_LONG_VALUE)));
-
-        assertThat(pluginSettings.getAttributeFromSettings(NOT_PRESENT_ATTRIBUTE), nullValue());
-        assertThat(pluginSettings.getAttributeOrDefault(NOT_PRESENT_ATTRIBUTE, 500), is(500));
-        assertThat(pluginSettings.getIntegerOrDefault(NOT_PRESENT_ATTRIBUTE, 500), is(500));
-        assertThat(pluginSettings.getStringOrDefault(NOT_PRESENT_ATTRIBUTE, NOT_PRESENT_ATTRIBUTE),
-                is(equalTo(NOT_PRESENT_ATTRIBUTE)));
-        assertThat(pluginSettings.getBooleanOrDefault(NOT_PRESENT_ATTRIBUTE, Boolean.FALSE), is(equalTo(Boolean.FALSE)));
-        assertThat(pluginSettings.getLongOrDefault(NOT_PRESENT_ATTRIBUTE, Long.MAX_VALUE), is(equalTo(Long.MAX_VALUE)));
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, ImmutableMap.of());
+        pluginSetting.setPipelineName(TEST_PIPELINE);
+        pluginSetting.setProcessWorkers(TEST_WORKERS);
+        assertThat(pluginSetting, notNullValue());
+        assertThat(pluginSetting.getName(), is(TEST_PLUGIN_NAME));
+        assertThat(pluginSetting.getPipelineName(), is(TEST_PIPELINE));
+        assertThat(pluginSetting.getNumberOfProcessWorkers(), is(TEST_WORKERS));
     }
 
     @Test
-    public void testNullSettingsInPluginSetting() {
+    public void testPluginSettingAttributes() {
+        final String TEST_STRING_VALUE = "TEST";
+
+        final Map<String, Object> TEST_SETTINGS = ImmutableMap.of(
+                TEST_INT_ATTRIBUTE, TEST_INT_VALUE,
+                TEST_STRING_ATTRIBUTE, TEST_STRING_VALUE,
+                TEST_BOOL_ATTRIBUTE, TEST_BOOL_VALUE,
+                TEST_LONG_ATTRIBUTE, TEST_LONG_VALUE);
+
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
+
+        assertThat(pluginSetting.getAttributeFromSettings(TEST_INT_ATTRIBUTE), is(TEST_INT_VALUE));
+
+        // test attributes that exist when passing in a different default value
+        assertThat(pluginSetting.getAttributeOrDefault(TEST_INT_ATTRIBUTE, TEST_INT_DEFAULT_VALUE), is(TEST_INT_VALUE));
+        assertThat(pluginSetting.getIntegerOrDefault(TEST_INT_ATTRIBUTE, TEST_INT_DEFAULT_VALUE), is(TEST_INT_VALUE));
+        assertThat(pluginSetting.getStringOrDefault(TEST_STRING_ATTRIBUTE, TEST_STRING_DEFAULT_VALUE),
+                is(equalTo(TEST_STRING_VALUE)));
+        assertThat(pluginSetting.getBooleanOrDefault(TEST_BOOL_ATTRIBUTE, TEST_BOOL_DEFAULT_VALUE), is(equalTo(TEST_BOOL_VALUE)));
+        assertThat(pluginSetting.getLongOrDefault(TEST_LONG_ATTRIBUTE, TEST_LONG_DEFAULT_VALUE), is(equalTo(TEST_LONG_VALUE)));
+    }
+
+    @Test
+    public void testPluginSettingAttributesAsString() {
+        final String TEST_INT_VALUE_STRING = String.valueOf(TEST_INT_VALUE);
+        final String TEST_BOOL_VALUE_STRING = String.valueOf(TEST_BOOL_VALUE);
+        final String TEST_LONG_VALUE_STRING = String.valueOf(TEST_LONG_VALUE);
+
+        final String TEST_INT_STRING_ATTRIBUTE = "int-string-attribute";
+        final String TEST_BOOL_STRING_ATTRIBUTE = "bool-string-attribute";
+        final String TEST_LONG_STRING_ATTRIBUTE = "long-string-attribute";
+
+        final Map<String, Object> TEST_SETTINGS_AS_STRINGS = ImmutableMap.of(
+                TEST_INT_STRING_ATTRIBUTE, TEST_INT_VALUE_STRING,
+                TEST_BOOL_STRING_ATTRIBUTE, TEST_BOOL_VALUE_STRING,
+                TEST_LONG_STRING_ATTRIBUTE, TEST_LONG_VALUE_STRING);
+
+
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_AS_STRINGS);
+
+        // test attributes that exist when passing in a different default value
+        assertThat(pluginSetting.getIntegerOrDefault(TEST_INT_STRING_ATTRIBUTE, TEST_INT_DEFAULT_VALUE), is(TEST_INT_VALUE));
+        assertThat(pluginSetting.getBooleanOrDefault(TEST_BOOL_STRING_ATTRIBUTE, TEST_BOOL_DEFAULT_VALUE), is(equalTo(TEST_BOOL_VALUE)));
+        assertThat(pluginSetting.getLongOrDefault(TEST_LONG_STRING_ATTRIBUTE, TEST_LONG_DEFAULT_VALUE), is(equalTo(TEST_LONG_VALUE)));
+    }
+
+    /**
+     * Request attributes are present with null values, expect nulls to be returned
+     */
+    @Test
+    public void testPluginSettingAttributesAsNull() {
+        final String TEST_INT_NULL_ATTRIBUTE = "int-null-attribute";
+        final String TEST_STRING_NULL_ATTRIBUTE = "string-null-attribute";
+        final String TEST_BOOL_NULL_ATTRIBUTE = "bool-null-attribute";
+        final String TEST_LONG_NULL_ATTRIBUTE = "long-null-attribute";
+
+        final Map<String, Object> TEST_SETTINGS_AS_STRINGS = new HashMap<>();
+        TEST_SETTINGS_AS_STRINGS.put(TEST_INT_NULL_ATTRIBUTE, null);
+        TEST_SETTINGS_AS_STRINGS.put(TEST_STRING_NULL_ATTRIBUTE, null);
+        TEST_SETTINGS_AS_STRINGS.put(TEST_BOOL_NULL_ATTRIBUTE, null);
+        TEST_SETTINGS_AS_STRINGS.put(TEST_LONG_NULL_ATTRIBUTE, null);
+
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_AS_STRINGS);
+
+        // test attributes that exist when passing in a different default value
+        assertThat(pluginSetting.getIntegerOrDefault(TEST_INT_NULL_ATTRIBUTE, TEST_INT_DEFAULT_VALUE), nullValue());
+        assertThat(pluginSetting.getStringOrDefault(TEST_STRING_NULL_ATTRIBUTE, TEST_STRING_DEFAULT_VALUE), nullValue());
+        assertThat(pluginSetting.getBooleanOrDefault(TEST_BOOL_NULL_ATTRIBUTE, TEST_BOOL_DEFAULT_VALUE), nullValue());
+        assertThat(pluginSetting.getLongOrDefault(TEST_LONG_NULL_ATTRIBUTE, TEST_LONG_DEFAULT_VALUE), nullValue());
+    }
+
+    /**
+     * Requested attributes are not present, expect default values to be returned
+     */
+    @Test
+    public void testPluginSettingAttributesNotPresent() {
+        final String NOT_PRESENT_ATTRIBUTE = "not-present";
+
         final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, null);
-        pluginSetting.setPipelineName(TEST_PIPELINE);
-        pluginSetting.setProcessWorkers(TEST_WORKERS);
 
-        assertThat(pluginSetting, notNullValue());
-        assertThat(pluginSetting.getName(), is(TEST_PLUGIN_NAME));
         assertThat(pluginSetting.getSettings(), nullValue());
-        assertThat(pluginSetting.getPipelineName(), is(TEST_PIPELINE));
-        assertThat(pluginSetting.getNumberOfProcessWorkers(), is(TEST_WORKERS));
-
         assertThat(pluginSetting.getAttributeFromSettings(NOT_PRESENT_ATTRIBUTE), nullValue());
-        assertThat(pluginSetting.getAttributeOrDefault(NOT_PRESENT_ATTRIBUTE, 500), is(500));
-        assertThat(pluginSetting.getIntegerOrDefault(NOT_PRESENT_ATTRIBUTE, 500), is(500));
-        assertThat(pluginSetting.getStringOrDefault(NOT_PRESENT_ATTRIBUTE, NOT_PRESENT_ATTRIBUTE),
-                is(equalTo(NOT_PRESENT_ATTRIBUTE)));
-        assertThat(pluginSetting.getBooleanOrDefault(NOT_PRESENT_ATTRIBUTE, Boolean.FALSE), is(equalTo(Boolean.FALSE)));
-        assertThat(pluginSetting.getLongOrDefault(NOT_PRESENT_ATTRIBUTE, Long.MAX_VALUE), is(equalTo(Long.MAX_VALUE)));
+
+        assertThat(pluginSetting.getAttributeOrDefault(NOT_PRESENT_ATTRIBUTE, TEST_INT_DEFAULT_VALUE), is(TEST_INT_DEFAULT_VALUE));
+        assertThat(pluginSetting.getIntegerOrDefault(NOT_PRESENT_ATTRIBUTE, TEST_INT_DEFAULT_VALUE), is(TEST_INT_DEFAULT_VALUE));
+        assertThat(pluginSetting.getStringOrDefault(NOT_PRESENT_ATTRIBUTE, TEST_STRING_DEFAULT_VALUE),
+                is(equalTo(TEST_STRING_DEFAULT_VALUE)));
+        assertThat(pluginSetting.getBooleanOrDefault(NOT_PRESENT_ATTRIBUTE, TEST_BOOL_DEFAULT_VALUE), is(equalTo(TEST_BOOL_DEFAULT_VALUE)));
+        assertThat(pluginSetting.getLongOrDefault(NOT_PRESENT_ATTRIBUTE, TEST_LONG_DEFAULT_VALUE), is(equalTo(TEST_LONG_DEFAULT_VALUE)));
+    }
+
+    @Test
+    public void testPluginSettingAttributeUnsupportedType() {
+        final Object UNSUPPORTED_TYPE = new ArrayList<>();
+
+        final Map<String, Object> TEST_SETTINGS_AS_STRINGS = new HashMap<>();
+        TEST_SETTINGS_AS_STRINGS.put(TEST_INT_ATTRIBUTE, UNSUPPORTED_TYPE);
+        TEST_SETTINGS_AS_STRINGS.put(TEST_STRING_ATTRIBUTE, UNSUPPORTED_TYPE);
+        TEST_SETTINGS_AS_STRINGS.put(TEST_BOOL_ATTRIBUTE, UNSUPPORTED_TYPE);
+        TEST_SETTINGS_AS_STRINGS.put(TEST_LONG_ATTRIBUTE, UNSUPPORTED_TYPE);
+
+        final PluginSetting pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS_AS_STRINGS);
+
+        // test attributes that exist when passing in a different default value
+        assertThrows(IllegalArgumentException.class, () -> pluginSetting.getIntegerOrDefault(TEST_INT_ATTRIBUTE, TEST_INT_DEFAULT_VALUE));
+        assertThrows(IllegalArgumentException.class, () -> pluginSetting.getStringOrDefault(TEST_STRING_ATTRIBUTE, TEST_STRING_DEFAULT_VALUE));
+        assertThrows(IllegalArgumentException.class, () -> pluginSetting.getBooleanOrDefault(TEST_BOOL_ATTRIBUTE, TEST_BOOL_DEFAULT_VALUE));
+        assertThrows(IllegalArgumentException.class, () -> pluginSetting.getLongOrDefault(TEST_LONG_ATTRIBUTE, TEST_LONG_DEFAULT_VALUE));
     }
 }


### PR DESCRIPTION
This change is to allow the yaml property values for boolean, integer, and long values to be passed in as strings. This is supported for elements in the data-prepper config and some of the elements in the pipeline config. Nulls values are also now supported. Custom elements in source and sinks do not support this. It is not supported because the parsing of those configurations is done with custom code while the data-prepper config supports it because it uses json property binding via Jackson libraries. This changes brings more consistency throughout the config files.

String values were previously not supported but now they are:
```
entry-pipeline: 
  source: 
    otel_trace_source:  
      health_check_service: "false"  
      port: "8080"  
```

Null values were previously not supported but now they are:
```
entry-pipeline: 
  source: 
    otel_trace_source:  
      health_check_service:
      port:
```

Continues to be supported:
```
entry-pipeline: 
  source: 
    otel_trace_source:  
      health_check_service: false
      port: 8080
```

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
