### PR TITLE
Refactor of OTelTraceRawPrepper to improve performance.

### DIFF
--- a/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
+++ b/data-prepper-api/src/main/java/com/amazon/dataprepper/model/buffer/AbstractBuffer.java
@@ -1,17 +1,18 @@
 package com.amazon.dataprepper.model.buffer;
 
-import com.amazon.dataprepper.model.CheckpointState;
-import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.metrics.MetricNames;
 import com.amazon.dataprepper.metrics.PluginMetrics;
+import com.amazon.dataprepper.model.CheckpointState;
+import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
-import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicLong;
-
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Abstract implementation of the Buffer interface to record boilerplate metrics
@@ -50,41 +51,37 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
     /**
      * Records metrics for ingress, time elapsed, and timeouts, while calling the doWrite method
      * to perform the actual write
-     * @param record the Record to add
+     *
+     * @param record          the Record to add
      * @param timeoutInMillis how long to wait before giving up
      * @throws TimeoutException
      */
     @Override
     public void write(T record, int timeoutInMillis) throws TimeoutException {
+        long startTime = System.nanoTime();
+
         try {
-            writeTimer.record(() -> {
-                try {
-                    doWrite(record, timeoutInMillis);
-                } catch (TimeoutException e) {
-                    writeTimeoutCounter.increment();
-                    throw new RuntimeException(e);
-                }
-            });
+            doWrite(record, timeoutInMillis);
             recordsWrittenCounter.increment();
-        } catch (RuntimeException e) {
-            if(e.getCause() instanceof TimeoutException) {
-                throw (TimeoutException) e.getCause();
-            } else  {
-                throw e;
-            }
+        } catch (TimeoutException e) {
+            writeTimeoutCounter.increment();
+            throw e;
+        } finally {
+            writeTimer.record(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
         }
     }
 
     /**
      * Records egress and time elapsed metrics, while calling the doRead function to
      * do the actual read
+     *
      * @param timeoutInMillis how long to wait before giving up
      * @return Records collection and checkpoint state read from the buffer
      */
     @Override
     public Map.Entry<Collection<T>, CheckpointState> read(int timeoutInMillis) {
         final Map.Entry<Collection<T>, CheckpointState> readResult = readTimer.record(() -> doRead(timeoutInMillis));
-        recordsReadCounter.increment(readResult.getKey().size()*1.0);
+        recordsReadCounter.increment(readResult.getKey().size() * 1.0);
         recordsInFlight.addAndGet(readResult.getValue().getNumRecordsToBeChecked());
         return readResult;
     }
@@ -103,7 +100,8 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
 
     /**
      * This method should implement the logic for writing to the  buffer
-     * @param record Record to write to buffer
+     *
+     * @param record          Record to write to buffer
      * @param timeoutInMillis Timeout for write operation in millis
      * @throws TimeoutException
      */
@@ -111,6 +109,7 @@ public abstract class AbstractBuffer<T extends Record<?>> implements Buffer<T> {
 
     /**
      * This method should implement the logic for reading from the buffer
+     *
      * @param timeoutInMillis Timeout in millis
      * @return Records collection and checkpoint state read from the buffer
      */

--- a/data-prepper-core/src/integrationTest/resources/raw-span-e2e-pipeline-latest-release.yml
+++ b/data-prepper-core/src/integrationTest/resources/raw-span-e2e-pipeline-latest-release.yml
@@ -16,6 +16,7 @@ raw-pipeline:
       name: "entry-pipeline"
   prepper:
     - otel_trace_raw_prepper:
+        root_span_flush_delay: 3 # TODO: remove after 1.1 release
         trace_flush_interval: 5
   sink:
     - elasticsearch:

--- a/data-prepper-core/src/integrationTest/resources/raw-span-e2e-pipeline-latest-release.yml
+++ b/data-prepper-core/src/integrationTest/resources/raw-span-e2e-pipeline-latest-release.yml
@@ -16,7 +16,6 @@ raw-pipeline:
       name: "entry-pipeline"
   prepper:
     - otel_trace_raw_prepper:
-        root_span_flush_delay: 3
         trace_flush_interval: 5
   sink:
     - elasticsearch:

--- a/data-prepper-core/src/integrationTest/resources/raw-span-e2e-pipeline.yml
+++ b/data-prepper-core/src/integrationTest/resources/raw-span-e2e-pipeline.yml
@@ -11,7 +11,6 @@ raw-pipeline:
       name: "entry-pipeline"
   prepper:
     - otel_trace_raw_prepper:
-        root_span_flush_delay: 1
         trace_flush_interval: 5
     - otel_trace_group_prepper:
         hosts: [ "https://node-0.example.com:9200" ]

--- a/data-prepper-core/src/integrationTest/resources/raw-span-e2e-pipeline.yml
+++ b/data-prepper-core/src/integrationTest/resources/raw-span-e2e-pipeline.yml
@@ -11,6 +11,7 @@ raw-pipeline:
       name: "entry-pipeline"
   prepper:
     - otel_trace_raw_prepper:
+        root_span_flush_delay: 1 # TODO: remove after 1.1 release
         trace_flush_interval: 5
     - otel_trace_group_prepper:
         hosts: [ "https://node-0.example.com:9200" ]

--- a/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/Pipeline.java
+++ b/data-prepper-core/src/main/java/com/amazon/dataprepper/pipeline/Pipeline.java
@@ -79,7 +79,8 @@ public class Pipeline {
         this.prepperExecutorService = PipelineThreadPoolExecutor.newFixedThreadPool(prepperThreads,
                 new PipelineThreadFactory(format("%s-prepper-worker", name)), this);
 
-        this.sinkExecutorService = PipelineThreadPoolExecutor.newFixedThreadPool(sinks.size(),
+        // TODO: allow this to be configurable as well?
+        this.sinkExecutorService = PipelineThreadPoolExecutor.newFixedThreadPool(prepperThreads,
                 new PipelineThreadFactory(format("%s-sink-worker", name)), this);
 
         stopRequested = false;

--- a/data-prepper-plugins/otel-trace-raw-prepper/README.md
+++ b/data-prepper-plugins/otel-trace-raw-prepper/README.md
@@ -11,7 +11,6 @@ prepper:
 
 ## Configuration
 
-* `root_span_flush_delay`: An `int` represents the time interval in seconds to flush all the root spans in the prepper together with their descendants. Default to 30.
 * `trace_flush_interval`: An `int` represents the time interval in seconds to flush all the descendant spans without any root span. Default to 180.
 
 ## Metrics

--- a/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OTelTraceRawPrepper.java
+++ b/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OTelTraceRawPrepper.java
@@ -11,12 +11,10 @@ import com.amazon.dataprepper.plugins.prepper.oteltrace.model.RawSpanBuilder;
 import com.amazon.dataprepper.plugins.prepper.oteltrace.model.RawSpanSet;
 import com.amazon.dataprepper.plugins.prepper.oteltrace.model.TraceGroup;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Ints;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.util.StringUtils;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
@@ -29,18 +27,15 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.DelayQueue;
-import java.util.concurrent.Delayed;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
 
 @DataPrepperPlugin(name = "otel_trace_raw_prepper", type = PluginType.PREPPER)
 public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServiceRequest>, Record<String>> {
-
     private static final long SEC_TO_MILLIS = 1_000L;
     private static final Logger LOG = LoggerFactory.getLogger(OTelTraceRawPrepper.class);
 
@@ -49,17 +44,11 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServi
     public static final String TOTAL_PROCESSING_ERRORS = "totalProcessingErrors";
 
     private final long traceFlushInterval;
-    private final long rootSpanFlushDelay;
 
     private final Counter spanErrorsCounter;
     private final Counter resourceSpanErrorsCounter;
     private final Counter totalProcessingErrorsCounter;
 
-    // TODO: replace with file store, e.g. MapDB?
-    // TODO: introduce a gauge to monitor the size
-    private final Queue<DelayedParentSpan> delayedParentSpanQueue = new DelayQueue<>();
-    // TODO: replace with file store, e.g. MapDB?
-    // TODO: introduce a gauge to monitor the size
     private final Map<String, RawSpanSet> traceIdRawSpanSetMap = new ConcurrentHashMap<>();
 
     private final Cache<String, TraceGroup> traceIdTraceGroupCache;
@@ -69,15 +58,13 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServi
     private final ReentrantLock traceFlushLock = new ReentrantLock();
     private final ReentrantLock prepareForShutdownLock = new ReentrantLock();
 
+    private volatile boolean isShuttingDown = false;
+
     //TODO: https://github.com/opendistro-for-elasticsearch/simple-ingest-transformation-utility-pipeline/issues/66
     public OTelTraceRawPrepper(final PluginSetting pluginSetting) {
         super(pluginSetting);
         traceFlushInterval = SEC_TO_MILLIS * pluginSetting.getLongOrDefault(
                 OtelTraceRawPrepperConfig.TRACE_FLUSH_INTERVAL, OtelTraceRawPrepperConfig.DEFAULT_TG_FLUSH_INTERVAL_SEC);
-        rootSpanFlushDelay = SEC_TO_MILLIS * pluginSetting.getLongOrDefault(
-                OtelTraceRawPrepperConfig.ROOT_SPAN_FLUSH_DELAY, OtelTraceRawPrepperConfig.DEFAULT_ROOT_SPAN_FLUSH_DELAY_SEC);
-        Preconditions.checkArgument(rootSpanFlushDelay <= traceFlushInterval,
-                "rootSpanSetFlushDelay should not be greater than traceFlushInterval.");
         final int numProcessWorkers = pluginSetting.getNumberOfProcessWorkers();
         traceIdTraceGroupCache = CacheBuilder.newBuilder()
                 .concurrencyLevel(numProcessWorkers)
@@ -98,6 +85,8 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServi
      */
     @Override
     public Collection<Record<String>> doExecute(Collection<Record<ExportTraceServiceRequest>> records) {
+        final List<RawSpan> rawSpans = new LinkedList<>();
+
         for (Record<ExportTraceServiceRequest> ets : records) {
             for (ResourceSpans rs : ets.getData().getResourceSpansList()) {
                 try {
@@ -108,7 +97,8 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServi
                             final RawSpan rawSpan = new RawSpanBuilder()
                                     .setFromSpan(sp, is.getInstrumentationLibrary(), serviceName, resourceAttributes)
                                     .build();
-                            processRawSpan(rawSpan);
+
+                            processRawSpan(rawSpan, rawSpans);
                         }
                     }
                 } catch (Exception ex) {
@@ -119,39 +109,84 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServi
             }
         }
 
-        final List<RawSpan> rawSpans = new LinkedList<>();
-        rawSpans.addAll(getTracesToFlushByRootSpan());
         rawSpans.addAll(getTracesToFlushByGarbageCollection());
 
         return convertRawSpansToJsonRecords(rawSpans);
     }
 
-    private void processRawSpan(final RawSpan rawSpan) {
-        if (rawSpan.getParentSpanId() == null || "".equals(rawSpan.getParentSpanId())) {
-            processRootRawSpan(rawSpan);
+    /**
+     * Branching logic to handle root and child spans.
+     * A root span is the first span of a trace, it has no parentSpanId.
+     *
+     * @param rawSpan Span to be evaluated
+     * @param spanSet Collection to insert spans to
+     */
+    private void processRawSpan(final RawSpan rawSpan, final Collection<RawSpan> spanSet) {
+        if (StringUtils.isBlank(rawSpan.getParentSpanId())) {
+            final List<RawSpan> rootSpanAndChildren = processRootSpan(rawSpan);
+            spanSet.addAll(rootSpanAndChildren);
         } else {
-            processDescendantRawSpan(rawSpan);
+            final Optional<RawSpan> populatedChildSpanOptional = processChildSpan(rawSpan);
+            if (populatedChildSpanOptional.isPresent()) {
+                spanSet.add(populatedChildSpanOptional.get());
+            }
         }
     }
 
-    private void processRootRawSpan(final RawSpan rawSpan) {
-        // TODO: flush descendants here to get rid of DelayQueue
-        // TODO: safe-guard against null traceGroup for rootSpan?
-        traceIdTraceGroupCache.put(rawSpan.getTraceId(), rawSpan.getTraceGroup());
-        final long now = System.currentTimeMillis();
-        final long nowPlusOffset = now + rootSpanFlushDelay;
-        final DelayedParentSpan delayedParentSpan = new DelayedParentSpan(rawSpan, nowPlusOffset);
-        delayedParentSpanQueue.add(delayedParentSpan);
+    /**
+     * Retrieves all child spans from memory and returns them as a set with the root span.
+     * Also adds an entry to the traceID cache so that later child spans can be tagged,
+     * in the case where a child span is processed AFTER the root span.
+     *
+     * @param parentSpan
+     * @return List containing root span, along with any child spans that have already been processed.
+     */
+    private List<RawSpan> processRootSpan(final RawSpan parentSpan) {
+        traceIdTraceGroupCache.put(parentSpan.getTraceId(), parentSpan.getTraceGroup());
+
+        final List<RawSpan> recordsToFlush = new LinkedList<>();
+        recordsToFlush.add(parentSpan);
+
+        final TraceGroup traceGroup = parentSpan.getTraceGroup();
+        final String parentSpanTraceId = parentSpan.getTraceId();
+
+        final RawSpanSet rawSpanSet = traceIdRawSpanSetMap.get(parentSpanTraceId);
+        if (rawSpanSet != null) {
+            for (final RawSpan rawSpan : rawSpanSet.getRawSpans()) {
+                rawSpan.setTraceGroup(traceGroup);
+                recordsToFlush.add(rawSpan);
+            }
+
+            traceIdRawSpanSetMap.remove(parentSpanTraceId);
+        }
+
+        return recordsToFlush;
     }
 
-    private void processDescendantRawSpan(final RawSpan rawSpan) {
-        traceIdRawSpanSetMap.compute(rawSpan.getTraceId(), (traceId, rawSpanSet) -> {
-            if (rawSpanSet == null) {
-                rawSpanSet = new RawSpanSet();
-            }
-            rawSpanSet.addRawSpan(rawSpan);
-            return rawSpanSet;
-        });
+    /**
+     * Attempts to populate the traceGroup of the child span by fetching from a cache. If the traceGroup is not in the cache,
+     * the child span is kept in memory to be populated when its corresponding root span arrives.
+     *
+     * @param childSpan
+     * @return Optional containing childSpan if its traceGroup is in memory, otherwise an empty Optional
+     */
+    private Optional<RawSpan> processChildSpan(final RawSpan childSpan) {
+        final TraceGroup traceGroup = traceIdTraceGroupCache.getIfPresent(childSpan.getTraceId());
+
+        if (traceGroup != null) {
+            childSpan.setTraceGroup(traceGroup);
+            return Optional.of(childSpan);
+        } else {
+            traceIdRawSpanSetMap.compute(childSpan.getTraceId(), (traceId, rawSpanSet) -> {
+                if (rawSpanSet == null) {
+                    rawSpanSet = new RawSpanSet();
+                }
+                rawSpanSet.addRawSpan(childSpan);
+                return rawSpanSet;
+            });
+
+            return Optional.empty();
+        }
     }
 
     private List<Record<String>> convertRawSpansToJsonRecords(final List<RawSpan> rawSpans) {
@@ -174,51 +209,32 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServi
         return records;
     }
 
-    private List<RawSpan> getTracesToFlushByRootSpan() {
-        final List<RawSpan> recordsToFlush = new LinkedList<>();
-
-        for (DelayedParentSpan delayedParentSpan; (delayedParentSpan = delayedParentSpanQueue.poll()) != null;) {
-            RawSpan parentSpan = delayedParentSpan.getRawSpan();
-            recordsToFlush.add(parentSpan);
-
-            TraceGroup traceGroup = parentSpan.getTraceGroup();
-            String parentSpanTraceId = parentSpan.getTraceId();
-
-            RawSpanSet rawSpanSet = traceIdRawSpanSetMap.get(parentSpanTraceId);
-            if (rawSpanSet != null) {
-                for (RawSpan rawSpan : rawSpanSet.getRawSpans()) {
-                    rawSpan.setTraceGroup(traceGroup);
-                    recordsToFlush.add(rawSpan);
-                }
-
-                traceIdRawSpanSetMap.remove(parentSpanTraceId);
-            }
-        }
-
-        return recordsToFlush;
-    }
-
-
+    /**
+     * Periodically flush spans from memory. Typically all spans of a trace are written
+     * once the trace's root span arrives, however some child spans my arrive after the root span.
+     * This method ensures "orphaned" child spans are eventually flushed from memory.
+     * @return List of RawSpans to be sent down the pipeline
+     */
     private List<RawSpan> getTracesToFlushByGarbageCollection() {
         final List<RawSpan> recordsToFlush = new LinkedList<>();
 
         if (shouldGarbageCollect()) {
-            boolean isLockAcquired = traceFlushLock.tryLock();
+            final boolean isLockAcquired = traceFlushLock.tryLock();
 
             if (isLockAcquired) {
                 try {
                     final long now = System.currentTimeMillis();
                     lastTraceFlushTime = now;
 
-                    Iterator<Map.Entry<String, RawSpanSet>> entryIterator = traceIdRawSpanSetMap.entrySet().iterator();
+                    final Iterator<Map.Entry<String, RawSpanSet>> entryIterator = traceIdRawSpanSetMap.entrySet().iterator();
                     while (entryIterator.hasNext()) {
-                        Map.Entry<String, RawSpanSet> entry = entryIterator.next();
-                        String traceId = entry.getKey();
-                        TraceGroup traceGroup = traceIdTraceGroupCache.getIfPresent(traceId);
-                        RawSpanSet rawSpanSet = entry.getValue();
-                        long traceTime = rawSpanSet.getTimeSeen();
-                        if (now - traceTime >= traceFlushInterval) {
-                            Set<RawSpan> rawSpans = rawSpanSet.getRawSpans();
+                        final Map.Entry<String, RawSpanSet> entry = entryIterator.next();
+                        final String traceId = entry.getKey();
+                        final TraceGroup traceGroup = traceIdTraceGroupCache.getIfPresent(traceId);
+                        final RawSpanSet rawSpanSet = entry.getValue();
+                        final long traceTime = rawSpanSet.getTimeSeen();
+                        if (now - traceTime >= traceFlushInterval || isShuttingDown) {
+                            final Set<RawSpan> rawSpans = rawSpanSet.getRawSpans();
                             if (traceGroup != null) {
                                 rawSpans.forEach(rawSpan -> {
                                     rawSpan.setTraceGroup(traceGroup);
@@ -247,11 +263,11 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServi
     }
 
     private boolean shouldGarbageCollect() {
-        return System.currentTimeMillis() - lastTraceFlushTime >= traceFlushInterval;
+        return System.currentTimeMillis() - lastTraceFlushTime >= traceFlushInterval || isShuttingDown;
     }
 
     /**
-     * Re-enqueues all spans with time "0" so that all will be available for consumption.
+     * Forces a flush of all spans in memory
      */
     @Override
     public void prepareForShutdown() {
@@ -259,16 +275,8 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServi
 
         if (isLockAcquired) {
             try {
-                LOG.info("Preparing for shutdown, re-enqueueing {} spans", delayedParentSpanQueue.size());
-                Iterator iterator = delayedParentSpanQueue.iterator();
-                List<DelayedParentSpan> delayedParentSpanList = ImmutableList.copyOf(iterator);
-
-                delayedParentSpanQueue.clear();
-
-                for (final DelayedParentSpan delayedParentSpan : delayedParentSpanList) {
-                    final DelayedParentSpan newSpan = new DelayedParentSpan(delayedParentSpan.getRawSpan(), 0L);
-                    delayedParentSpanQueue.add(newSpan);
-                }
+                LOG.info("Preparing for shutdown, will attempt to flush {} spans", traceIdRawSpanSetMap.size());
+                isShuttingDown = true;
             } finally {
                 prepareForShutdownLock.unlock();
             }
@@ -277,38 +285,11 @@ public class OTelTraceRawPrepper extends AbstractPrepper<Record<ExportTraceServi
 
     @Override
     public boolean isReadyForShutdown() {
-        return delayedParentSpanQueue.isEmpty()
-                && traceIdRawSpanSetMap.isEmpty();
+        return traceIdRawSpanSetMap.isEmpty();
     }
 
     @Override
     public void shutdown() {
         traceIdTraceGroupCache.cleanUp();
-    }
-
-    class DelayedParentSpan implements Delayed {
-        private RawSpan rawSpan;
-        private long delayTime;
-
-        public DelayedParentSpan(RawSpan rawSpan, long startTime) {
-            this.rawSpan = rawSpan;
-            this.delayTime = startTime;
-        }
-
-        @Override
-        public long getDelay(TimeUnit unit) {
-            long diff = delayTime - System.currentTimeMillis();
-            return unit.convert(diff, TimeUnit.MILLISECONDS);
-        }
-
-        @Override
-        public int compareTo(Delayed o) {
-            return Ints.saturatedCast(
-                    this.delayTime - ((DelayedParentSpan) o).delayTime);
-        }
-
-        public RawSpan getRawSpan() {
-            return rawSpan;
-        }
     }
 }

--- a/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OtelTraceRawPrepperConfig.java
+++ b/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OtelTraceRawPrepperConfig.java
@@ -3,8 +3,6 @@ package com.amazon.dataprepper.plugins.prepper.oteltrace;
 public class OtelTraceRawPrepperConfig {
     static final String TRACE_FLUSH_INTERVAL = "trace_flush_interval";
     static final long DEFAULT_TG_FLUSH_INTERVAL_SEC = 180L;
-    static final String ROOT_SPAN_FLUSH_DELAY = "root_span_flush_delay";
-    static final long DEFAULT_ROOT_SPAN_FLUSH_DELAY_SEC = 30L;
-    static final long DEFAULT_TRACE_ID_TTL_SEC = 300L;
+    static final long DEFAULT_TRACE_ID_TTL_SEC = 15L;
     static final long MAX_TRACE_ID_CACHE_SIZE = 1000_000L;
 }

--- a/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/model/OTelProtoHelper.java
+++ b/data-prepper-plugins/otel-trace-raw-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/oteltrace/model/OTelProtoHelper.java
@@ -8,8 +8,6 @@ import io.opentelemetry.proto.resource.v1.Resource;
 import io.opentelemetry.proto.trace.v1.Span;
 import io.opentelemetry.proto.trace.v1.Status;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,9 +17,7 @@ import java.util.stream.Collectors;
 
 public final class OTelProtoHelper {
 
-    private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final BigDecimal MILLIS_TO_NANOS = new BigDecimal(1_000_000);
-    private static final BigDecimal SEC_TO_MILLIS = new BigDecimal(1_000);
+    private final static ObjectMapper OBJECT_MAPPER =  new ObjectMapper();
     private static final String SERVICE_NAME = "service.name";
     private static final String SPAN_ATTRIBUTES = "span.attributes";
     static final String RESOURCE_ATTRIBUTES = "resource.attributes";
@@ -136,10 +132,7 @@ public final class OTelProtoHelper {
     }
 
     private static String convertUnixNanosToISO8601(final long unixNano) {
-        final BigDecimal nanos = new BigDecimal(unixNano);
-        final long epochSeconds = nanos.divide(MILLIS_TO_NANOS.multiply(SEC_TO_MILLIS), RoundingMode.DOWN).longValue();
-        final int nanoAdj = nanos.remainder(MILLIS_TO_NANOS.multiply(SEC_TO_MILLIS)).intValue();
-        return Instant.ofEpochSecond(epochSeconds, nanoAdj).toString();
+        return Instant.ofEpochSecond(0L, unixNano).toString();
     }
 
     public static String getStartTimeISO8601(final Span span) {

--- a/data-prepper-plugins/otel-trace-raw-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OTelTraceRawPrepperTest.java
+++ b/data-prepper-plugins/otel-trace-raw-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/oteltrace/OTelTraceRawPrepperTest.java
@@ -50,7 +50,6 @@ public class OTelTraceRawPrepperTest {
 
     private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final long TEST_TRACE_FLUSH_INTERVAL = 3L;
-    private static final long TEST_ROOT_SPAN_FLUSH_DELAY = 1L;
     private static final int TEST_CONCURRENCY_SCALE = 2;
 
     private static final String TEST_REQUEST_ONE_FULL_TRACE_GROUP_JSON_FILE = "sample-request-one-full-trace-group.json";
@@ -71,7 +70,6 @@ public class OTelTraceRawPrepperTest {
                 "OTelTrace",
                 new HashMap<String, Object>() {{
                     put(OtelTraceRawPrepperConfig.TRACE_FLUSH_INTERVAL, TEST_TRACE_FLUSH_INTERVAL);
-                    put(OtelTraceRawPrepperConfig.ROOT_SPAN_FLUSH_DELAY, TEST_ROOT_SPAN_FLUSH_DELAY);
                 }});
         pluginSetting.setPipelineName("pipelineOTelTrace");
         pluginSetting.setProcessWorkers(TEST_CONCURRENCY_SCALE);
@@ -130,12 +128,12 @@ public class OTelTraceRawPrepperTest {
     @Test
     public void testExportRequestFlushByParentSpan() throws IOException {
         final ExportTraceServiceRequest exportTraceServiceRequest = buildExportTraceServiceRequestFromJsonFile(TEST_REQUEST_TWO_FULL_TRACE_GROUP_JSON_FILE);
-        oTelTraceRawPrepper.doExecute(Collections.singletonList(new Record<>(exportTraceServiceRequest)));
-        await().atMost(2 * TEST_ROOT_SPAN_FLUSH_DELAY, TimeUnit.SECONDS).untilAsserted(() -> {
-            final List<Record<String>> processedRecords = (List<Record<String>>) oTelTraceRawPrepper.doExecute(Collections.emptyList());
-            Assertions.assertThat(processedRecords.size()).isEqualTo(6);
-            Assertions.assertThat(getMissingTraceGroupFieldsSpanCount(processedRecords)).isEqualTo(0);
-        });
+        final List<Record<String>> processedRecords = (List<Record<String>>)oTelTraceRawPrepper.doExecute(
+                Collections.singletonList(new Record<>(exportTraceServiceRequest))
+        );
+
+        Assertions.assertThat(processedRecords.size()).isEqualTo(6);
+        Assertions.assertThat(getMissingTraceGroupFieldsSpanCount(processedRecords)).isEqualTo(0);
     }
 
     @Test
@@ -149,7 +147,7 @@ public class OTelTraceRawPrepperTest {
         for (Future<Collection<Record<String>>> future : futures) {
             processedRecords.addAll(future.get());
         }
-        await().atMost(2 * TEST_ROOT_SPAN_FLUSH_DELAY, TimeUnit.SECONDS).untilAsserted(() -> {
+        await().atMost(2 * TEST_TRACE_FLUSH_INTERVAL, TimeUnit.SECONDS).untilAsserted(() -> {
             List<Future<Collection<Record<String>>>> futureList = submitExportTraceServiceRequests(Collections.emptyList());
             for (Future<Collection<Record<String>>> future : futureList) {
                 processedRecords.addAll(future.get());
@@ -197,7 +195,7 @@ public class OTelTraceRawPrepperTest {
         assertTrue(oTelTraceRawPrepper.isReadyForShutdown());
 
         // Add records to memory/queue
-        final ExportTraceServiceRequest exportTraceServiceRequest = buildExportTraceServiceRequestFromJsonFile(TEST_REQUEST_TWO_FULL_TRACE_GROUP_JSON_FILE);
+        final ExportTraceServiceRequest exportTraceServiceRequest = buildExportTraceServiceRequestFromJsonFile(TEST_REQUEST_TWO_TRACE_GROUP_MISSING_ROOTS_JSON_FILE);
         oTelTraceRawPrepper.doExecute(Collections.singletonList(new Record<>(exportTraceServiceRequest)));
 
         // Assert records exist in memory


### PR DESCRIPTION
Signed-off-by: Jeff Wright <74204404+wrijeff@users.noreply.github.com>

*Issue #, if available:*

*Description of changes:*
* Changed Prepper logic to no longer use a DelayQueue to allow child spans to arrive after the root span. This is instead handled by the traceID cache. 
* Changed Sink thread count per pipeline to equal the number of "workers" 

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
