### PR TITLE
Only register the Health gRPC service when it is configured to be used.

### DIFF
--- a/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
+++ b/data-prepper-plugins/otel-trace-source/src/main/java/com/amazon/dataprepper/plugins/source/oteltrace/OTelTraceSource.java
@@ -60,7 +60,6 @@ public class OTelTraceSource implements Source<Record<ExportTraceServiceRequest>
                             buffer,
                             pluginMetrics
                     ))
-                    .addService(new HealthGrpcService())
                     .useClientTimeoutHeader(false);
 
             if (oTelTraceSourceConfig.hasHealthCheck()) {


### PR DESCRIPTION
Signed-off-by: David Venable <dlv@amazon.com>

*Issue #, if available:* 

None

*Description of changes:*

While reviewing the code, I noticed that the `OTelTraceSource` always registers a `HealthGrpcService`. We have a boolean flag which appears to be how we should determine whether to include it. I made this change to only conditionally add the service. Additionally, I added unit tests for both scenarios.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
