### PR TITLE
MAINT: report back failure if exception found in data-prepper.log

### DIFF
--- a/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
+++ b/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
@@ -192,7 +192,7 @@ Resources:
           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
           nohup /usr/local/bin/$RELEASE/data-prepper-tar-install.sh /etc/data-prepper/pipelines.yaml /etc/data-prepper/data-prepper-config.yaml > /var/log/data-prepper.out &
           sleep 5s
-          export EXCEPTION_MSG=$(echo $(grep -E "Exception" /var/log/data-prepper.out) | iconv -t utf-8)
+          export EXCEPTION_MSG=$(grep -E "Exception" /var/log/data-prepper.out)
           if [[ $EXCEPTION_MSG == "" ]]
           then
              /opt/aws/bin/cfn-signal --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}

--- a/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
+++ b/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
@@ -191,7 +191,14 @@ Resources:
           tar -xzf /tmp/$RELEASE.tar.gz --directory /usr/local/bin
           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
           nohup /usr/local/bin/$RELEASE/data-prepper-tar-install.sh /etc/data-prepper/pipelines.yaml /etc/data-prepper/data-prepper-config.yaml > /var/log/data-prepper.out &
-          /opt/aws/bin/cfn-signal --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+          sleep 5s
+          export EXCEPTION_MSG=$(echo $(grep -E "Exception" /var/log/data-prepper.out) | iconv -t utf-8)
+          if [[ $EXCEPTION_MSG == "" ]]
+          then
+             /opt/aws/bin/cfn-signal --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+          else
+             /opt/aws/bin/cfn-signal -s false --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+          fi
     CreationPolicy:
       ResourceSignal:
         Count: 1

--- a/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
+++ b/deployment-template/ec2/data-prepper-ec2-deployment-cfn.yaml
@@ -188,16 +188,18 @@ Resources:
           export RELEASE=opendistroforelasticsearch-data-prepper-${DataPrepperVersion}-linux-x64
           yum install java-11-amazon-corretto-headless -y
           wget https://github.com/opendistro-for-elasticsearch/data-prepper/releases/download/v${DataPrepperVersion}/$RELEASE.tar.gz -O /tmp/$RELEASE.tar.gz
-          tar -xzf /tmp/$RELEASE.tar.gz --directory /usr/local/bin
-          /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
-          nohup /usr/local/bin/$RELEASE/data-prepper-tar-install.sh /etc/data-prepper/pipelines.yaml /etc/data-prepper/data-prepper-config.yaml > /var/log/data-prepper.out &
-          sleep 5s
-          export EXCEPTION_MSG=$(grep -E "Exception" /var/log/data-prepper.out)
-          if [[ $EXCEPTION_MSG == "" ]]
+          wget_exit_code = $?
+          if [ $wget_exit_code -ne 0 ]
           then
-             /opt/aws/bin/cfn-signal --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+            /opt/aws/bin/cfn-signal -e $wget_exit_code --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
           else
-             /opt/aws/bin/cfn-signal -s false --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+            tar -xzf /tmp/$RELEASE.tar.gz --directory /usr/local/bin
+            /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
+            nohup /usr/local/bin/$RELEASE/data-prepper-tar-install.sh /etc/data-prepper/pipelines.yaml /etc/data-prepper/data-prepper-config.yaml > /var/log/data-prepper.out &
+            data_prepper_pid=$!
+            sleep 5s
+            ps -p $data_prepper_pid
+            /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
           fi
     CreationPolicy:
       ResourceSignal:


### PR DESCRIPTION
Signed-off-by: qchea <qchea@amazon.com>

*Issue #, if available:*
#313 

*Description of changes:*

-----
This PR adds failure signal into CFN by looking up exception in the log. Did not figure out a way to report the error message back

![Screen Shot 2021-05-13 at 6 25 36 PM](https://user-images.githubusercontent.com/19492223/118199839-8a282180-b419-11eb-9900-a38606ac9d94.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
