### PR TITLE
Bug Fixes: capture invalid index alias exception and display instructive msg

### DIFF
--- a/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSink.java
+++ b/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSink.java
@@ -71,10 +71,9 @@ public class ElasticsearchSink extends AbstractSink<Record<String>> {
     this.documentIdField = esSinkConfig.getIndexConfiguration().getDocumentIdField();
     try {
       start();
-    } catch (final IOException e) {
-      throw new RuntimeException(e.getMessage(), e);
-    } finally {
+    } catch (final Exception e) {
       this.shutdown();
+      throw new RuntimeException(e.getMessage(), e);
     }
   }
 

--- a/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSink.java
+++ b/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSink.java
@@ -72,8 +72,11 @@ public class ElasticsearchSink extends AbstractSink<Record<String>> {
     try {
       start();
     } catch (final Exception e) {
-      this.shutdown();
-      throw new RuntimeException(e.getMessage(), e);
+      try {
+        throw new RuntimeException(e.getMessage(), e);
+      } finally {
+        this.shutdown();
+      }
     }
   }
 

--- a/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSink.java
+++ b/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSink.java
@@ -193,6 +193,7 @@ public class ElasticsearchSink extends AbstractSink<Record<String>> {
           // Do nothing - likely caused by a race condition where the resource was created
           // by another host before this host's restClient made its request
         } else if (e.getMessage().contains(String.format(INDEX_ALIAS_USED_AS_INDEX_ERROR, indexAlias))) {
+          // TODO: replace IOException with custom data-prepper exception
           throw new IOException(
                   String.format("An index exists with the same name as the reserved index alias name [%s], please delete or migrate the existing index",
                           indexAlias));

--- a/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSink.java
+++ b/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSink.java
@@ -70,18 +70,15 @@ public class ElasticsearchSink extends AbstractSink<Record<String>> {
     this.indexType = esSinkConfig.getIndexConfiguration().getIndexType();
     this.documentIdField = esSinkConfig.getIndexConfiguration().getDocumentIdField();
     try {
-      start();
+      initialize();
     } catch (final IOException e) {
-      try {
-        throw new RuntimeException(e.getMessage(), e);
-      } finally {
-        this.shutdown();
-      }
+      this.shutdown();
+      throw new RuntimeException(e.getMessage(), e);
     }
   }
 
-  public void start() throws IOException {
-    LOG.info("Starting Elasticsearch sink");
+  public void initialize() throws IOException {
+    LOG.info("Initializing Elasticsearch sink");
     restHighLevelClient = esSinkConfig.getConnectionConfiguration().createClient();
     final boolean isISMEnabled = IndexStateManagement.checkISMEnabled(restHighLevelClient);
     final Optional<String> policyIdOptional = isISMEnabled? IndexStateManagement.checkAndCreatePolicy(restHighLevelClient, indexType) : Optional.empty();
@@ -99,7 +96,7 @@ public class ElasticsearchSink extends AbstractSink<Record<String>> {
             this::logFailure,
             pluginMetrics,
             bulkRequestSupplier);
-    LOG.info("Started Elasticsearch sink");
+    LOG.info("Initialized Elasticsearch sink");
   }
 
   @Override

--- a/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSink.java
+++ b/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSink.java
@@ -71,7 +71,7 @@ public class ElasticsearchSink extends AbstractSink<Record<String>> {
     this.documentIdField = esSinkConfig.getIndexConfiguration().getDocumentIdField();
     try {
       start();
-    } catch (final Exception e) {
+    } catch (final IOException e) {
       try {
         throw new RuntimeException(e.getMessage(), e);
       } finally {
@@ -193,11 +193,11 @@ public class ElasticsearchSink extends AbstractSink<Record<String>> {
           // Do nothing - likely caused by a race condition where the resource was created
           // by another host before this host's restClient made its request
         } else if (e.getMessage().contains(String.format(INDEX_ALIAS_USED_AS_INDEX_ERROR, indexAlias))) {
-          throw new ElasticsearchException(
+          throw new IOException(
                   String.format("An index exists with the same name as the reserved index alias name [%s], please delete or migrate the existing index",
                           indexAlias));
         } else {
-          throw e;
+          throw new IOException(e);
         }
       }
     }

--- a/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
+++ b/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
@@ -17,6 +17,7 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.util.EntityUtils;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
@@ -111,6 +112,15 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
       // Check managed index
       assertEquals(IndexConstants.RAW_ISM_POLICY, getIndexPolicyId(rolloverIndexName));
     }
+  }
+
+  public void testInstantiateSinkRawSpanReservedAliasAlreadyUsedAsIndex() throws IOException {
+    final String reservedIndexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(IndexConstants.RAW);
+    final Request request = new Request(HttpMethod.PUT, reservedIndexAlias);
+    client().performRequest(request);
+    final PluginSetting pluginSetting = generatePluginSetting(true, false, null, null);
+    assertThrows(String.format(ElasticsearchSink.INDEX_ALIAS_USED_AS_INDEX_ERROR, reservedIndexAlias),
+            ElasticsearchException.class, () -> new ElasticsearchSink(pluginSetting));
   }
 
   public void testOutputRawSpanDefault() throws IOException, InterruptedException {

--- a/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
+++ b/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
@@ -17,7 +17,6 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.util.EntityUtils;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;

--- a/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
+++ b/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
@@ -120,7 +120,7 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
     client().performRequest(request);
     final PluginSetting pluginSetting = generatePluginSetting(true, false, null, null);
     assertThrows(String.format(ElasticsearchSink.INDEX_ALIAS_USED_AS_INDEX_ERROR, reservedIndexAlias),
-            ElasticsearchException.class, () -> new ElasticsearchSink(pluginSetting));
+            RuntimeException.class, () -> new ElasticsearchSink(pluginSetting));
   }
 
   public void testOutputRawSpanDefault() throws IOException, InterruptedException {


### PR DESCRIPTION
Signed-off-by: qchea <qchea@amazon.com>

*Issue #, if available:*
#491 

*Description of changes:*

-----
This PR:

(1) Captures invalid raw-span index alias caused by existing index under the same name from misoperation on ES backend.
(2) make sure REST client gets cleaned up if ElasticsearchSink starts failed to prevent thread leakage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
