### PR TITLE
Add support to read certificate from ACM and S3 for peer forwarder

### DIFF
--- a/data-prepper-plugins/peer-forwarder/README.md
+++ b/data-prepper-plugins/peer-forwarder/README.md
@@ -49,8 +49,16 @@ A DNS server (like [dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html)) can
 * `discovery_mode`: peer discovery mode to be used. Allowable values are `static` and `dns`. Defaults to `static`
 * `static_endpoints`: list containing endpoints of all Data Prepper instances.
 * `domain_name`: single domain name to query DNS against. Typically used by creating multiple [DNS A Records](https://www.cloudflare.com/learning/dns/dns-records/dns-a-record/) for the same domain.
-* `ssl` => Default is ```true```.
-* `sslKeyCertChainFile` => Should be provided if ```ssl``` is set to ```true```
+
+### SSL
+The SSL configuration for setting up trust manager for peer forwarding client to connect to other Data Prepper instances. The SSL configuration should be same as the one used for OTel Trace Source.
+
+* `ssl(Optional)` => A boolean enables TLS/SSL. Default is ```true```.
+* `sslKeyCertChainFile(Optional)` => A `String` represents the SSL certificate chain file path or AWS S3 path. S3 path example ```s3://<bucketName>/<path>```. Required if ```ssl``` is set to ```true```.
+* `useAcmCertForSSL(Optional)` => A boolean enables TLS/SSL using certificate and private key from AWS Certificate Manager (ACM). Default is ```false```.
+* `acmCertificateArn(Optional)` => A `String` represents the ACM certificate ARN. ACM certificate take preference over S3 or local file system certificate. Required if ```useAcmCertForSSL``` is set to ```true```.
+* `awsRegion(Optional)` => A `String` represents the AWS region to use ACM or S3. Required if ```useAcmCertForSSL``` is set to ```true``` or ```sslKeyCertChainFile``` and ```sslKeyFile``` is ```AWS S3 path```.
+
 
 ## Metrics
 

--- a/data-prepper-plugins/peer-forwarder/build.gradle
+++ b/data-prepper-plugins/peer-forwarder/build.gradle
@@ -15,9 +15,16 @@ dependencies {
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
     implementation "com.linecorp.armeria:armeria:1.9.1"
     implementation "com.linecorp.armeria:armeria-grpc:1.9.1"
+    implementation "com.amazonaws:aws-java-sdk-s3:1.12.15"
+    implementation "com.amazonaws:aws-java-sdk-acm:1.12.12"
+    implementation "commons-io:commons-io:2.10.0"
+    implementation "org.apache.commons:commons-lang3:3.12.0"
     implementation "commons-validator:commons-validator:1.7"
     testImplementation "junit:junit:4.13.2"
+    testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation "org.mockito:mockito-inline:3.11.2"
+    testImplementation "org.mockito:mockito-core:3.11.2"
+    testImplementation "commons-io:commons-io:2.10.0"
 }
 
 jacocoTestCoverageVerification {

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/CertificateProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/CertificateProvider.java
@@ -1,0 +1,7 @@
+package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate;
+
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.model.Certificate;
+
+public interface CertificateProvider {
+    Certificate getCertificate();
+}

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/CertificateProviderConfig.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/CertificateProviderConfig.java
@@ -1,0 +1,43 @@
+package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate;
+
+public class CertificateProviderConfig {
+    private static final String S3_PREFIX = "s3://";
+
+    private final boolean useAcmCertForSSL;
+    private final String acmCertificateArn;
+    private final String awsRegion;
+    private final long acmCertIssueTimeOutMillis;
+    private final String sslKeyCertChainFile;
+
+    public CertificateProviderConfig(final boolean useAcmCertForSSL, final String acmCertificateArn, final String awsRegion, final long acmCertIssueTimeOutMillis, final String sslKeyCertChainFile) {
+        this.useAcmCertForSSL = useAcmCertForSSL;
+        this.acmCertificateArn = acmCertificateArn;
+        this.awsRegion = awsRegion;
+        this.acmCertIssueTimeOutMillis = acmCertIssueTimeOutMillis;
+        this.sslKeyCertChainFile = sslKeyCertChainFile;
+    }
+
+    public boolean useAcmCertForSSL() {
+        return useAcmCertForSSL;
+    }
+
+    public String getAcmCertificateArn() {
+        return acmCertificateArn;
+    }
+
+    public String getAwsRegion() {
+        return awsRegion;
+    }
+
+    public long getAcmCertIssueTimeOutMillis() {
+        return acmCertIssueTimeOutMillis;
+    }
+
+    public String getSslKeyCertChainFile() {
+        return sslKeyCertChainFile;
+    }
+
+    public boolean isSslCertFileInS3() {
+        return sslKeyCertChainFile.toLowerCase().startsWith(S3_PREFIX);
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/CertificateProviderFactory.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/CertificateProviderFactory.java
@@ -1,0 +1,51 @@
+package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate;
+
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.acm.ACMCertificateProvider;
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.file.FileCertificateProvider;
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.s3.S3CertificateProvider;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.certificatemanager.AWSCertificateManager;
+import com.amazonaws.services.certificatemanager.AWSCertificateManagerClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CertificateProviderFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(CertificateProviderFactory.class);
+
+    final CertificateProviderConfig certificateProviderConfig;
+    public CertificateProviderFactory(final CertificateProviderConfig certificateProviderConfig) {
+        this.certificateProviderConfig = certificateProviderConfig;
+    }
+
+    public CertificateProvider getCertificateProvider() {
+        // ACM Cert for SSL takes preference
+        if (certificateProviderConfig.useAcmCertForSSL()) {
+            LOG.info("Using ACM certificate for SSL/TLS to setup trust store.");
+            final AWSCredentialsProvider credentialsProvider = new DefaultAWSCredentialsProviderChain();
+            final ClientConfiguration clientConfig = new ClientConfiguration()
+                    .withThrottledRetries(true);
+            final AWSCertificateManager awsCertificateManager = AWSCertificateManagerClientBuilder.standard()
+                    .withRegion(certificateProviderConfig.getAwsRegion())
+                    .withCredentials(credentialsProvider)
+                    .withClientConfiguration(clientConfig)
+                    .build();
+            return new ACMCertificateProvider(awsCertificateManager, certificateProviderConfig.getAcmCertificateArn(),
+                    certificateProviderConfig.getAcmCertIssueTimeOutMillis());
+        } else if (certificateProviderConfig.isSslCertFileInS3()) {
+            LOG.info("Using S3 to fetch certificate for SSL/TLS to setup trust store.");
+            final AWSCredentialsProvider credentialsProvider = new DefaultAWSCredentialsProviderChain();
+            final AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                    .withRegion(certificateProviderConfig.getAwsRegion())
+                    .withCredentials(credentialsProvider)
+                    .build();
+            return new S3CertificateProvider(s3Client, certificateProviderConfig.getSslKeyCertChainFile());
+        } else {
+            LOG.info("Using local file system to get certificate for SSL/TLS to setup trust store.");
+            return new FileCertificateProvider(certificateProviderConfig.getSslKeyCertChainFile());
+        }
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/acm/ACMCertificateProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/acm/ACMCertificateProvider.java
@@ -1,0 +1,58 @@
+package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.acm;
+
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.CertificateProvider;
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.model.Certificate;
+import com.amazonaws.services.certificatemanager.AWSCertificateManager;
+import com.amazonaws.services.certificatemanager.model.GetCertificateRequest;
+import com.amazonaws.services.certificatemanager.model.GetCertificateResult;
+import com.amazonaws.services.certificatemanager.model.InvalidArnException;
+import com.amazonaws.services.certificatemanager.model.RequestInProgressException;
+import com.amazonaws.services.certificatemanager.model.ResourceNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+
+public class ACMCertificateProvider implements CertificateProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(ACMCertificateProvider.class);
+    private static final long SLEEP_INTERVAL = 10000L;
+    private final AWSCertificateManager awsCertificateManager;
+    private final String acmArn;
+    private final long totalTimeout;
+    public ACMCertificateProvider(final AWSCertificateManager awsCertificateManager,
+                                  final String acmArn,
+                                  final long totalTimeout) {
+        this.awsCertificateManager = Objects.requireNonNull(awsCertificateManager);
+        this.acmArn = Objects.requireNonNull(acmArn);
+        this.totalTimeout = totalTimeout;
+    }
+
+    public Certificate getCertificate() {
+        GetCertificateResult getCertificateResult = null;
+        long timeSlept = 0L;
+
+        while (getCertificateResult == null && timeSlept < totalTimeout) {
+            try {
+                final GetCertificateRequest getCertificateRequest = new GetCertificateRequest()
+                        .withCertificateArn(acmArn);
+                getCertificateResult = awsCertificateManager.getCertificate(getCertificateRequest);
+
+            } catch (final RequestInProgressException ex) {
+                try {
+                    Thread.sleep(SLEEP_INTERVAL);
+                } catch (InterruptedException iex) {
+                    throw new RuntimeException(iex);
+                }
+            } catch (final ResourceNotFoundException | InvalidArnException ex) {
+                LOG.error("Exception retrieving the certificate with arn: {}", acmArn, ex);
+                throw ex;
+            }
+            timeSlept += SLEEP_INTERVAL;
+        }
+        if(getCertificateResult != null) {
+            return new Certificate(getCertificateResult.getCertificate());
+        } else {
+            throw new IllegalStateException(String.format("Exception retrieving certificate results. Time spent retrieving certificate is %d ms and total time out set is %d ms.", timeSlept, totalTimeout));
+        }
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/file/FileCertificateProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/file/FileCertificateProvider.java
@@ -1,0 +1,33 @@
+package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.file;
+
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.CertificateProvider;
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.model.Certificate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+public class FileCertificateProvider implements CertificateProvider {
+    private final String certificateFilePath;
+
+    public FileCertificateProvider(final String certificateFilePath) {
+        this.certificateFilePath = Objects.requireNonNull(certificateFilePath);
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileCertificateProvider.class);
+
+    public Certificate getCertificate() {
+        try {
+            final Path certFilePath = Path.of(certificateFilePath);
+
+            final String certAsString = Files.readString(certFilePath);
+
+            return new Certificate(certAsString);
+        } catch (final Exception ex) {
+            LOG.error("Error encountered while reading the certificate.", ex);
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/model/Certificate.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/model/Certificate.java
@@ -1,0 +1,18 @@
+package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.model;
+
+import static java.util.Objects.requireNonNull;
+
+public class Certificate {
+    /**
+     * The base64 PEM-encoded certificate.
+     */
+    private String certificate;
+
+    public Certificate(final String certificate) {
+        this.certificate = requireNonNull(certificate, "certificate must not be null");
+    }
+
+    public String getCertificate() {
+        return certificate;
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/s3/S3CertificateProvider.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/s3/S3CertificateProvider.java
@@ -1,0 +1,44 @@
+package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.s3;
+
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.CertificateProvider;
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.model.Certificate;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3URI;
+import com.amazonaws.services.s3.model.S3Object;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+public class S3CertificateProvider implements CertificateProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(S3CertificateProvider.class);
+    private final AmazonS3 s3Client;
+    private final String certificateFilePath;
+
+    public S3CertificateProvider(final AmazonS3 s3Client,
+                                 final String certificateFilePath) {
+        this.s3Client = Objects.requireNonNull(s3Client);
+        this.certificateFilePath = Objects.requireNonNull(certificateFilePath);
+    }
+
+    public Certificate getCertificate() {
+        final AmazonS3URI certificateS3URI = new AmazonS3URI(certificateFilePath);
+        final String certificate = getObjectWithKey(certificateS3URI.getBucket(), certificateS3URI.getKey());
+
+        return new Certificate(certificate);
+    }
+
+    private String getObjectWithKey(final String bucketName, final String key) {
+
+        // Download the object
+        try (final S3Object s3Object = s3Client.getObject(bucketName, key)) {
+            LOG.info("Object with key \"{}\" downloaded.", key);
+            return IOUtils.toString(s3Object.getObjectContent(), StandardCharsets.UTF_8);
+        } catch (final Exception ex) {
+            LOG.error("Error encountered while processing the response from Amazon S3.", ex);
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerClientPoolTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerClientPoolTest.java
@@ -1,5 +1,6 @@
 package com.amazon.dataprepper.plugins.prepper.peerforwarder;
 
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.model.Certificate;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
@@ -10,6 +11,9 @@ import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -32,7 +36,7 @@ public class PeerClientPoolTest {
     }
 
     @Test
-    public void testGetClientWithSSL() {
+    public void testGetClientWithSSL() throws IOException {
         // Set up test server with SSL
         ServerBuilder sb = Server.builder();
         sb.service(GrpcService.builder()
@@ -46,7 +50,11 @@ public class PeerClientPoolTest {
             // Configure client pool
             PeerClientPool pool = PeerClientPool.getInstance();
             pool.setSsl(true);
-            pool.setSslKeyCertChainFile(SSL_CRT_FILE);
+
+            final Path certFilePath = Path.of(PeerClientPoolTest.class.getClassLoader().getResource("test-crt.crt").getPath());
+            final String certAsString = Files.readString(certFilePath);
+            final Certificate certificate = new Certificate(certAsString);
+            pool.setCertificate(certificate);
             TraceServiceGrpc.TraceServiceBlockingStub client = pool.getClient(LOCALHOST);
             assertNotNull(client);
 

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderConfigTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderConfigTest.java
@@ -1,22 +1,25 @@
 package com.amazon.dataprepper.plugins.prepper.peerforwarder;
 
 import com.amazon.dataprepper.model.configuration.PluginSetting;
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.model.Certificate;
 import com.amazon.dataprepper.plugins.prepper.peerforwarder.discovery.DiscoveryMode;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mockStatic;
@@ -42,7 +45,6 @@ public class PeerForwarderConfigTest {
         mockedPeerClientPoolClass = mockStatic(PeerClientPool.class);
         mockedPeerClientPoolClass.when(PeerClientPool::getInstance).thenReturn(peerClientPool);
         doNothing().when(peerClientPool).setSsl(anyBoolean());
-        doNothing().when(peerClientPool).setSslKeyCertChainFile(any(File.class));
     }
 
     @After
@@ -87,13 +89,13 @@ public class PeerForwarderConfigTest {
         });
 
         settings.put(PeerForwarderConfig.SSL_KEY_CERT_FILE, INVALID_SSL_KEY_CERT_FILE);
-        Assert.assertThrows(IllegalArgumentException.class, () -> {
+        Assert.assertThrows(RuntimeException.class, () -> {
             PeerForwarderConfig.buildConfig(new PluginSetting("peer_forwarder", settings){{ setPipelineName(PIPELINE_NAME); }});
         });
     }
 
     @Test
-    public void testBuildConfigValidSSL() {
+    public void testBuildConfigValidSSL() throws IOException {
         final HashMap<String, Object> settings = new HashMap<>();
         settings.put(PeerForwarderConfig.DISCOVERY_MODE, DiscoveryMode.STATIC.toString());
         settings.put(PeerForwarderConfig.STATIC_ENDPOINTS, TEST_ENDPOINTS);
@@ -102,6 +104,12 @@ public class PeerForwarderConfigTest {
 
         PeerForwarderConfig.buildConfig(new PluginSetting("peer_forwarder", settings){{ setPipelineName(PIPELINE_NAME); }});
         verify(peerClientPool, times(1)).setSsl(true);
-        verify(peerClientPool, times(1)).setSslKeyCertChainFile(new File(VALID_SSL_KEY_CERT_FILE));
+        final ArgumentCaptor<Certificate> certificateArgumentCaptor = ArgumentCaptor.forClass(Certificate.class);
+        verify(peerClientPool, times(1)).setCertificate(certificateArgumentCaptor.capture());
+        final Certificate certificate = certificateArgumentCaptor.getValue();
+
+        final Path certFilePath = Path.of(VALID_SSL_KEY_CERT_FILE);
+        final String certAsString = Files.readString(certFilePath);
+        Assert.assertEquals(certificate.getCertificate(), certAsString);
     }
 }

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/CertificateProviderFactoryTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/CertificateProviderFactoryTest.java
@@ -1,0 +1,82 @@
+package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate;
+
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.acm.ACMCertificateProvider;
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.file.FileCertificateProvider;
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.s3.S3CertificateProvider;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CertificateProviderFactoryTest {
+    private CertificateProviderFactory certificateProviderFactory;
+
+    @Test
+    public void getCertificateProviderAcmProviderSuccess() {
+        final boolean useAcmCertForSSL = true;
+        final String awsRegion = "us-east-1";
+        final String acmCertificateArn = "arn:aws:acm:us-east-1:account:certificate/1234-567-856456";
+        final String sslKeyCertChainFile = null;
+        final long acmCertIssueTimeOutMillis = 1000L;
+
+        final CertificateProviderConfig certificateProviderConfig = new CertificateProviderConfig(
+                useAcmCertForSSL,
+                acmCertificateArn,
+                awsRegion,
+                acmCertIssueTimeOutMillis,
+                sslKeyCertChainFile
+        );
+
+        certificateProviderFactory = new CertificateProviderFactory(certificateProviderConfig);
+        final CertificateProvider certificateProvider = certificateProviderFactory.getCertificateProvider();
+
+        assertThat(certificateProvider, IsInstanceOf.instanceOf(ACMCertificateProvider.class));
+    }
+
+    @Test
+    public void getCertificateProviderS3ProviderSuccess() {
+        final boolean useAcmCertForSSL = false;
+        final String awsRegion = "us-east-1";
+        final String acmCertificateArn = null;
+        final String sslKeyCertChainFile = "s3://some_s3_bucket/certificate/test_cert.crt";
+        final long acmCertIssueTimeOutMillis = 1000L;
+
+        final CertificateProviderConfig certificateProviderConfig = new CertificateProviderConfig(
+                useAcmCertForSSL,
+                acmCertificateArn,
+                awsRegion,
+                acmCertIssueTimeOutMillis,
+                sslKeyCertChainFile
+        );
+
+        certificateProviderFactory = new CertificateProviderFactory(certificateProviderConfig);
+        final CertificateProvider certificateProvider = certificateProviderFactory.getCertificateProvider();;
+
+        assertThat(certificateProvider, IsInstanceOf.instanceOf(S3CertificateProvider.class));
+    }
+
+    @Test
+    public void getCertificateProviderFileProviderSuccess() {
+        final boolean useAcmCertForSSL = false;
+        final String awsRegion = null;
+        final String acmCertificateArn = null;
+        final String sslKeyCertChainFile = "path_to_certificate/test_cert.crt";
+        final long acmCertIssueTimeOutMillis = 1000L;
+
+        final CertificateProviderConfig certificateProviderConfig = new CertificateProviderConfig(
+                useAcmCertForSSL,
+                acmCertificateArn,
+                awsRegion,
+                acmCertIssueTimeOutMillis,
+                sslKeyCertChainFile
+        );
+
+        certificateProviderFactory = new CertificateProviderFactory(certificateProviderConfig);
+        final CertificateProvider certificateProvider = certificateProviderFactory.getCertificateProvider();
+
+        assertThat(certificateProvider, IsInstanceOf.instanceOf(FileCertificateProvider.class));
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/acm/ACMCertificateProviderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/acm/ACMCertificateProviderTest.java
@@ -1,0 +1,67 @@
+package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.acm;
+
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.model.Certificate;
+import com.amazonaws.services.certificatemanager.AWSCertificateManager;
+import com.amazonaws.services.certificatemanager.model.GetCertificateRequest;
+import com.amazonaws.services.certificatemanager.model.GetCertificateResult;
+import com.amazonaws.services.certificatemanager.model.InvalidArnException;
+import com.amazonaws.services.certificatemanager.model.RequestInProgressException;
+import com.amazonaws.services.certificatemanager.model.ResourceNotFoundException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ACMCertificateProviderTest {
+    private static final String acmCertificateArn = "arn:aws:acm:us-east-1:account:certificate/1234-567-856456";
+    private static final long acmCertIssueTimeOutMillis = 2000L;
+    @Mock
+    private AWSCertificateManager  awsCertificateManager;
+
+    @Mock
+    private GetCertificateResult getCertificateResult;
+
+    private ACMCertificateProvider acmCertificateProvider;
+
+    @Before
+    public void beforeEach() {
+        acmCertificateProvider = new ACMCertificateProvider(awsCertificateManager, acmCertificateArn, acmCertIssueTimeOutMillis);
+    }
+
+    @Test
+    public void getACMCertificateSuccess() {
+        final String certificateContent = UUID.randomUUID().toString();
+        when(getCertificateResult.getCertificate()).thenReturn(certificateContent);
+        when(awsCertificateManager.getCertificate(any(GetCertificateRequest.class))).thenReturn(getCertificateResult);
+        final Certificate certificate = acmCertificateProvider.getCertificate();
+        assertThat(certificate.getCertificate(), is(certificateContent));
+    }
+
+    @Test
+    public void getACMCertificateRequestInProgressException() {
+        when(awsCertificateManager.getCertificate(any(GetCertificateRequest.class))).thenThrow(new RequestInProgressException("Request in progress."));
+        assertThrows(IllegalStateException.class, () -> acmCertificateProvider.getCertificate());
+    }
+
+    @Test
+    public void getACMCertificateResourceNotFoundException() {
+        when(awsCertificateManager.getCertificate(any(GetCertificateRequest.class))).thenThrow(new ResourceNotFoundException("Resource not found."));
+        assertThrows(ResourceNotFoundException.class, () -> acmCertificateProvider.getCertificate());
+    }
+
+    @Test
+    public void getACMCertificateInvalidArnException() {
+        when(awsCertificateManager.getCertificate(any(GetCertificateRequest.class))).thenThrow(new InvalidArnException("Invalid certificate arn."));
+        assertThrows(InvalidArnException.class, () -> acmCertificateProvider.getCertificate());
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/file/FileCertificateProviderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/file/FileCertificateProviderTest.java
@@ -1,0 +1,42 @@
+package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.file;
+
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.model.Certificate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FileCertificateProviderTest {
+
+    private FileCertificateProvider fileCertificateProvider;
+
+    @Test
+    public void getCertificateValidPathSuccess() throws IOException {
+        final String certificateFilePath = FileCertificateProviderTest.class.getClassLoader().getResource("test-crt.crt").getPath();
+
+        fileCertificateProvider = new FileCertificateProvider(certificateFilePath);
+
+        final Certificate certificate = fileCertificateProvider.getCertificate();
+
+        final Path certFilePath = Path.of(certificateFilePath);
+        final String certAsString = Files.readString(certFilePath);
+
+        assertThat(certificate.getCertificate(), is(certAsString));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getCertificateInvalidPathSuccess() {
+        final String certificateFilePath = "path_does_not_exit/test_cert.crt";
+
+        fileCertificateProvider = new FileCertificateProvider(certificateFilePath);
+
+        fileCertificateProvider.getCertificate();
+    }
+}

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/s3/S3CertificateProviderTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/certificate/s3/S3CertificateProviderTest.java
@@ -1,0 +1,65 @@
+package com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.s3;
+
+import com.amazon.dataprepper.plugins.prepper.peerforwarder.certificate.model.Certificate;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class S3CertificateProviderTest {
+    @Mock
+    private AmazonS3 amazonS3;
+
+    @Mock
+    private S3Object certS3Object;
+
+    private S3CertificateProvider s3CertificateProvider;
+
+    @Test
+    public void getCertificateValidKeyPathSuccess() {
+        final String certificateContent = UUID.randomUUID().toString();
+        final String bucketName = UUID.randomUUID().toString();
+        final String certificatePath = UUID.randomUUID().toString();
+
+        final String s3SslKeyCertChainFile = String.format("s3://%s/%s",bucketName, certificatePath);
+
+        final InputStream certObjectStream = IOUtils.toInputStream(certificateContent, StandardCharsets.UTF_8);
+
+        when(certS3Object.getObjectContent()).thenReturn(new S3ObjectInputStream(certObjectStream,null));
+
+        when(amazonS3.getObject(bucketName, certificatePath)).thenReturn(certS3Object);
+
+        s3CertificateProvider = new S3CertificateProvider(amazonS3, s3SslKeyCertChainFile);
+
+        final Certificate certificate = s3CertificateProvider.getCertificate();
+
+        assertThat(certificate.getCertificate(), is(certificateContent));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getCertificateValidKeyPathS3Exception() {
+        final String certificatePath = UUID.randomUUID().toString();
+        final String bucketName = UUID.randomUUID().toString();
+
+        final String s3SslKeyCertChainFile = String.format("s3://%s/%s",bucketName, certificatePath);
+
+        s3CertificateProvider = new S3CertificateProvider(amazonS3, s3SslKeyCertChainFile);
+        when(amazonS3.getObject(anyString(), anyString())).thenThrow(new RuntimeException("S3 exception"));
+
+        s3CertificateProvider.getCertificate();
+    }
+}


### PR DESCRIPTION
### Add support to read certificate from ACM and S3 for peer forwarder

Changes include:
* Added support to build the trust manager by abstracting how the certificates are read. The certificate can be local file system location, AWS ACM ARN or AWS S3 location.
* Added unit test to support above case.

Signed-off-by: Dinu John <86094133+dinujoh@users.noreply.github.com>

*Issue #, if available:*


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
