### PR TITLE
Add capability to configure unframed requets from otel trace source configuration

### DIFF
--- a/data-prepper-plugins/otel-trace-source/README.md
+++ b/data-prepper-plugins/otel-trace-source/README.md
@@ -16,6 +16,7 @@ source:
 * request_timeout(Optional) => An `int` represents request timeout in millis. Default is ```10_000```.
 * health_check_service(Optional) => A boolean enables a gRPC health check service under ```grpc.health.v1 / Health / Check```. Default is ```false```.
 * proto_reflection_service(Optional) => A boolean enables a reflection service for Protobuf services (see [ProtoReflectionService](https://grpc.github.io/grpc-java/javadoc/io/grpc/protobuf/services/ProtoReflectionService.html) and [gRPC reflection](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md) docs). Default is ```false```.
+* unframed_requests(Optional) => A boolean to enable requests not framed using the gRPC wire protocol. 
 * ssl(Optional) => A boolean enables TLS/SSL. Default is ```true```.
 * sslKeyCertChainFile(Optional) => A `String` represents the SSL certificate chain file path. Required if ```ssl``` is set to ```true```
 * sslKeyFile(Optional) => A `String` represents the SSL key file path. Required if ```ssl``` is set to ```true```

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
@@ -59,6 +59,7 @@ public class OTelTraceSource implements Source<Record<ExportTraceServiceRequest>
                 LOG.info("Proto reflection service is enabled");
                 grpcServiceBuilder.addService(ProtoReflectionService.newInstance());
             }
+            grpcServiceBuilder.enableUnframedRequests(oTelTraceSourceConfig.enableUnframedRequests());
 
             final ServerBuilder sb = Server.builder();
             sb.service(grpcServiceBuilder.build());

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
@@ -59,6 +59,7 @@ public class OTelTraceSource implements Source<Record<ExportTraceServiceRequest>
                 LOG.info("Proto reflection service is enabled");
                 grpcServiceBuilder.addService(ProtoReflectionService.newInstance());
             }
+            
             grpcServiceBuilder.enableUnframedRequests(oTelTraceSourceConfig.enableUnframedRequests());
 
             final ServerBuilder sb = Server.builder();

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
@@ -12,6 +12,7 @@ public class OTelTraceSourceConfig {
     static final String SSL_KEY_FILE = "sslKeyFile";
     static final String THREAD_COUNT = "thread_count";
     static final String MAX_CONNECTION_COUNT = "max_connection_count";
+    static final String ENABLE_UNFRAMED_REQUESTS = "unframed-requests";
     static final int DEFAULT_REQUEST_TIMEOUT_MS = 10000;
     static final int DEFAULT_PORT = 21890;
     static final int DEFAULT_THREAD_COUNT = 200;
@@ -21,6 +22,7 @@ public class OTelTraceSourceConfig {
     private final int port;
     private final boolean healthCheck;
     private final boolean protoReflectionService;
+    private final boolean enableUnframedRequests;
     private final boolean ssl;
     private final String sslKeyCertChainFile;
     private final String sslKeyFile;
@@ -31,6 +33,7 @@ public class OTelTraceSourceConfig {
                                   final int port,
                                   final boolean healthCheck,
                                   final boolean protoReflectionService,
+                                  final boolean enableUnframedRequests,
                                   final boolean isSSL,
                                   final String sslKeyCertChainFile,
                                   final String sslKeyFile,
@@ -40,6 +43,7 @@ public class OTelTraceSourceConfig {
         this.port = port;
         this.healthCheck = healthCheck;
         this.protoReflectionService = protoReflectionService;
+        this.enableUnframedRequests = enableUnframedRequests;
         this.ssl = isSSL;
         this.sslKeyCertChainFile = sslKeyCertChainFile;
         this.sslKeyFile = sslKeyFile;
@@ -58,6 +62,7 @@ public class OTelTraceSourceConfig {
                 pluginSetting.getIntegerOrDefault(PORT, DEFAULT_PORT),
                 pluginSetting.getBooleanOrDefault(HEALTH_CHECK_SERVICE, false),
                 pluginSetting.getBooleanOrDefault(PROTO_REFLECTION_SERVICE, false),
+                pluginSetting.getBooleanOrDefault(ENABLE_UNFRAMED_REQUESTS, false),
                 pluginSetting.getBooleanOrDefault(SSL, DEFAULT_SSL),
                 pluginSetting.getStringOrDefault(SSL_KEY_CERT_FILE, null),
                 pluginSetting.getStringOrDefault(SSL_KEY_FILE, null),
@@ -79,6 +84,10 @@ public class OTelTraceSourceConfig {
 
     public boolean hasProtoReflectionService() {
         return protoReflectionService;
+    }
+
+    public boolean enableUnframedRequests() {
+        return enableUnframedRequests;
     }
 
     public boolean isSsl() {

--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSourceConfig.java
@@ -12,7 +12,7 @@ public class OTelTraceSourceConfig {
     static final String SSL_KEY_FILE = "sslKeyFile";
     static final String THREAD_COUNT = "thread_count";
     static final String MAX_CONNECTION_COUNT = "max_connection_count";
-    static final String ENABLE_UNFRAMED_REQUESTS = "unframed-requests";
+    static final String ENABLE_UNFRAMED_REQUESTS = "unframed_requests";
     static final int DEFAULT_REQUEST_TIMEOUT_MS = 10000;
     static final int DEFAULT_PORT = 21890;
     static final int DEFAULT_THREAD_COUNT = 200;

--- a/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
+++ b/data-prepper-plugins/otel-trace-source/src/test/java/com/amazon/dataprepper/plugins/source/oteltrace/OtelTraceSourceConfigTests.java
@@ -53,6 +53,7 @@ public class OtelTraceSourceConfigTests {
                 TEST_PORT,
                 true,
                 true,
+                false,
                 true,
                 TEST_KEY_CERT,
                 TEST_KEY,
@@ -81,6 +82,7 @@ public class OtelTraceSourceConfigTests {
                 DEFAULT_REQUEST_TIMEOUT_MS,
                 DEFAULT_PORT, false,
                 false,
+                false,
                 true, null,
                 TEST_KEY,
                 DEFAULT_THREAD_COUNT,
@@ -92,6 +94,7 @@ public class OtelTraceSourceConfigTests {
         final PluginSetting sslEmptyKeyCertPluginSetting = completePluginSettingForOtelTraceSource(
                 DEFAULT_REQUEST_TIMEOUT_MS,
                 DEFAULT_PORT,
+                false,
                 false,
                 false,
                 true,
@@ -108,6 +111,7 @@ public class OtelTraceSourceConfigTests {
                 DEFAULT_PORT,
                 false,
                 false,
+                false,
                 true,
                 TEST_KEY_CERT,
                 null,
@@ -120,6 +124,7 @@ public class OtelTraceSourceConfigTests {
         final PluginSetting sslEmptyKeyFilePluginSetting = completePluginSettingForOtelTraceSource(
                 DEFAULT_REQUEST_TIMEOUT_MS,
                 DEFAULT_PORT,
+                false,
                 false,
                 false,
                 true,
@@ -135,6 +140,7 @@ public class OtelTraceSourceConfigTests {
                                                                   final int port,
                                                                   final boolean healthCheck,
                                                                   final boolean protoReflectionService,
+                                                                  final boolean enableUnframedRequests,
                                                                   final boolean isSSL,
                                                                   final String sslKeyCertChainFile,
                                                                   final String sslKeyFile,
@@ -145,6 +151,7 @@ public class OtelTraceSourceConfigTests {
         settings.put(OTelTraceSourceConfig.PORT, port);
         settings.put(OTelTraceSourceConfig.HEALTH_CHECK_SERVICE, healthCheck);
         settings.put(OTelTraceSourceConfig.PROTO_REFLECTION_SERVICE, protoReflectionService);
+        settings.put(OTelTraceSourceConfig.ENABLE_UNFRAMED_REQUESTS, enableUnframedRequests);
         settings.put(OTelTraceSourceConfig.SSL, isSSL);
         settings.put(OTelTraceSourceConfig.SSL_KEY_CERT_FILE, sslKeyCertChainFile);
         settings.put(OTelTraceSourceConfig.SSL_KEY_FILE, sslKeyFile);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Adds feasibility to configure unframed requests via data prepper pipeline configuration for otel_trace_source

*Testing*
* Verified on local
```
$ curl -H 'Content-Type: application/json; charset=utf-8' -d '{"resourceSpans":[{"instrumentationLibrarySpans":[{"spans":[{"spanId":"AAAAAAAAAAM=","name":"test-span"}]}]}]}'  localhost:21890/opentelemetry.proto.collector.trace.v1.TraceService/Export

related log for data prepper
2021-05-17T14:00:28,108 [entry-pipeline-prepper-worker-1-thread-1] INFO  com.amazon.dataprepper.pipeline.ProcessWorker -  entry-pipeline Worker: Processing 1 records from buffer
2021-05-17T14:00:28,208 [service-map-pipeline-prepper-worker-3-thread-1] INFO  com.amazon.dataprepper.pipeline.ProcessWorker -  service-map-pipeline Worker: Processing 1 records from buffer
2021-05-17T14:00:31,111 [raw-pipeline-prepper-worker-5-thread-1] INFO  com.amazon.dataprepper.pipeline.ProcessWorker -  raw-pipeline Worker: Processing 1 records from buffer

```

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
