### PR TITLE
Metric dimension

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
@@ -4,7 +4,7 @@ public class MetricNames {
     private MetricNames() {}
 
     /**
-     * Metric dimension represents the dimension to drill-down on.
+     * Metric dimension representing service name.
      * Applicable to all components
      */
     public static final String SERVICE_NAME = "serviceName";

--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/metrics/MetricNames.java
@@ -2,6 +2,13 @@ package com.amazon.dataprepper.metrics;
 
 public class MetricNames {
     private MetricNames() {}
+
+    /**
+     * Metric dimension represents the dimension to drill-down on.
+     * Applicable to all components
+     */
+    public static final String SERVICE_NAME = "serviceName";
+
     /**
      * Metric representing the ingress of records to a pipeline component.
      * Applicable to preppers and sinks

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
@@ -63,7 +63,7 @@ public class DataPrepper {
      */
     public static String getServiceNameForMetrics() {
         final String serviceName = System.getenv(DATAPREPPER_SERVICE_NAME);
-        return (serviceName != null && !"".equals(serviceName)) ? serviceName : DEFAULT_SERVICE_NAME;
+        return (serviceName != null && !serviceName.trim().isEmpty()) ? serviceName : DEFAULT_SERVICE_NAME;
     }
 
     public static DataPrepper getInstance() {

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
@@ -27,6 +27,8 @@ import java.util.Map;
  */
 public class DataPrepper {
     private static final Logger LOG = LoggerFactory.getLogger(DataPrepper.class);
+    private static final String DATAPREPPER_SERVICE_NAME = "DATAPREPPER_SERVICE_NAME";
+    private static final String DEFAULT_SERVICE_NAME = "dataprepper";
 
     private static final CompositeMeterRegistry systemMeterRegistry = new CompositeMeterRegistry();
 
@@ -53,6 +55,15 @@ public class DataPrepper {
     public static void configureWithDefaults() {
         configuration = DataPrepperConfiguration.DEFAULT_CONFIG;
         configureMeterRegistry();
+    }
+
+    /**
+     * returns serviceName if exists or default serviceName
+     * @return serviceName for data-prepper
+     */
+    public static String getServiceNameForMetrics() {
+        final String serviceName = System.getenv(DATAPREPPER_SERVICE_NAME);
+        return (serviceName != null && !"".equals(serviceName)) ? serviceName : DEFAULT_SERVICE_NAME;
     }
 
     public static DataPrepper getInstance() {

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/DataPrepper.java
@@ -12,6 +12,7 @@ import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +64,7 @@ public class DataPrepper {
      */
     public static String getServiceNameForMetrics() {
         final String serviceName = System.getenv(DATAPREPPER_SERVICE_NAME);
-        return (serviceName != null && !serviceName.trim().isEmpty()) ? serviceName : DEFAULT_SERVICE_NAME;
+        return StringUtils.isNotBlank(serviceName) ? serviceName : DEFAULT_SERVICE_NAME;
     }
 
     public static DataPrepper getInstance() {

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/MetricRegistryType.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/parser/model/MetricRegistryType.java
@@ -2,9 +2,14 @@ package com.amazon.dataprepper.parser.model;
 
 import com.amazon.dataprepper.pipeline.server.CloudWatchMeterRegistryProvider;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 
+import java.util.Arrays;
+
+import static com.amazon.dataprepper.DataPrepper.getServiceNameForMetrics;
+import static com.amazon.dataprepper.metrics.MetricNames.SERVICE_NAME;
 import static java.lang.String.format;
 
 public enum MetricRegistryType {
@@ -12,14 +17,18 @@ public enum MetricRegistryType {
     CloudWatch;
 
     public static MeterRegistry getDefaultMeterRegistryForType(final MetricRegistryType metricRegistryType) {
+        MeterRegistry meterRegistry = null;
         switch (metricRegistryType) {
             case Prometheus:
-                return new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+                meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+                break;
             case CloudWatch:
-                return new CloudWatchMeterRegistryProvider().getCloudWatchMeterRegistry();
+                meterRegistry = new CloudWatchMeterRegistryProvider().getCloudWatchMeterRegistry();
+                break;
             default:
                 throw new IllegalArgumentException(format("Invalid metricRegistryType %s", metricRegistryType));
-
         }
+        meterRegistry.config().commonTags(Arrays.asList(Tag.of(SERVICE_NAME, getServiceNameForMetrics())));
+        return meterRegistry;
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Adds dimension to MeterRegistry - this way the metrics will have a default dimension to drill into.
* Enables to use environment variable `DATAPREPPER_SERVICE_NAME` if we execute datapreppers in containerized frameworks

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
