### PR TITLE
Add CloudWatchMeterRegistry

### DIFF
--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     implementation "org.reflections:reflections:0.9.12"
     implementation "io.micrometer:micrometer-core:1.6.5"
     implementation "io.micrometer:micrometer-registry-prometheus:1.6.5"
+    implementation "io.micrometer:micrometer-registry-cloudwatch2:1.6.6"
+    implementation "software.amazon.awssdk:cloudwatch:2.16.54"
     testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation "org.mockito:mockito-core:3.9.0"
 }
@@ -50,7 +52,7 @@ jacocoTestCoverageVerification {
             limit {
                 // temporarily lowering this to unblock the release.
                 // some builds pass with 0.9 coverage, some fail with 0.89
-                minimum = 0.89
+                minimum = 0.80
             }
         }
     }

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -52,7 +52,7 @@ jacocoTestCoverageVerification {
             limit {
                 // temporarily lowering this to unblock the release.
                 // some builds pass with 0.9 coverage, some fail with 0.89
-                minimum = 0.80
+                minimum = 0.89
             }
         }
     }

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/CloudWatchMeterRegistryProvider.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/CloudWatchMeterRegistryProvider.java
@@ -1,0 +1,63 @@
+package com.amazon.dataprepper.pipeline.server;
+
+import io.micrometer.cloudwatch2.CloudWatchConfig;
+import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
+import io.micrometer.core.instrument.Clock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * Provides {@link CloudWatchMeterRegistry} that enables publishing metrics to AWS Cloudwatch. Registry
+ * uses the default aws credentials (i.e. credentials from .aws directory;
+ * refer https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/credentials.html#credentials-file-format).
+ * {@link CloudWatchMeterRegistryProvider} also has a constructor with {@link CloudWatchAsyncClient} that will be used
+ * for communication with Cloudwatch.
+ */
+public class CloudWatchMeterRegistryProvider {
+    private static final String CLOUDWATCH_PROPERTIES = "cloudwatch.properties";
+    private static final Logger LOG = LoggerFactory.getLogger(PrometheusMetricsHandler.class);
+
+    private final CloudWatchMeterRegistry cloudWatchMeterRegistry;
+
+    public CloudWatchMeterRegistryProvider() {
+        this(CLOUDWATCH_PROPERTIES, CloudWatchAsyncClient.create());
+    }
+
+    public CloudWatchMeterRegistryProvider(
+            final String cwPropertiesFile,
+            final CloudWatchAsyncClient cloudWatchClient) {
+        final CloudWatchConfig cloudWatchConfig = createCloudWatchConfig(cwPropertiesFile);
+        this.cloudWatchMeterRegistry = new CloudWatchMeterRegistry(cloudWatchConfig, Clock.SYSTEM, cloudWatchClient);
+    }
+
+    /**
+     * Returns the CloudWatchMeterRegistry created using the default aws credentials
+     */
+    public CloudWatchMeterRegistry getCloudWatchMeterRegistry() {
+        return this.cloudWatchMeterRegistry;
+    }
+
+    /**
+     * Returns CloudWatchConfig using the properties from {@link #CLOUDWATCH_PROPERTIES}
+     */
+    private CloudWatchConfig createCloudWatchConfig(final String cwPropertiesFile) {
+        CloudWatchConfig cloudWatchConfig = null;
+        try (final InputStream inputStream = Objects.requireNonNull(getClass()
+                .getClassLoader().getResourceAsStream(cwPropertiesFile))) {
+            final Properties cloudwatchProperties = new Properties();
+            cloudwatchProperties.load(inputStream);
+            cloudWatchConfig = cloudwatchProperties::getProperty; //overriding getKey() from CloudWatchConfig
+        } catch (IOException ex) {
+            LOG.error("Encountered exception in creating CloudWatchConfig for CloudWatchMeterRegistry, " +
+                    "Proceeding without metrics", ex);
+            //If there is no registry attached, micrometer will make NoopMeters which are discarded.
+        }
+        return cloudWatchConfig;
+    }
+}

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/CloudWatchMeterRegistryProvider.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/server/CloudWatchMeterRegistryProvider.java
@@ -21,7 +21,7 @@ import java.util.Properties;
  */
 public class CloudWatchMeterRegistryProvider {
     private static final String CLOUDWATCH_PROPERTIES = "cloudwatch.properties";
-    private static final Logger LOG = LoggerFactory.getLogger(PrometheusMetricsHandler.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CloudWatchMeterRegistryProvider.class);
 
     private final CloudWatchMeterRegistry cloudWatchMeterRegistry;
 

--- a/data-prepper-core/src/main/resources/cloudwatch.properties
+++ b/data-prepper-core/src/main/resources/cloudwatch.properties
@@ -1,0 +1,4 @@
+cloudwatch.enabled=true
+cloudwatch.namespace=dataprepper
+cloudwatch.batchSize=20
+cloudwatch.step=PT1M

--- a/data-prepper-core/src/test/java/com/amazon/dataprepper/server/CloudWatchMeterRegistryProviderTest.java
+++ b/data-prepper-core/src/test/java/com/amazon/dataprepper/server/CloudWatchMeterRegistryProviderTest.java
@@ -1,0 +1,57 @@
+package com.amazon.dataprepper.server;
+
+import com.amazon.dataprepper.pipeline.server.CloudWatchMeterRegistryProvider;
+import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CloudWatchMeterRegistryProviderTest {
+    private static final String TEST_CLOUDWATCH_PROPERTIES = "cloudwatch_test.properties";
+
+    @Mock
+    CloudWatchAsyncClient cloudWatchAsyncClient;
+
+    @Mock
+    CompletableFuture<PutMetricDataResponse> putMetricDataResponseCompletableFuture;
+
+
+    @Before
+    public void setup() throws Exception {
+        when(cloudWatchAsyncClient.putMetricData(any(PutMetricDataRequest.class))).thenReturn(putMetricDataResponseCompletableFuture);
+        doAnswer(ans -> null).when(putMetricDataResponseCompletableFuture).whenCompleteAsync(any());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCreateWithInvalidPropertiesFile() {
+        new CloudWatchMeterRegistryProvider("does not exist", cloudWatchAsyncClient);
+    }
+
+    @Test
+    public void testCreateCloudWatchMeterRegistry() {
+        final CloudWatchMeterRegistryProvider cloudWatchMeterRegistryProvider = new CloudWatchMeterRegistryProvider(
+                TEST_CLOUDWATCH_PROPERTIES, cloudWatchAsyncClient);
+        final CloudWatchMeterRegistry cloudWatchMeterRegistry = cloudWatchMeterRegistryProvider.getCloudWatchMeterRegistry();
+        assertThat(cloudWatchMeterRegistry, notNullValue());
+        cloudWatchMeterRegistry.gauge("test-gauge", 1d);
+        cloudWatchMeterRegistry.close(); //This will trigger publishing of metrics
+        verify(cloudWatchAsyncClient, atLeast(1)).putMetricData(any(PutMetricDataRequest.class));
+    }
+
+}

--- a/data-prepper-core/src/test/resources/cloudwatch_test.properties
+++ b/data-prepper-core/src/test/resources/cloudwatch_test.properties
@@ -1,0 +1,4 @@
+cloudwatch.enabled=true
+cloudwatch.namespace=dataprepper-test
+cloudwatch.batchSize=20
+cloudwatch.step=PT1S


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Adds CloudWatchRegistry

_Please note that the registry is not currently hooked to data prepper, the current meter registry will still be Prometheus which is already hooked. This PR only adds the CloudWatchRegistry enabling customers who wish to use Cloudwatch to replace Prometheus with CloudWatch_

*Testing after updating the global registry*
Have tested on my dev account and below is the screenshot 

![Screen Shot 2021-05-05 at 9 17 07 AM](https://user-images.githubusercontent.com/55510769/117155831-be00a880-ad82-11eb-9c71-21902e54522f.png)
![Screen Shot 2021-05-05 at 9 16 57 AM](https://user-images.githubusercontent.com/55510769/117155866-c658e380-ad82-11eb-9b30-b5c616b3703f.png)

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
