### PR TITLE
Fixed Gradle deprecation warnings.

### DIFF
--- a/data-prepper-benchmarks/mapdb-benchmarks/build.gradle
+++ b/data-prepper-benchmarks/mapdb-benchmarks/build.gradle
@@ -13,5 +13,5 @@ repositories {
 }
 
 dependencies {
-    compile project(':data-prepper-plugins:mapdb-prepper-state')
+    implementation project(':data-prepper-plugins:mapdb-prepper-state')
 }

--- a/data-prepper-benchmarks/service-map-stateful-benchmarks/build.gradle
+++ b/data-prepper-benchmarks/service-map-stateful-benchmarks/build.gradle
@@ -13,6 +13,6 @@ repositories {
 }
 
 dependencies {
-    compile project(':data-prepper-plugins:service-map-stateful')
+    implementation project(':data-prepper-plugins:service-map-stateful')
     jmh "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
 }

--- a/data-prepper-core/build.gradle
+++ b/data-prepper-core/build.gradle
@@ -9,9 +9,10 @@ sourceSets {
 apply from: "integrationTest.gradle"
 
 dependencies {
-    compile project(':data-prepper-api')
-    compile project(':data-prepper-plugins')
-    testCompile project(':data-prepper-plugins:common').sourceSets.test.output
+    implementation project(':data-prepper-api')
+    implementation project(':data-prepper-plugins')
+    implementation project(':data-prepper-plugins:common')
+    testImplementation project(':data-prepper-plugins:common').sourceSets.test.output
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.3"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.3"
     implementation "javax.validation:validation-api:2.0.1.Final"

--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -27,9 +27,9 @@ sourceSets {
 }
 
 dependencies {
-    integrationTestCompile("junit:junit:4.13")
-    integrationTestCompile project(':data-prepper-plugins:elasticsearch')
-    integrationTestCompile project(':data-prepper-plugins:otel-trace-group-prepper')
+    integrationTestImplementation("junit:junit:4.13")
+    integrationTestImplementation project(':data-prepper-plugins:elasticsearch')
+    integrationTestImplementation project(':data-prepper-plugins:otel-trace-group-prepper')
     integrationTestImplementation "org.awaitility:awaitility:4.0.3"
     integrationTestImplementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
     integrationTestImplementation 'com.google.protobuf:protobuf-java-util:3.13.0'

--- a/data-prepper-plugins/blocking-buffer/build.gradle
+++ b/data-prepper-plugins/blocking-buffer/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
 }
 dependencies {
-    compile project(':data-prepper-api')
+    implementation project(':data-prepper-api')
     testImplementation "junit:junit:4.13.2"
 }
 

--- a/data-prepper-plugins/build.gradle
+++ b/data-prepper-plugins/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 dependencies {
-    subprojects.forEach { compile project(':data-prepper-plugins:' + it.name) }
+    subprojects.forEach { api project(':data-prepper-plugins:' + it.name) }
 }

--- a/data-prepper-plugins/common/build.gradle
+++ b/data-prepper-plugins/common/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-    id 'java'
+    id 'java-library'
 }
 dependencies {
-    compile project(':data-prepper-api')
+    api project(':data-prepper-api')
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.3"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.3"
     implementation "org.reflections:reflections:0.9.12"

--- a/data-prepper-plugins/elasticsearch/build.gradle
+++ b/data-prepper-plugins/elasticsearch/build.gradle
@@ -28,9 +28,9 @@ ext {
 }
 
 dependencies {
-    compile project(':data-prepper-api')
-    testCompile project(':data-prepper-api').sourceSets.test.output
-    compile project(':data-prepper-plugins:common')
+    api project(':data-prepper-api')
+    testImplementation project(':data-prepper-api').sourceSets.test.output
+    api project(':data-prepper-plugins:common')
     implementation "org.elasticsearch.client:elasticsearch-rest-high-level-client:${es_version}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.3"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.3"

--- a/data-prepper-plugins/mapdb-prepper-state/build.gradle
+++ b/data-prepper-plugins/mapdb-prepper-state/build.gradle
@@ -12,14 +12,14 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.13.2'
-    compile project(':data-prepper-api')
-    compile project(':data-prepper-plugins:common')
+    implementation project(':data-prepper-api')
+    implementation project(':data-prepper-plugins:common')
     implementation group: 'org.mapdb', name: 'mapdb', version: '3.0.8'
     implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.5.0'
     implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-common', version: '1.5.0'
 
-    testCompile project(':data-prepper-plugins:common').sourceSets.test.output
+    testImplementation project(':data-prepper-plugins:common').sourceSets.test.output
+    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation "org.hamcrest:hamcrest:2.2"
 }
 

--- a/data-prepper-plugins/otel-trace-group-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-group-prepper/build.gradle
@@ -7,9 +7,9 @@ ext {
 }
 
 dependencies {
-    compile project(':data-prepper-api')
-    compile project(':data-prepper-plugins:elasticsearch')
-    testCompile project(':data-prepper-api').sourceSets.test.output
+    implementation project(':data-prepper-api')
+    implementation project(':data-prepper-plugins:elasticsearch')
+    testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation "org.elasticsearch.client:elasticsearch-rest-high-level-client:${es_version}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.3"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.3"

--- a/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
+++ b/data-prepper-plugins/otel-trace-raw-prepper/build.gradle
@@ -3,10 +3,10 @@ plugins {
 }
 
 dependencies {
-    compile project(':data-prepper-api')
-    compile project(':data-prepper-plugins:common')
-    compile 'commons-codec:commons-codec:1.15'
-    testCompile project(':data-prepper-api').sourceSets.test.output
+    implementation project(':data-prepper-api')
+    implementation project(':data-prepper-plugins:common')
+    implementation 'commons-codec:commons-codec:1.15'
+    testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
     implementation 'com.google.protobuf:protobuf-java-util:3.17.0'
     implementation "com.linecorp.armeria:armeria:1.8.0"

--- a/data-prepper-plugins/otel-trace-source/build.gradle
+++ b/data-prepper-plugins/otel-trace-source/build.gradle
@@ -3,10 +3,10 @@ plugins {
 }
 
 dependencies {
-    compile project(':data-prepper-api')
-    compile project(':data-prepper-plugins:blocking-buffer')
-    compile 'commons-codec:commons-codec:1.15'
-    testCompile project(':data-prepper-api').sourceSets.test.output
+    implementation project(':data-prepper-api')
+    implementation project(':data-prepper-plugins:blocking-buffer')
+    implementation 'commons-codec:commons-codec:1.15'
+    testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
     implementation 'com.google.protobuf:protobuf-java-util:3.17.0'
     implementation "com.linecorp.armeria:armeria:1.8.0"

--- a/data-prepper-plugins/peer-forwarder/build.gradle
+++ b/data-prepper-plugins/peer-forwarder/build.gradle
@@ -10,8 +10,8 @@ repositories {
 }
 
 dependencies {
-    compile project(':data-prepper-api')
-    testCompile project(':data-prepper-api').sourceSets.test.output
+    implementation project(':data-prepper-api')
+    testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
     implementation "com.linecorp.armeria:armeria:1.8.0"
     implementation "com.linecorp.armeria:armeria-grpc:1.8.0"

--- a/data-prepper-plugins/service-map-stateful/build.gradle
+++ b/data-prepper-plugins/service-map-stateful/build.gradle
@@ -12,10 +12,10 @@ repositories {
 }
 
 dependencies {
-    compile project(':data-prepper-api')
-    compile project(':data-prepper-plugins:common')
-    compile project(':data-prepper-plugins:mapdb-prepper-state')
-    testCompile project(':data-prepper-api').sourceSets.test.output
+    implementation project(':data-prepper-api')
+    implementation project(':data-prepper-plugins:common')
+    implementation project(':data-prepper-plugins:mapdb-prepper-state')
+    testImplementation project(':data-prepper-api').sourceSets.test.output
     implementation "io.micrometer:micrometer-core:1.7.0"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.3"
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"

--- a/examples/trace-analytics-sample-app/sample-app/analytics-service/build.gradle
+++ b/examples/trace-analytics-sample-app/sample-app/analytics-service/build.gradle
@@ -16,9 +16,9 @@ repositories {
 dependencies {
     implementation('org.springframework.boot:spring-boot-starter-web')
     testImplementation('org.springframework.boot:spring-boot-starter-test')
-    compile 'org.elasticsearch.client:elasticsearch-rest-high-level-client:7.8.1'
-    compile 'org.elasticsearch.client:elasticsearch-rest-client:7.8.1'
-    compile 'org.elasticsearch:elasticsearch:7.8.1'
+    implementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client:7.8.1'
+    implementation 'org.elasticsearch.client:elasticsearch-rest-client:7.8.1'
+    implementation 'org.elasticsearch:elasticsearch:7.8.1'
 }
 
 bootJar {

--- a/release/archives/build.gradle
+++ b/release/archives/build.gradle
@@ -86,7 +86,7 @@ subprojects {
     tasks.withType(Tar) {
         dependsOn ':release:releasePrerequisites'
         compression = Compression.GZIP
-        extension = 'tar.gz'
+        archiveExtension = 'tar.gz'
     }
 
     tasks.withType(Zip) {

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -2,7 +2,7 @@ apply from: file("build-resources.gradle")
 
 allprojects {
     dependencies {
-        compile project(':data-prepper-core')
+        implementation project(':data-prepper-core')
     }
 }
 

--- a/research/zipkin-elastic-to-otel/build.gradle
+++ b/research/zipkin-elastic-to-otel/build.gradle
@@ -27,9 +27,10 @@ run {
 }
 
 dependencies {
-    compile project(':data-prepper-plugins:elasticsearch')
-    compile project(':data-prepper-plugins:otel-trace-source')
-    compile project(':data-prepper-plugins:otel-trace-raw-prepper')
+    implementation project(':data-prepper-plugins:blocking-buffer')
+    implementation project(':data-prepper-plugins:elasticsearch')
+    implementation project(':data-prepper-plugins:otel-trace-source')
+    implementation project(':data-prepper-plugins:otel-trace-raw-prepper')
     implementation "org.apache.commons:commons-lang3:3.11"
     implementation "com.linecorp.armeria:armeria:1.0.0"
     implementation "com.linecorp.armeria:armeria-grpc:1.0.0"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

I fixed some Gradle deprecation warnings. I also noticed that some projects are intended to be libraries, though they were not building that way. I change a few of them to get their transitive dependencies working with `api` dependencies.

I don't think we will be able to support Gradle 7 and JDK 16 yet because of dependencies on OpenSearch/ElasticSearch. Regardless, I hope these changes get us ready for such an update.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
