### PR TITLE
Refactor of ServiceMapStatefulPrepper, moved MapDbPrepperState from f…

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/prepper/state/PrepperState.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/prepper/state/PrepperState.java
@@ -57,7 +57,13 @@ public interface PrepperState<K, V> {
     /**
      * @return Size of the prepper state data stored in file, in bytes.
      */
+    // TODO: Potentially remove, this is file-specific
     public long sizeInBytes();
+
+    /**
+     * Clear internal state
+     */
+    void clear();
 
     /**
      * Any cleanup code goes here

--- a/data-prepper-plugins/mapdb-prepper-state/src/main/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperState.java
+++ b/data-prepper-plugins/mapdb-prepper-state/src/main/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperState.java
@@ -1,18 +1,20 @@
 package com.amazon.dataprepper.plugins.prepper.state;
 
-import com.google.common.primitives.SignedBytes;
 import com.amazon.dataprepper.prepper.state.PrepperState;
-import java.io.File;
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.function.BiFunction;
+import com.google.common.primitives.SignedBytes;
 import org.mapdb.BTreeMap;
 import org.mapdb.DBMaker;
 import org.mapdb.Serializer;
 import org.mapdb.serializer.SerializerByteArray;
+
+import java.io.File;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
 
 public class MapDbPrepperState<V> implements PrepperState<byte[], V> {
 
@@ -30,14 +32,11 @@ public class MapDbPrepperState<V> implements PrepperState<byte[], V> {
     private final File dbFile;
 
     public MapDbPrepperState(final File dbPath, final String dbName, final int concurrencyScale) {
+        // TODO: Cleanup references to file-based map
         this.dbFile = new File(String.join("/", dbPath.getPath(), dbName));
         map =
-                (BTreeMap<byte[], V>) DBMaker.fileDB(dbFile)
-                        .fileDeleteAfterClose()
-                        .fileMmapEnable() //MapDB uses the (slower) Random Access Files by default
-                        .fileMmapPreclearDisable()
+                (BTreeMap<byte[], V>) DBMaker.heapDB()
                         .executorEnable()
-                        .transactionEnable()
                         .closeOnJvmShutdown()
                         .concurrencyScale(concurrencyScale)
                         .make()
@@ -87,12 +86,18 @@ public class MapDbPrepperState<V> implements PrepperState<byte[], V> {
         return returnList;
     }
 
+    public Iterator<Map.Entry<byte[], V>> getIterator(final int segments, final int index) {
+        final KeyRange iterationEndpoints = getIterationEndpoints(segments, index);
+        return map.entryIterator(iterationEndpoints.low, true, iterationEndpoints.high, false);
+    }
+
     /**
      * Gets iteration endpoints by taking the lowest and highest key and splitting the keyrange into segments.
      * These endpoints are an approximation of segments, and segments are guaranteed to cover the entire key range,
      * but there is no guarantee that all segments contain an equal number of elements.
+     *
      * @param segments Number of segments
-     * @param index Index to find segment endpoints for
+     * @param index    Index to find segment endpoints for
      * @return KeyRange containing the two endpoints
      */
     private KeyRange getIterationEndpoints(final int segments, final int index) {
@@ -103,7 +108,7 @@ public class MapDbPrepperState<V> implements PrepperState<byte[], V> {
         final byte[] highIndex =
                 index == segments - 1 ?
                         highEnd.add(new BigInteger("1")).toByteArray() :
-                        lowEnd.add(step.multiply(new BigInteger(String.valueOf(index+1)))).toByteArray();
+                        lowEnd.add(step.multiply(new BigInteger(String.valueOf(index + 1)))).toByteArray();
         return new KeyRange(lowIndex, highIndex);
     }
 
@@ -116,6 +121,11 @@ public class MapDbPrepperState<V> implements PrepperState<byte[], V> {
     @Override
     public long sizeInBytes() {
         return dbFile.length();
+    }
+
+    @Override
+    public void clear() {
+        map.clear();
     }
 
     @Override

--- a/data-prepper-plugins/mapdb-prepper-state/src/test/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperStateTest.java
+++ b/data-prepper-plugins/mapdb-prepper-state/src/test/java/com/amazon/dataprepper/plugins/prepper/state/MapDbPrepperStateTest.java
@@ -1,14 +1,15 @@
 package com.amazon.dataprepper.plugins.prepper.state;
 
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.BiFunction;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 public class MapDbPrepperStateTest extends PrepperStateTest {
 
@@ -22,9 +23,9 @@ public class MapDbPrepperStateTest extends PrepperStateTest {
 
     @Test
     public void testIterateSegment() throws IOException {
-        final byte[] key1  = new byte[]{-64, 0, -64, 0};
+        final byte[] key1 = new byte[]{-64, 0, -64, 0};
         final byte[] key2 = new byte[]{0};
-        final byte[] key3 = new byte[]{64, 64, 64 , 64};
+        final byte[] key3 = new byte[]{64, 64, 64, 64};
         final byte[] key4 = new byte[]{126, 126, 126, 126};
 
         final DataClass data1 = new DataClass(UUID.randomUUID().toString(), random.nextInt());
@@ -61,8 +62,6 @@ public class MapDbPrepperStateTest extends PrepperStateTest {
                 data3.stringVal,
                 data4.stringVal
         )));
-
-        Assert.assertEquals( 1048576, prepperState.sizeInBytes());
     }
 
 }

--- a/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
+++ b/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java
@@ -7,8 +7,8 @@ import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.prepper.AbstractPrepper;
 import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.prepper.state.MapDbPrepperState;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
 import com.google.common.primitives.SignedBytes;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import org.slf4j.Logger;
@@ -21,13 +21,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiFunction;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @SingleThread
 @DataPrepperPlugin(name = "service_map_stateful", type = PluginType.PREPPER)
@@ -46,17 +44,16 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
     private static final AtomicInteger preppersCreated = new AtomicInteger(0);
     private static long previousTimestamp;
     private static long windowDurationMillis;
-    private static CountDownLatch edgeEvaluationLatch;
-    private static CountDownLatch windowRotationLatch = new CountDownLatch(1);
+    private static CyclicBarrier allThreadsCyclicBarrier;
+
     private volatile static MapDbPrepperState<ServiceMapStateData> previousWindow;
     private volatile static MapDbPrepperState<ServiceMapStateData> currentWindow;
     private volatile static MapDbPrepperState<String> previousTraceGroupWindow;
     private volatile static MapDbPrepperState<String> currentTraceGroupWindow;
     //TODO: Consider keeping this state in a db
-    private volatile static HashSet<ServiceMapRelationship> relationshipState = new HashSet<>();
+    private static final Set<ServiceMapRelationship> RELATIONSHIP_STATE = Sets.newConcurrentHashSet();
     private static File dbPath;
     private static Clock clock;
-    private static int processWorkers;
 
     private final int thisPrepperId;
 
@@ -77,15 +74,18 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
 
         ServiceMapStatefulPrepper.clock = clock;
         this.thisPrepperId = preppersCreated.getAndIncrement();
+
         if (isMasterInstance()) {
             previousTimestamp = ServiceMapStatefulPrepper.clock.millis();
             ServiceMapStatefulPrepper.windowDurationMillis = windowDurationMillis;
             ServiceMapStatefulPrepper.dbPath = createPath(databasePath);
-            ServiceMapStatefulPrepper.processWorkers = processWorkers;
+
             currentWindow = new MapDbPrepperState<>(dbPath, getNewDbName(), processWorkers);
             previousWindow = new MapDbPrepperState<>(dbPath, getNewDbName() + EMPTY_SUFFIX, processWorkers);
             currentTraceGroupWindow = new MapDbPrepperState<>(dbPath, getNewTraceDbName(), processWorkers);
             previousTraceGroupWindow = new MapDbPrepperState<>(dbPath, getNewTraceDbName() + EMPTY_SUFFIX, processWorkers);
+
+            allThreadsCyclicBarrier = new CyclicBarrier(processWorkers);
         }
 
         pluginMetrics.gauge(SPANS_DB_SIZE, this, serviceMapStateful -> serviceMapStateful.getSpansDbSize());
@@ -165,88 +165,81 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
      * @return Set of Record<String> containing json representation of ServiceMapRelationships found
      */
     private Collection<Record<String>> evaluateEdges() {
+        LOG.info("Evaluating service map edges");
         try {
-            final Stream<ServiceMapRelationship> previousStream = previousWindow.iterate(relationshipIterationFunction, preppersCreated.get(), thisPrepperId).stream().flatMap(serviceMapEdgeStream -> serviceMapEdgeStream);
-            final Stream<ServiceMapRelationship> currentStream = currentWindow.iterate(relationshipIterationFunction, preppersCreated.get(), thisPrepperId).stream().flatMap(serviceMapEdgeStream -> serviceMapEdgeStream);
+            final Collection<Record<String>> serviceDependencyRecords = new HashSet<>();
 
-            final Collection<Record<String>> serviceDependencyRecords =
-                    Stream.concat(previousStream, currentStream).filter(Objects::nonNull)
-                            .filter(serviceMapRelationship -> !relationshipState.contains(serviceMapRelationship))
-                            .map(serviceMapRelationship -> {
-                                try {
-                                    relationshipState.add(serviceMapRelationship);
-                                    return new Record<>(OBJECT_MAPPER.writeValueAsString(serviceMapRelationship));
-                                } catch (JsonProcessingException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            })
-                            .collect(Collectors.toSet());
+            serviceDependencyRecords.addAll(iteratePrepperState(previousWindow));
+            serviceDependencyRecords.addAll(iteratePrepperState(currentWindow));
+            LOG.info("Done evaluating service map edges");
 
-            if (edgeEvaluationLatch == null) {
-                initEdgeEvaluationLatch();
-            }
-            doneEvaluatingEdges();
-            waitForEvaluationFinish();
+            // Wait for all workers before rotating windows
+            allThreadsCyclicBarrier.await();
 
             if (isMasterInstance()) {
                 rotateWindows();
-                resetWorkState();
-            } else {
-                waitForRotationFinish();
             }
 
+            // Wait for all workers before exiting this method
+            allThreadsCyclicBarrier.await();
+
             return serviceDependencyRecords;
-        } catch (InterruptedException e) {
+        } catch (InterruptedException | BrokenBarrierException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private static synchronized void initEdgeEvaluationLatch() {
-        if (edgeEvaluationLatch == null) {
-            edgeEvaluationLatch = new CountDownLatch(preppersCreated.get());
-        }
-    }
+    private Collection<Record<String>> iteratePrepperState(final MapDbPrepperState<ServiceMapStateData> prepperState) {
+        final Collection<Record<String>> serviceDependencyRecords = new HashSet<>();
 
-    /**
-     * This function is used to iterate over the current window and find parent/child relationships in the current and
-     * previous windows.
-     */
-    private final BiFunction<byte[], ServiceMapStateData, Stream<ServiceMapRelationship>> relationshipIterationFunction = new BiFunction<byte[], ServiceMapStateData, Stream<ServiceMapRelationship>>() {
-        @Override
-        public Stream<ServiceMapRelationship> apply(byte[] s, ServiceMapStateData serviceMapStateData) {
-            return lookupParentSpan(serviceMapStateData, true);
-        }
-    };
+        if (prepperState.getAll() != null && !prepperState.getAll().isEmpty()) {
+            prepperState.getIterator(preppersCreated.get(), thisPrepperId).forEachRemaining(entry -> {
+                final ServiceMapStateData child = entry.getValue();
 
-    private Stream<ServiceMapRelationship> lookupParentSpan(final ServiceMapStateData serviceMapStateData, final boolean checkPrev) {
-        if (serviceMapStateData.parentSpanId != null) {
-            final ServiceMapStateData parentStateData = getParentStateData(serviceMapStateData.parentSpanId, checkPrev);
-            final String traceGroupName = getTraceGroupName(serviceMapStateData.traceId);
-            if (traceGroupName != null && parentStateData != null && !parentStateData.serviceName.equals(serviceMapStateData.serviceName)) {
-                return Stream.of(
-                        ServiceMapRelationship.newDestinationRelationship(parentStateData.serviceName, parentStateData.spanKind, serviceMapStateData.serviceName, serviceMapStateData.name, traceGroupName),
-                        //This extra edge is added for compatibility of the index for both stateless and stateful preppers
-                        ServiceMapRelationship.newTargetRelationship(serviceMapStateData.serviceName, serviceMapStateData.spanKind, serviceMapStateData.serviceName, serviceMapStateData.name, traceGroupName)
-                );
-            }
-        }
-        return Stream.empty();
-    }
+                if (child.parentSpanId == null) {
+                    return;
+                }
 
-    /**
-     * Checks both current and previous windows for the given parent span id
-     *
-     * @param spanId
-     * @return ServiceMapStateData for the parent span, if exists. Otherwise null
-     */
-    private ServiceMapStateData getParentStateData(final byte[] spanId, final boolean checkPrev) {
-        try {
-            final ServiceMapStateData serviceMapStateData = currentWindow.get(spanId);
-            return serviceMapStateData != null ? serviceMapStateData : checkPrev ? previousWindow.get(spanId) : null;
-        } catch (RuntimeException e) {
-            LOG.error("Caught exception trying to get parent state data", e);
-            return null;
+                ServiceMapStateData parent = currentWindow.get(child.parentSpanId);
+                if (parent == null) {
+                    parent = previousWindow.get(child.parentSpanId);
+                }
+
+
+                final String traceGroupName = getTraceGroupName(child.traceId);
+                if (traceGroupName == null || parent == null || parent.serviceName.equals(child.serviceName)) {
+                    return;
+                }
+
+                final ServiceMapRelationship destinationRelationship =
+                        ServiceMapRelationship.newDestinationRelationship(parent.serviceName,
+                                parent.spanKind, child.serviceName, child.name, traceGroupName);
+                final ServiceMapRelationship targetRelationship = ServiceMapRelationship.newTargetRelationship(child.serviceName,
+                        child.spanKind, child.serviceName, child.name, traceGroupName);
+
+
+                // check if relationshipState has it
+                if (!RELATIONSHIP_STATE.contains(destinationRelationship)) {
+                    try {
+                        serviceDependencyRecords.add(new Record<>(OBJECT_MAPPER.writeValueAsString(destinationRelationship)));
+                        RELATIONSHIP_STATE.add(destinationRelationship);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                if (!RELATIONSHIP_STATE.contains(targetRelationship)) {
+                    try {
+                        serviceDependencyRecords.add(new Record<>(OBJECT_MAPPER.writeValueAsString(targetRelationship)));
+                        RELATIONSHIP_STATE.add(targetRelationship);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
         }
+
+        return serviceDependencyRecords;
     }
 
     /**
@@ -287,63 +280,29 @@ public class ServiceMapStatefulPrepper extends AbstractPrepper<Record<ExportTrac
     // TODO: Temp code, complex instance creation logic should be moved to a separate class
     static void resetStaticCounters() {
         preppersCreated.set(0);
-        edgeEvaluationLatch = null;
     }
 
-    /**
-     * Indicate/notify that this instance has finished evaluating edges
-     */
-    private void doneEvaluatingEdges() {
-        edgeEvaluationLatch.countDown();
-    }
-
-    /**
-     * Wait on all instances to finish evaluating edges
-     *
-     * @throws InterruptedException
-     */
-    private void waitForEvaluationFinish() throws InterruptedException {
-        edgeEvaluationLatch.await();
-    }
-
-    /**
-     * Indicate that window rotation is complete
-     */
-    private void doneRotatingWindows() {
-        windowRotationLatch.countDown();
-    }
-
-    /**
-     * Wait on window rotation to complete
-     *
-     * @throws InterruptedException
-     */
-    private void waitForRotationFinish() throws InterruptedException {
-        windowRotationLatch.await();
-    }
-
-    /**
-     * Reset state that indicates whether edge evaluation and window rotation is complete
-     */
-    private void resetWorkState() {
-        windowRotationLatch = new CountDownLatch(1);
-        edgeEvaluationLatch = new CountDownLatch(preppersCreated.get());
-    }
 
     /**
      * Rotate windows for prepper state
      */
-    private void rotateWindows() {
-        LOG.debug("Rotating windows at " + clock.instant().toString());
-        previousWindow.delete();
-        previousTraceGroupWindow.delete();
+    private void rotateWindows() throws InterruptedException {
+        LOG.info("Rotating service map windows at " + clock.instant().toString());
+
+        MapDbPrepperState tempWindow = previousWindow;
         previousWindow = currentWindow;
-        currentWindow = new MapDbPrepperState<>(dbPath, getNewDbName(), processWorkers);
+        currentWindow = tempWindow;
+        currentWindow.clear();
+
+        tempWindow = previousTraceGroupWindow;
         previousTraceGroupWindow = currentTraceGroupWindow;
-        currentTraceGroupWindow = new MapDbPrepperState<>(dbPath, getNewTraceDbName(), processWorkers);
+        currentTraceGroupWindow = tempWindow;
+        currentTraceGroupWindow.clear();
+
         previousTimestamp = clock.millis();
-        doneRotatingWindows();
+        LOG.info("Done rotating service map windows");
     }
+
 
     /**
      * @return Spans database size in bytes

--- a/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepperTest.java
+++ b/data-prepper-plugins/service-map-stateful/src/test/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepperTest.java
@@ -92,8 +92,8 @@ public class ServiceMapStatefulPrepperTest {
         Mockito.when(clock.instant()).thenReturn(Instant.now());
         ExecutorService threadpool = Executors.newCachedThreadPool();
         final File path = new File(ServiceMapPrepperConfig.DEFAULT_DB_PATH);
-        final ServiceMapStatefulPrepper serviceMapStateful1 = new ServiceMapStatefulPrepper(100, path, clock, 16, PLUGIN_SETTING);
-        final ServiceMapStatefulPrepper serviceMapStateful2 = new ServiceMapStatefulPrepper(100, path, clock, 16, PLUGIN_SETTING);
+        final ServiceMapStatefulPrepper serviceMapStateful1 = new ServiceMapStatefulPrepper(100, path, clock, 2, PLUGIN_SETTING);
+        final ServiceMapStatefulPrepper serviceMapStateful2 = new ServiceMapStatefulPrepper(100, path, clock, 2, PLUGIN_SETTING);
 
         final byte[] rootSpanId1 = ServiceMapTestUtils.getRandomBytes(8);
         final byte[] rootSpanId2 = ServiceMapTestUtils.getRandomBytes(8);
@@ -194,13 +194,11 @@ public class ServiceMapStatefulPrepperTest {
                 new StringJoiner(MetricNames.DELIMITER).add("testPipelineName").add("testServiceMapPrepper")
                         .add(ServiceMapStatefulPrepper.SPANS_DB_SIZE).toString());
         Assert.assertEquals(1, spansDbSizeMeasurement.size());
-        Assert.assertEquals(2097152, spansDbSizeMeasurement.get(0).getValue(), 0);
 
         final List<Measurement> traceGroupDbSizeMeasurement = MetricsTestUtil.getMeasurementList(
                 new StringJoiner(MetricNames.DELIMITER).add("testPipelineName").add("testServiceMapPrepper")
                         .add(ServiceMapStatefulPrepper.TRACE_GROUP_DB_SIZE).toString());
         Assert.assertEquals(1, traceGroupDbSizeMeasurement.size());
-        Assert.assertEquals(2097152, traceGroupDbSizeMeasurement.get(0).getValue(), 0);
 
 
         //Make sure that future relationships that are equivalent are caught by cache


### PR DESCRIPTION
…ile to heap.

Signed-off-by: Jeff Wright <74204404+wrijeff@users.noreply.github.com>

*Issue #, if available:*

*Description of changes:*
While attempting to benchmark a Data Prepper instance configured for only the service-map usecase, I found that it could not handle more than ~5 minutes of sustained load before locking up and eventually running out of memory. This PR introduce 3 fixes which enable the service-map prepper to run for at least an hour without any performance degradation.

#### Heap-based MapDB
Primary change here is moving from a file-based MapDB to heap-based. Basic benchmarks comparing file vs heap-based showed that file-based was an order of magnitude slower when inserting items. Simply switching from file to heap showed the biggest gain and allowed the instance to survive more than 5 minutes.

#### CyclicBarriers
Being able to run the test for longer revealed a race condition involving the current implementation's countdown latches ([code link](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java#L189-L196)). We expect for "non-master" threads to reach the `waitForRotationFinish();` before the master thread finishes `rotateWindows();` and calls `resetWorkState();`, however this isn't guaranteed. The race condition happens when the master thread resets the windowRotationLatch before other threads have a chance to await it. This results in a thread getting stuck forever. This change swaps out countdown latches for cyclic barriers to cut down on some of the synchronization complexity.

#### Re-use of window maps
It was observed that "old gen" heap space was ever growing, up to a point where garbage collection would kick in. This was caused by creating new `MapDbPrepperState` maps being created on window rotation ([code link](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/data-prepper-plugins/service-map-stateful/src/main/java/com/amazon/dataprepper/plugins/prepper/ServiceMapStatefulPrepper.java#L340-L343)). As the windows are long-lived objects, they survive past the eden heap space and exist in old gen. Eventually they would accumulate to the point where a full GC was needed. This can be avoided by re-using long-lived objects instead of creating new ones.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
