### PR TITLE
Changing Dependabot scans from weekly to monthly.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,54 +4,54 @@ updates:
 - package-ecosystem: gradle
   directory: "/data-prepper-api"
   schedule:
-    interval: weekly
+    interval: monthly
 
 - package-ecosystem: gradle
   directory: "/data-prepper-core"
   schedule:
-    interval: weekly
+    interval: monthly
 
 - package-ecosystem: gradle
   directory: "/data-prepper-plugins/blocking-buffer"
   schedule:
-    interval: weekly
+    interval: monthly
 
 - package-ecosystem: gradle
   directory: "/data-prepper-plugins/common"
   schedule:
-    interval: weekly
+    interval: monthly
 
 - package-ecosystem: gradle
   directory: "/data-prepper-plugins/elasticsearch"
   schedule:
-    interval: weekly
+    interval: monthly
 
 - package-ecosystem: gradle
   directory: "/data-prepper-plugins/mapdb-prepper-state"
   schedule:
-    interval: weekly
+    interval: monthly
 
 - package-ecosystem: gradle
   directory: "/data-prepper-plugins/otel-trace-raw-prepper"
   schedule:
-    interval: weekly
+    interval: monthly
 
 - package-ecosystem: gradle
   directory: "/data-prepper-plugins/otel-trace-group-prepper"
   schedule:
-    interval: weekly
+    interval: monthly
 
 - package-ecosystem: gradle
   directory: "/data-prepper-plugins/otel-trace-source"
   schedule:
-    interval: weekly
+    interval: monthly
 
 - package-ecosystem: gradle
   directory: "/data-prepper-plugins/peer-forwarder"
   schedule:
-    interval: weekly
+    interval: monthly
 
 - package-ecosystem: gradle
   directory: "/data-prepper-plugins/service-map-stateful"
   schedule:
-    interval: weekly
+    interval: monthly


### PR DESCRIPTION
Signed-off-by: Jeff Wright <74204404+wrijeff@users.noreply.github.com>

*Issue #, if available:*

*Description of changes:*
* Changing Dependabot scans from weekly to monthly to cut down on maintenance tasks
-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
