### PR TITLE
Fixes #666 by including AWS STS library required for IRSA in EKS

### DIFF
--- a/data-prepper-plugins/elasticsearch/build.gradle
+++ b/data-prepper-plugins/elasticsearch/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.3"
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     implementation "com.amazonaws:aws-java-sdk-core:1.11.1024"
+    implementation "com.amazonaws:aws-java-sdk-sts:1.11.1024"
     implementation "com.github.awslabs:aws-request-signing-apache-interceptor:b3772780da"
     implementation "io.micrometer:micrometer-core:1.7.0"
     testImplementation("junit:junit:4.13.2") {


### PR DESCRIPTION
Issue #666 

As described in the issue, the AWS STS library is required at runtime to support IRSA.  If the maintainers are happy to package the dependency with data-prepper, this could ease adoption as I had to debug the app to understand why this wasn't working.

I've matched the version of the AWS STS library to the AWS Core library included in this plugin.   (Elsewhere in this project I see v2 of the AWS SDK used)

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
