### PR TITLE
Update roleSessionName to be less that 64 character

### DIFF
--- a/data-prepper-plugins/elasticsearch/README.md
+++ b/data-prepper-plugins/elasticsearch/README.md
@@ -70,7 +70,7 @@ Default is null.
 
 - `aws_region`: A String represents the region of Amazon Elasticsearch Service domain, e.g. us-west-2. Only applies to Amazon Elasticsearch Service. Defaults to `us-east-1`.
 
-- `aws_sts_role`: A IAM role which the sink plugin will assume to sign request to Amazon Elasticsearch. If not provided the plugin will use the default credentials.
+- `aws_sts_role_arn`: A IAM role arn which the sink plugin will assume to sign request to Amazon Elasticsearch. If not provided the plugin will use the default credentials.
 
 - `insecure`: A boolean flag to turn off SSL certificate verification. If set to true, CA certificate verification will be turned off and insecure HTTP requests will be sent. Default to `false`.
 

--- a/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ConnectionConfiguration.java
+++ b/data-prepper-plugins/elasticsearch/src/main/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ConnectionConfiguration.java
@@ -54,7 +54,7 @@ public class ConnectionConfiguration {
   public static final String INSECURE = "insecure";
   public static final String AWS_SIGV4 = "aws_sigv4";
   public static final String AWS_REGION = "aws_region";
-  public static final String AWS_STS_ROLE = "aws_sts_role";
+  public static final String AWS_STS_ROLE_ARN = "aws_sts_role_arn";
 
   private final List<String> hosts;
   private final String username;
@@ -65,7 +65,7 @@ public class ConnectionConfiguration {
   private final boolean insecure;
   private final boolean awsSigv4;
   private final String awsRegion;
-  private final String awsStsRole;
+  private final String awsStsRoleArn;
   private final String pipelineName;
 
   public List<String> getHosts() {
@@ -88,8 +88,8 @@ public class ConnectionConfiguration {
     return awsRegion;
   }
 
-  public String getAwsStsRole() {
-    return awsStsRole;
+  public String getAwsStsRoleArn() {
+    return awsStsRoleArn;
   }
 
   public Path getCertPath() {
@@ -114,7 +114,7 @@ public class ConnectionConfiguration {
     this.insecure = builder.insecure;
     this.awsSigv4 = builder.awsSigv4;
     this.awsRegion = builder.awsRegion;
-    this.awsStsRole = builder.awsStsRole;
+    this.awsStsRoleArn = builder.awsStsRoleArn;
     this.pipelineName = builder.pipelineName;
   }
 
@@ -143,7 +143,7 @@ public class ConnectionConfiguration {
     builder.withAwsSigv4(pluginSetting.getBooleanOrDefault(AWS_SIGV4, false));
     if (builder.awsSigv4) {
       builder.withAwsRegion(pluginSetting.getStringOrDefault(AWS_REGION, DEFAULT_AWS_REGION));
-      builder.withAWSStsRole(pluginSetting.getStringOrDefault(AWS_STS_ROLE, null));
+      builder.withAWSStsRoleArn(pluginSetting.getStringOrDefault(AWS_STS_ROLE_ARN, null));
     }
 
     final String certPath = pluginSetting.getStringOrDefault(CERT_PATH, null);
@@ -169,7 +169,7 @@ public class ConnectionConfiguration {
       i++;
     }
     final RestClientBuilder restClientBuilder = RestClient.builder(httpHosts);
-    /**
+    /*
      * Given that this is a patch release, we will support only the IAM based access policy AES domains.
      * We will not support FGAC and Custom endpoint domains. This will be followed in the next version.
      */
@@ -197,13 +197,13 @@ public class ConnectionConfiguration {
     LOG.info("{} is set, will sign requests using AWSRequestSigningApacheInterceptor", AWS_SIGV4);
     final Aws4Signer aws4Signer = Aws4Signer.create();
     AwsCredentialsProvider credentialsProvider;
-    if (awsStsRole != null && !awsStsRole.isEmpty()) {
+    if (awsStsRoleArn != null && !awsStsRoleArn.isEmpty()) {
       credentialsProvider = StsAssumeRoleCredentialsProvider.builder()
               .stsClient(StsClient.create())
               .refreshRequest(AssumeRoleRequest.builder()
-                      .roleSessionName(pipelineName + " Elasticsearch-Sink " + UUID.randomUUID()
+                      .roleSessionName("Elasticsearch-Sink-" + UUID.randomUUID()
                               .toString())
-                      .roleArn(awsStsRole)
+                      .roleArn(awsStsRoleArn)
                       .build())
               .build();
     } else {
@@ -281,7 +281,7 @@ public class ConnectionConfiguration {
     private boolean insecure;
     private boolean awsSigv4;
     private String awsRegion;
-    private String awsStsRole;
+    private String awsStsRoleArn;
     private String pipelineName;
 
 
@@ -337,8 +337,8 @@ public class ConnectionConfiguration {
       return this;
     }
 
-    public Builder withAWSStsRole(final String awsStsRole) {
-      this.awsStsRole = awsStsRole;
+    public Builder withAWSStsRoleArn(final String awsStsRoleArn) {
+      this.awsStsRoleArn = awsStsRoleArn;
       return this;
     }
 

--- a/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ConnectionConfigurationTests.java
+++ b/data-prepper-plugins/elasticsearch/src/test/java/com/amazon/dataprepper/plugins/sink/elasticsearch/ConnectionConfigurationTests.java
@@ -152,14 +152,14 @@ public class ConnectionConfigurationTests {
                 ConnectionConfiguration.readConnectionConfiguration(pluginSetting);
         assertEquals("us-east-1", connectionConfiguration.getAwsRegion());
         assertTrue(connectionConfiguration.isAwsSigv4());
-        assertEquals("some-iam-role", connectionConfiguration.getAwsStsRole());
+        assertEquals("some-iam-role", connectionConfiguration.getAwsStsRoleArn());
         assertEquals(TEST_PIPELINE_NAME, connectionConfiguration.getPipelineName());
     }
 
     private PluginSetting generatePluginSetting(
             final List<String> hosts, final String username, final String password,
             final Integer connectTimeout, final Integer socketTimeout, final boolean awsSigv4, final String awsRegion,
-            final String awsStsRole, final String certPath, final boolean insecure) {
+            final String awsStsRoleArn, final String certPath, final boolean insecure) {
         final Map<String, Object> metadata = new HashMap<>();
         metadata.put("hosts", hosts);
         metadata.put("username", username);
@@ -170,7 +170,7 @@ public class ConnectionConfigurationTests {
         if (awsRegion != null) {
             metadata.put("aws_region", awsRegion);
         }
-        metadata.put("aws_sts_role", awsStsRole);
+        metadata.put("aws_sts_role_arn", awsStsRoleArn);
         metadata.put("cert", certPath);
         metadata.put("insecure", insecure);
         final PluginSetting pluginSetting = new PluginSetting("elasticsearch", metadata);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* The roleSessionName has length constraint max of 64 characters.
* Removing the pipelineName as the length was exceeding 64 characters.

Signed-off-by: Dinu John <86094133+dinujoh@users.noreply.github.com>
-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
