### PR TITLE
Updated workflows to potentially stop duplicate actions from firing.

### DIFF
--- a/.github/workflows/data-prepper-trace-analytics-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-e2e-tests.yml
@@ -5,9 +5,8 @@ name: Data Prepper Trace Analytics End-to-end test with Gradle
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+    types: [opened]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/data-prepper-trace-analytics-e2e-tests.yml
+++ b/.github/workflows/data-prepper-trace-analytics-e2e-tests.yml
@@ -5,8 +5,8 @@ name: Data Prepper Trace Analytics End-to-end test with Gradle
 
 on:
   push:
+    branches: [ main ]
   pull_request:
-    types: [opened]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,7 +3,11 @@
 
 name: Data Prepper Java CI with Gradle
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+    types: [opened]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,6 +5,7 @@ name: Data Prepper Java CI with Gradle
 
 on:
   push:
+    branches: [ main ]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,7 +6,6 @@ name: Data Prepper Java CI with Gradle
 on:
   push:
   pull_request:
-    types: [opened]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/opensearch-sink-odfe-before-1_13_0-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-odfe-before-1_13_0-integration-tests.yml
@@ -3,7 +3,11 @@
 
 name: Data Prepper elasticsearch sink integration tests with ODFE < 1.13.0
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+    types: [opened]
+  workflow_dispatch:
 
 jobs:
   integration_tests:

--- a/.github/workflows/opensearch-sink-odfe-before-1_13_0-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-odfe-before-1_13_0-integration-tests.yml
@@ -5,8 +5,8 @@ name: Data Prepper elasticsearch sink integration tests with ODFE < 1.13.0
 
 on:
   push:
+    branches: [ main ]
   pull_request:
-    types: [opened]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/opensearch-sink-odfe-since-1_13_0-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-odfe-since-1_13_0-integration-tests.yml
@@ -3,7 +3,11 @@
 
 name: Data Prepper elasticsearch sink integration tests with ODFE >= 1.13.0
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+    types: [opened]
+  workflow_dispatch:
 
 jobs:
   integration_tests:

--- a/.github/workflows/opensearch-sink-odfe-since-1_13_0-integration-tests.yml
+++ b/.github/workflows/opensearch-sink-odfe-since-1_13_0-integration-tests.yml
@@ -5,8 +5,8 @@ name: Data Prepper elasticsearch sink integration tests with ODFE >= 1.13.0
 
 on:
   push:
+    branches: [ main ]
   pull_request:
-    types: [opened]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Signed-off-by: Jeff Wright <74204404+wrijeff@users.noreply.github.com>

*Description of changes:*
Noticed duplicate test runs were being started when PRs are opened/code pushed ([example](https://github.com/opendistro-for-elasticsearch/data-prepper/pull/560)). This is an attempt to fix it.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
