### PR TITLE
Allowing PeerForwarder port to be configurable.

### DIFF
--- a/data-prepper-plugins/peer-forwarder/README.md
+++ b/data-prepper-plugins/peer-forwarder/README.md
@@ -91,6 +91,7 @@ IAM policy shows the necessary permissions.
 
 * `time_out`: timeout in seconds for sending `ExportTraceServiceRequest`. Defaults to 3 seconds.
 * `span_agg_count`: batch size for number of spans per `ExportTraceServiceRequest`. Defaults to 48.
+* `target_port`: the destination port to forward requests to. Defaults to `21890`
 * `discovery_mode`: peer discovery mode to be used. Allowable values are `static`, `dns`, and `aws_cloud_map`. Defaults to `static`
 * `static_endpoints`: list containing endpoints of all Data Prepper instances.
 * `domain_name`: single domain name to query DNS against. Typically used by creating multiple [DNS A Records](https://www.cloudflare.com/learning/dns/dns-records/dns-a-record/) for the same domain.

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerClientPool.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerClientPool.java
@@ -18,6 +18,7 @@ public class PeerClientPool {
     private static final PeerClientPool INSTANCE = new PeerClientPool();
     private final Map<String, TraceServiceGrpc.TraceServiceBlockingStub> peerClients;
 
+    private int port;
     private int clientTimeoutSeconds = 3;
     private boolean ssl;
     private Certificate certificate;
@@ -27,6 +28,7 @@ public class PeerClientPool {
     }
 
     public static PeerClientPool getInstance() {
+        // TODO: remove singleton now that port is configurable
         return INSTANCE;
     }
 
@@ -36,6 +38,10 @@ public class PeerClientPool {
 
     public void setSsl(boolean ssl) {
         this.ssl = ssl;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
     }
 
     public void setCertificate(final Certificate certificate) {
@@ -51,7 +57,7 @@ public class PeerClientPool {
         // TODO: replace hardcoded port with customization
         final ClientBuilder clientBuilder;
         if (ssl) {
-            clientBuilder = Clients.builder(String.format("%s://%s:21890/", GRPC_HTTPS, ipAddress))
+            clientBuilder = Clients.builder(String.format("%s://%s:%s/", GRPC_HTTPS, ipAddress, port))
                     .writeTimeout(Duration.ofSeconds(clientTimeoutSeconds))
                     .factory(ClientFactory.builder()
                             .tlsCustomizer(sslContextBuilder -> sslContextBuilder.trustManager(

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderConfig.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderConfig.java
@@ -13,6 +13,7 @@ public class PeerForwarderConfig {
     public static final String TIME_OUT = "time_out";
     public static final String MAX_NUM_SPANS_PER_REQUEST = "span_agg_count";
     public static final int NUM_VIRTUAL_NODES = 10;
+    public static final String TARGET_PORT = "target_port";
     public static final String DISCOVERY_MODE = "discovery_mode";
     public static final String DOMAIN_NAME = "domain_name";
     public static final String STATIC_ENDPOINTS = "static_endpoints";
@@ -21,6 +22,7 @@ public class PeerForwarderConfig {
     private static final boolean DEFAULT_SSL = true;
     private static final String USE_ACM_CERT_FOR_SSL = "useAcmCertForSSL";
     private static final boolean DEFAULT_USE_ACM_CERT_FOR_SSL = false;
+    private static final int DEFAULT_TARGET_PORT = 21890;
     private static final String ACM_CERT_ISSUE_TIME_OUT_MILLIS = "acmCertIssueTimeOutMillis";
     private static final int DEFAULT_ACM_CERT_ISSUE_TIME_OUT_MILLIS = 120000;
     private static final String ACM_CERT_ARN = "acmCertificateArn";
@@ -51,6 +53,10 @@ public class PeerForwarderConfig {
         final HashRing hashRing = new HashRing(peerListProvider, NUM_VIRTUAL_NODES);
         final PeerClientPool peerClientPool = PeerClientPool.getInstance();
         peerClientPool.setClientTimeoutSeconds(3);
+
+        final int targetPort = pluginSetting.getIntegerOrDefault(TARGET_PORT, DEFAULT_TARGET_PORT);
+        peerClientPool.setPort(targetPort);
+
         final boolean ssl = pluginSetting.getBooleanOrDefault(SSL, DEFAULT_SSL);
         final String sslKeyCertChainFilePath = pluginSetting.getStringOrDefault(SSL_KEY_CERT_FILE, null);
         final boolean useAcmCertForSsl = pluginSetting.getBooleanOrDefault(USE_ACM_CERT_FOR_SSL, DEFAULT_USE_ACM_CERT_FOR_SSL);

--- a/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerClientPoolTest.java
+++ b/data-prepper-plugins/peer-forwarder/src/test/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerClientPoolTest.java
@@ -29,6 +29,7 @@ public class PeerClientPoolTest {
     @Test
     public void testGetClientValidAddress() {
         PeerClientPool pool = PeerClientPool.getInstance();
+        pool.setPort(PORT);
 
         TraceServiceGrpc.TraceServiceBlockingStub client = pool.getClient(VALID_ADDRESS);
 


### PR DESCRIPTION
Signed-off-by: Jeff Wright <74204404+wrijeff@users.noreply.github.com>

*Description of changes:*
* Adding a config key to Peer Forwarder to allow the target port to be configurable.
-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
