### PR TITLE
Overhaul of LocationData, now applies data to documents in a more ES …

### DIFF
--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepper.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepper.java
@@ -73,18 +73,17 @@ public class GeoIpPrepper extends AbstractPrepper<Record<String>, Record<String>
                 final Optional<String> foundIp = parser.getIpFromJson(rawSpanMap, targetField);
                 if (foundIp.isPresent()) {
                     final Optional<LocationData> foundData = provider.getDataFromIp(foundIp.get());
-                    //TODO This is a placeholder, how data is attached is still TBD
                     if (foundData.isPresent()) {
-                        rawSpanMap.put(locationField, foundData.get().toString());
+                        for (Map.Entry<String, Object> entry : foundData.get().toMap().entrySet())
+                            rawSpanMap.put(entry.getKey(), entry.getValue());
                         final String newData = OBJECT_MAPPER.writeValueAsString(rawSpanMap);
                         recordsOut.add(new Record<>(newData, record.getMetadata()));
-                        System.out.println(recordsOut);
                     } else {
                         recordsOut.add(record);
                     }
                 } else {
                     recordsOut.add(record);
-                    //TODO Handle no IP returned
+                    //TODO Handle logging for no IP returned
                 }
             } catch (JsonProcessingException e) {
                 LOG.error("Failed to parse the record: [{}]", record.getData());

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepper.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepper.java
@@ -8,8 +8,6 @@ import com.amazon.dataprepper.model.record.Record;
 import com.amazon.dataprepper.plugins.prepper.geoip.provider.GeoIpProvider;
 import com.amazon.dataprepper.plugins.prepper.geoip.provider.GeoIpProviderFactory;
 import com.amazon.dataprepper.plugins.prepper.geoip.provider.LocationData;
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepper.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepper.java
@@ -27,7 +27,6 @@ public class GeoIpPrepper extends AbstractPrepper<Record<String>, Record<String>
     private static final Logger LOG = LoggerFactory.getLogger(GeoIpPrepper.class);
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
     private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {};
     private final String targetField;
     private final GeoIpProvider provider;
@@ -40,7 +39,6 @@ public class GeoIpPrepper extends AbstractPrepper<Record<String>, Record<String>
         Objects.requireNonNull(targetField);
         provider = new GeoIpProviderFactory().createGeoIpProvider(pluginSetting);
         parser = new IpParser();
-
     }
 
     //
@@ -51,7 +49,6 @@ public class GeoIpPrepper extends AbstractPrepper<Record<String>, Record<String>
         parser = new IpParser();
         targetField = (String) pluginSetting.getAttributeFromSettings(GeoIpPrepperConfig.TARGET_FIELD);
         Objects.requireNonNull(targetField);
-
     }
 
     /**

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepperConfig.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepperConfig.java
@@ -1,10 +1,11 @@
 package com.amazon.dataprepper.plugins.prepper.geoip;
 
 public final class GeoIpPrepperConfig {
-    //TODO add config variables for cache size, location fields, possibly more
+    //TODO add config variables for cache size, possibly more
     public static final String TARGET_FIELD = "target_field";
     public static final String DATA_SOURCE = "data_source";
     public static final String DATABASE_PATH = "database_path";
     public static final String LOCATION_FIELD = "location_field";
     public static final String DEFAULT_LOCATION_FIELD = "locationData";
+    public static final String DESIRED_FIELDS = "desired_fields";
 }

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/Fields.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/Fields.java
@@ -1,0 +1,26 @@
+package com.amazon.dataprepper.plugins.prepper.geoip.provider;
+
+public enum Fields {
+    IP("ip"),
+    CITY_NAME("geo.city_name"),
+    COUNTRY_NAME("geo.country_name"),
+    CONTINENT_CODE("geo.continent_code"),
+    COUNTRY_CODE2("geo.country_iso_code"),
+    POSTAL_CODE("geo.postal_code"),
+    REGION_NAME("geo.region_name"),
+    REGION_CODE("geo.region_code"),
+    TIMEZONE("geo.timezone"),
+    LOCATION("geo.location"),
+    LATITUDE("geo.location.lat"),
+    LONGITUDE("geo.location.lon");
+
+    private final String fieldName;
+
+    Fields(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String fieldName() {
+        return fieldName;
+    }
+}

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoDataField.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoDataField.java
@@ -1,26 +1,16 @@
 package com.amazon.dataprepper.plugins.prepper.geoip.provider;
 
 public enum GeoDataField {
-    IP("ip"),
-    CITY_NAME("geo.city_name"),
-    COUNTRY_NAME("geo.country_name"),
-    CONTINENT_CODE("geo.continent_code"),
-    COUNTRY_ISO_CODE("geo.country_iso_code"),
-    POSTAL_CODE("geo.postal_code"),
-    REGION_NAME("geo.region_name"),
-    REGION_CODE("geo.region_code"),
-    TIMEZONE("geo.timezone"),
-    LOCATION("geo.location"),
-    LATITUDE("geo.location.lat"),
-    LONGITUDE("geo.location.lon");
-
-    private final String fieldName;
-
-    GeoDataField(String fieldName) {
-        this.fieldName = fieldName;
-    }
-
-    public String fieldName() {
-        return fieldName;
-    }
+    IP,
+    CITY_NAME,
+    COUNTRY_NAME,
+    CONTINENT_CODE,
+    COUNTRY_ISO_CODE,
+    POSTAL_CODE,
+    REGION_NAME,
+    REGION_CODE,
+    TIMEZONE,
+    LOCATION,
+    LATITUDE,
+    LONGITUDE
 }

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoDataField.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoDataField.java
@@ -1,11 +1,11 @@
 package com.amazon.dataprepper.plugins.prepper.geoip.provider;
 
-public enum Fields {
+public enum GeoDataField {
     IP("ip"),
     CITY_NAME("geo.city_name"),
     COUNTRY_NAME("geo.country_name"),
     CONTINENT_CODE("geo.continent_code"),
-    COUNTRY_CODE2("geo.country_iso_code"),
+    COUNTRY_ISO_CODE("geo.country_iso_code"),
     POSTAL_CODE("geo.postal_code"),
     REGION_NAME("geo.region_name"),
     REGION_CODE("geo.region_code"),
@@ -16,7 +16,7 @@ public enum Fields {
 
     private final String fieldName;
 
-    Fields(String fieldName) {
+    GeoDataField(String fieldName) {
         this.fieldName = fieldName;
     }
 

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoIpProviderFactory.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoIpProviderFactory.java
@@ -15,8 +15,9 @@ public class GeoIpProviderFactory {
         switch (provider) {
             case MaxMindGeolite2CityDatabase:
                 String dbPath = pluginSetting.getStringOrDefault(GeoIpPrepperConfig.DATABASE_PATH, null);
+                String[] desiredFields = (String[]) pluginSetting.getAttributeOrDefault(GeoIpPrepperConfig.DESIRED_FIELDS, null);
                 Objects.requireNonNull(dbPath, "database_path must not be null when provider is MaxMind database");
-                return new MaxMindGeoIpProvider(dbPath);
+                return new MaxMindGeoIpProvider(dbPath, desiredFields);
             default:
                 throw new UnsupportedOperationException(String.format("Unsupported data source: %s", provider));
 

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoIpProviderFactory.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoIpProviderFactory.java
@@ -5,7 +5,10 @@ import com.amazon.dataprepper.plugins.prepper.geoip.GeoIpPrepperConfig;
 
 import java.util.Objects;
 
+
 public class GeoIpProviderFactory {
+    private static final String[] DEFAULT_DESIRED_FIELDS = new String[]{};
+
     public GeoIpProvider createGeoIpProvider(final PluginSetting pluginSetting) {
         Objects.requireNonNull(pluginSetting);
         final String providerString = pluginSetting.getStringOrDefault(GeoIpPrepperConfig.DATA_SOURCE, null);
@@ -15,7 +18,7 @@ public class GeoIpProviderFactory {
         switch (provider) {
             case MaxMindGeolite2CityDatabase:
                 String dbPath = pluginSetting.getStringOrDefault(GeoIpPrepperConfig.DATABASE_PATH, null);
-                String[] desiredFields = (String[]) pluginSetting.getAttributeOrDefault(GeoIpPrepperConfig.DESIRED_FIELDS, null);
+                String[] desiredFields = (String[]) pluginSetting.getAttributeOrDefault(GeoIpPrepperConfig.DESIRED_FIELDS, DEFAULT_DESIRED_FIELDS);
                 Objects.requireNonNull(dbPath, "database_path must not be null when provider is MaxMind database");
                 return new MaxMindGeoIpProvider(dbPath, desiredFields);
             default:

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoIpProviderFactory.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoIpProviderFactory.java
@@ -5,7 +5,6 @@ import com.amazon.dataprepper.plugins.prepper.geoip.GeoIpPrepperConfig;
 
 import java.util.Objects;
 
-
 public class GeoIpProviderFactory {
     private static final String[] DEFAULT_DESIRED_FIELDS = new String[]{};
 

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationData.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationData.java
@@ -1,31 +1,71 @@
 package com.amazon.dataprepper.plugins.prepper.geoip.provider;
 
-
-// This is a first pass of LocationData, simply to make sure lookup correctly passes through data.
-//TODO Find the best way to attach the location data to a document, and modify this class to allow that.
-
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 public class LocationData {
+    private final String ip;
     private final String countryName;
     private final String subdivisionName;
     private final String cityName;
+    private final Map<String, Object> location;
+    private final Double latitude;
+    private final Double longitude;
+    private final String continentCode;
+    private final String countryCode;
+    private final String postalCode;
+    private final String regionCode;
+    private final String timezone;
 
-    public LocationData(String countryName, String subdivisionName, String cityName) {
-        this.countryName = countryName;
-        this.subdivisionName = subdivisionName;
-        this.cityName = cityName;
+    public LocationData(Map<Fields, Object> fields) {
+        ip = (String) fields.get(Fields.IP);
+        countryName = (String) fields.get(Fields.COUNTRY_NAME);
+        subdivisionName = (String) fields.get(Fields.REGION_NAME);
+        cityName = (String) fields.get(Fields.CITY_NAME);
+        Double[] latlon = (Double[]) fields.get(Fields.LOCATION);
+        continentCode = (String) fields.get(Fields.CONTINENT_CODE);
+        countryCode = (String) fields.get(Fields.COUNTRY_CODE2);
+        postalCode = (String) fields.get(Fields.POSTAL_CODE);
+        regionCode = (String) fields.get(Fields.REGION_CODE);
+        timezone = (String) fields.get(Fields.TIMEZONE);
+
+        if (latlon != null && latlon.length == 2) {
+            location = new HashMap<String, Object>() {{
+                put("lat", latlon[0]);
+                put("lon", latlon[1]);
+            }};
+        } else {
+            location = null;
+        }
+        latitude = (Double) fields.get(Fields.LATITUDE);
+        longitude = (Double) fields.get(Fields.LONGITUDE);
     }
 
-    @Override
-    public String toString() {
-        return "LocationData{" +
-                "countryName='" + countryName + '\'' +
-                ", subdivisionName='" + subdivisionName + '\'' +
-                ", cityName='" + cityName + '\'' +
-                '}';
+    public Map<String, Object> toMap() {
+        final Map<String, Object> mapping = new HashMap<>();
+        if (this.countryName != null)
+            mapping.put(Fields.COUNTRY_NAME.fieldName(), this.countryName);
+        if (this.subdivisionName != null)
+            mapping.put(Fields.REGION_NAME.fieldName(), this.subdivisionName);
+        if (this.cityName != null)
+            mapping.put(Fields.CITY_NAME.fieldName(), this.cityName);
+        if (this.location != null)
+            mapping.put(Fields.LOCATION.fieldName(), this.location);
+        if (this.ip != null)
+            mapping.put(Fields.IP.fieldName(), this.ip);
+        if (this.continentCode != null)
+            mapping.put(Fields.CONTINENT_CODE.fieldName(), this.continentCode);
+        if (this.countryCode != null)
+            mapping.put(Fields.COUNTRY_CODE2.fieldName(), this.countryCode);
+        if (this.postalCode != null)
+            mapping.put(Fields.POSTAL_CODE.fieldName(), this.postalCode);
+        if (this.regionCode != null)
+            mapping.put(Fields.REGION_CODE.fieldName(), this.regionCode);
+        if (this.timezone != null)
+            mapping.put(Fields.TIMEZONE.fieldName(), this.timezone);
+        return mapping;
     }
-    //TODO Update this to use ObjectMapper to format the json data.
 
 
     @Override
@@ -33,11 +73,11 @@ public class LocationData {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         LocationData that = (LocationData) o;
-        return Objects.equals(countryName, that.countryName) && Objects.equals(subdivisionName, that.subdivisionName) && Objects.equals(cityName, that.cityName);
+        return Objects.equals(ip, that.ip) && Objects.equals(countryName, that.countryName) && Objects.equals(subdivisionName, that.subdivisionName) && Objects.equals(cityName, that.cityName) && Objects.equals(location, that.location) && Objects.equals(latitude, that.latitude) && Objects.equals(longitude, that.longitude) && Objects.equals(continentCode, that.continentCode) && Objects.equals(countryCode, that.countryCode) && Objects.equals(postalCode, that.postalCode) && Objects.equals(regionCode, that.regionCode) && Objects.equals(timezone, that.timezone);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(countryName, subdivisionName, cityName);
+        return Objects.hash(ip, countryName, subdivisionName, cityName, location, latitude, longitude, continentCode, countryCode, postalCode, regionCode, timezone);
     }
 }

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationData.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationData.java
@@ -44,17 +44,17 @@ public class LocationData {
     @JsonProperty(TIMEZONE_FIELD)
     private final String timeZone;
 
-    public LocationData(Map<GeoDataField, Object> fields) {
-        ip = (String) fields.get(GeoDataField.IP);
-        countryName = (String) fields.get(GeoDataField.COUNTRY_NAME);
-        regionName = (String) fields.get(GeoDataField.REGION_NAME);
-        cityName = (String) fields.get(GeoDataField.CITY_NAME);
-        Double[] latAndLong = (Double[]) fields.get(GeoDataField.LOCATION);
-        continentCode = (String) fields.get(GeoDataField.CONTINENT_CODE);
-        countryCode = (String) fields.get(GeoDataField.COUNTRY_ISO_CODE);
-        postalCode = (String) fields.get(GeoDataField.POSTAL_CODE);
-        regionCode = (String) fields.get(GeoDataField.REGION_CODE);
-        timeZone = (String) fields.get(GeoDataField.TIMEZONE);
+    public LocationData(builder builder) {
+        ip = builder.ip;
+        countryName = builder.countryName;
+        regionName = builder.regionName;
+        cityName = builder.cityName;
+        Double[] latAndLong = builder.location;
+        continentCode = builder.continentCode;
+        countryCode = builder.countryCode;
+        postalCode = builder.postalCode;
+        regionCode = builder.regionCode;
+        timeZone = builder.timeZone;
 
         if (latAndLong != null && latAndLong.length == 2) {
             location = new HashMap<String, Double>() {{
@@ -64,8 +64,8 @@ public class LocationData {
         } else {
             location = null;
         }
-        latitude = (Double) fields.get(GeoDataField.LATITUDE);
-        longitude = (Double) fields.get(GeoDataField.LONGITUDE);
+        latitude = builder.latitude;
+        longitude = builder.longitude;
     }
 
     @Override
@@ -80,4 +80,86 @@ public class LocationData {
     public int hashCode() {
         return Objects.hash(ip, countryName, regionName, cityName, location, latitude, longitude, continentCode, countryCode, postalCode, regionCode, timeZone);
     }
+
+    public static final class builder {
+        private String ip;
+        private String countryName;
+        private String regionName;
+        private String cityName;
+        private Double[] location;
+        private Double latitude;
+        private Double longitude;
+        private String continentCode;
+        private String countryCode;
+        private String postalCode;
+        private String regionCode;
+        private String timeZone;
+
+        public builder withIp(String ip) {
+            this.ip = ip;
+            return this;
+        }
+
+        public builder withCity(String city) {
+            this.cityName = city;
+            return this;
+        }
+
+        public builder withCountry(String country) {
+            this.countryName = country;
+            return this;
+        }
+
+        public builder withContinent(String continent) {
+            this.continentCode = continent;
+            return this;
+        }
+
+        public builder withCountryCode(String countryCode) {
+            this.countryCode = countryCode;
+            return this;
+        }
+
+        public builder withPostal(String postal) {
+            this.postalCode = postal;
+            return this;
+        }
+
+        public builder withRegion(String region) {
+            this.regionName = region;
+            return this;
+        }
+
+        public builder withRegionCode(String regionCode) {
+            this.regionCode = regionCode;
+            return this;
+        }
+
+        public builder withTimeZone(String timeZone) {
+            this.timeZone = timeZone;
+            return this;
+        }
+
+        public builder withLocation(Double[] location) {
+            if (location.length != 2)
+                throw new IllegalArgumentException("location must be an array of length 2 in form [lat, long]");
+            this.location = location;
+            return this;
+        }
+
+        public builder withLatitude(Double latitude) {
+            this.latitude = latitude;
+            return this;
+        }
+
+        public builder withLongitude(Double longitude) {
+            this.longitude = longitude;
+            return this;
+        }
+
+        public LocationData build() {
+            return new LocationData(this);
+        }
+    }
 }
+

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationData.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationData.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Objects;
 
 public class LocationData {
-
     private final String CITY_FIELD = "geo.city_name";
     private final String COUNTRY_FIELD = "geo.country_name";
     private final String CONTINENT_FIELD = "geo.continent_code";
@@ -44,7 +43,7 @@ public class LocationData {
     @JsonProperty(TIMEZONE_FIELD)
     private final String timeZone;
 
-    public LocationData(builder builder) {
+    public LocationData(Builder builder) {
         ip = builder.ip;
         countryName = builder.countryName;
         regionName = builder.regionName;
@@ -81,7 +80,7 @@ public class LocationData {
         return Objects.hash(ip, countryName, regionName, cityName, location, latitude, longitude, continentCode, countryCode, postalCode, regionCode, timeZone);
     }
 
-    public static final class builder {
+    public static final class Builder {
         private String ip;
         private String countryName;
         private String regionName;
@@ -95,64 +94,64 @@ public class LocationData {
         private String regionCode;
         private String timeZone;
 
-        public builder withIp(String ip) {
+        public Builder withIp(String ip) {
             this.ip = ip;
             return this;
         }
 
-        public builder withCity(String city) {
+        public Builder withCity(String city) {
             this.cityName = city;
             return this;
         }
 
-        public builder withCountry(String country) {
+        public Builder withCountry(String country) {
             this.countryName = country;
             return this;
         }
 
-        public builder withContinent(String continent) {
+        public Builder withContinent(String continent) {
             this.continentCode = continent;
             return this;
         }
 
-        public builder withCountryCode(String countryCode) {
+        public Builder withCountryCode(String countryCode) {
             this.countryCode = countryCode;
             return this;
         }
 
-        public builder withPostal(String postal) {
+        public Builder withPostal(String postal) {
             this.postalCode = postal;
             return this;
         }
 
-        public builder withRegion(String region) {
+        public Builder withRegion(String region) {
             this.regionName = region;
             return this;
         }
 
-        public builder withRegionCode(String regionCode) {
+        public Builder withRegionCode(String regionCode) {
             this.regionCode = regionCode;
             return this;
         }
 
-        public builder withTimeZone(String timeZone) {
+        public Builder withTimeZone(String timeZone) {
             this.timeZone = timeZone;
             return this;
         }
 
-        public builder withLocation(Double[] location) {
+        public Builder withLocation(Double[] location) {
             if (location.length != 2)
                 throw new IllegalArgumentException("location must be an array of length 2 in form [lat, long]");
             this.location = location;
             return this;
         }
 
-        public builder withLatitude(Double latitude) {
+        public Builder withLatitude(Double latitude) {
             this.latitude = latitude;
             return this;
         }
 
-        public builder withLongitude(Double longitude) {
+        public Builder withLongitude(Double longitude) {
             this.longitude = longitude;
             return this;
         }

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationData.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationData.java
@@ -8,10 +8,10 @@ import java.util.Objects;
 
 public class LocationData {
     private final String CITY_FIELD = "geo.city_name";
-    private final String COUNTRY_FIELD = "geo.country_name";
+    private final String COUNTRY_NAME_FIELD = "geo.country_name";
     private final String CONTINENT_FIELD = "geo.continent_code";
     private final String COUNTRY_ISO_FIELD = "geo.country_iso_code";
-    private final String POSTAL_FIELD = "geo.postal_code";
+    private final String POSTAL_CODE_FIELD = "geo.postal_code";
     private final String REGION_FIELD = "geo.region_name";
     private final String REGION_CODE_FIELD = "geo.region_code";
     private final String TIMEZONE_FIELD = "geo.timezone";
@@ -20,7 +20,7 @@ public class LocationData {
     private final String LONGITUDE_FIELD = "geo.location.lon";
     private final String ip;
 
-    @JsonProperty(COUNTRY_FIELD)
+    @JsonProperty(COUNTRY_NAME_FIELD)
     private final String countryName;
     @JsonProperty(REGION_FIELD)
     private final String regionName;
@@ -36,14 +36,14 @@ public class LocationData {
     private final String continentCode;
     @JsonProperty(COUNTRY_ISO_FIELD)
     private final String countryCode;
-    @JsonProperty(POSTAL_FIELD)
+    @JsonProperty(POSTAL_CODE_FIELD)
     private final String postalCode;
     @JsonProperty(REGION_CODE_FIELD)
     private final String regionCode;
     @JsonProperty(TIMEZONE_FIELD)
     private final String timeZone;
 
-    public LocationData(Builder builder) {
+    private LocationData(Builder builder) {
         ip = builder.ip;
         countryName = builder.countryName;
         regionName = builder.regionName;
@@ -54,11 +54,16 @@ public class LocationData {
         postalCode = builder.postalCode;
         regionCode = builder.regionCode;
         timeZone = builder.timeZone;
-
+        //TODO Investigate how location is seen in ElasticSearch and determine the best way to store the Lat/Lon point
         if (latAndLong != null && latAndLong.length == 2) {
             location = new HashMap<String, Double>() {{
                 put("lat", latAndLong[0]);
                 put("lon", latAndLong[1]);
+            }};
+        } else if ((builder.latitude != null) && (builder.longitude != null)){
+            location = new HashMap<String, Double>() {{
+                put("lat", builder.latitude);
+                put("lon", builder.longitude);
             }};
         } else {
             location = null;
@@ -72,12 +77,34 @@ public class LocationData {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         LocationData that = (LocationData) o;
-        return Objects.equals(ip, that.ip) && Objects.equals(countryName, that.countryName) && Objects.equals(regionName, that.regionName) && Objects.equals(cityName, that.cityName) && Objects.equals(location, that.location) && Objects.equals(latitude, that.latitude) && Objects.equals(longitude, that.longitude) && Objects.equals(continentCode, that.continentCode) && Objects.equals(countryCode, that.countryCode) && Objects.equals(postalCode, that.postalCode) && Objects.equals(regionCode, that.regionCode) && Objects.equals(timeZone, that.timeZone);
+        return Objects.equals(ip, that.ip)
+                && Objects.equals(countryName, that.countryName)
+                && Objects.equals(regionName, that.regionName)
+                && Objects.equals(cityName, that.cityName)
+                && Objects.equals(location, that.location)
+                && Objects.equals(latitude, that.latitude)
+                && Objects.equals(longitude, that.longitude)
+                && Objects.equals(continentCode, that.continentCode)
+                && Objects.equals(countryCode, that.countryCode)
+                && Objects.equals(postalCode, that.postalCode)
+                && Objects.equals(regionCode, that.regionCode)
+                && Objects.equals(timeZone, that.timeZone);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ip, countryName, regionName, cityName, location, latitude, longitude, continentCode, countryCode, postalCode, regionCode, timeZone);
+        return Objects.hash(ip,
+                countryName,
+                regionName,
+                cityName,
+                location,
+                latitude,
+                longitude,
+                continentCode,
+                countryCode,
+                postalCode,
+                regionCode,
+                timeZone);
     }
 
     public static final class Builder {
@@ -99,13 +126,13 @@ public class LocationData {
             return this;
         }
 
-        public Builder withCity(String city) {
+        public Builder withCityName(String city) {
             this.cityName = city;
             return this;
         }
 
-        public Builder withCountry(String country) {
-            this.countryName = country;
+        public Builder withCountry(String countryName) {
+            this.countryName = countryName;
             return this;
         }
 

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationData.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationData.java
@@ -12,7 +12,7 @@ public class LocationData {
     private final String CONTINENT_FIELD = "geo.continent_code";
     private final String COUNTRY_ISO_FIELD = "geo.country_iso_code";
     private final String POSTAL_CODE_FIELD = "geo.postal_code";
-    private final String REGION_FIELD = "geo.region_name";
+    private final String REGION_NAME_FIELD = "geo.region_name";
     private final String REGION_CODE_FIELD = "geo.region_code";
     private final String TIMEZONE_FIELD = "geo.timezone";
     private final String LOCATION_FIELD = "geo.location";
@@ -22,7 +22,7 @@ public class LocationData {
 
     @JsonProperty(COUNTRY_NAME_FIELD)
     private final String countryName;
-    @JsonProperty(REGION_FIELD)
+    @JsonProperty(REGION_NAME_FIELD)
     private final String regionName;
     @JsonProperty(CITY_FIELD)
     private final String cityName;
@@ -146,13 +146,13 @@ public class LocationData {
             return this;
         }
 
-        public Builder withPostal(String postal) {
-            this.postalCode = postal;
+        public Builder withPostalCode(String postalCode) {
+            this.postalCode = postalCode;
             return this;
         }
 
-        public Builder withRegion(String region) {
-            this.regionName = region;
+        public Builder withRegionName(String regionName) {
+            this.regionName = regionName;
             return this;
         }
 
@@ -167,8 +167,9 @@ public class LocationData {
         }
 
         public Builder withLocation(Double[] location) {
-            if (location.length != 2)
+            if (location.length != 2) {
                 throw new IllegalArgumentException("location must be an array of length 2 in form [lat, long]");
+            }
             this.location = location;
             return this;
         }

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationData.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationData.java
@@ -1,83 +1,83 @@
 package com.amazon.dataprepper.plugins.prepper.geoip.provider;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
 public class LocationData {
+
+    private final String CITY_FIELD = "geo.city_name";
+    private final String COUNTRY_FIELD = "geo.country_name";
+    private final String CONTINENT_FIELD = "geo.continent_code";
+    private final String COUNTRY_ISO_FIELD = "geo.country_iso_code";
+    private final String POSTAL_FIELD = "geo.postal_code";
+    private final String REGION_FIELD = "geo.region_name";
+    private final String REGION_CODE_FIELD = "geo.region_code";
+    private final String TIMEZONE_FIELD = "geo.timezone";
+    private final String LOCATION_FIELD = "geo.location";
+    private final String LATITUDE_FIELD = "geo.location.lat";
+    private final String LONGITUDE_FIELD = "geo.location.lon";
     private final String ip;
+
+    @JsonProperty(COUNTRY_FIELD)
     private final String countryName;
-    private final String subdivisionName;
+    @JsonProperty(REGION_FIELD)
+    private final String regionName;
+    @JsonProperty(CITY_FIELD)
     private final String cityName;
-    private final Map<String, Object> location;
+    @JsonProperty(LOCATION_FIELD)
+    private final Map<String, Double> location;
+    @JsonProperty(LATITUDE_FIELD)
     private final Double latitude;
+    @JsonProperty(LONGITUDE_FIELD)
     private final Double longitude;
+    @JsonProperty(CONTINENT_FIELD)
     private final String continentCode;
+    @JsonProperty(COUNTRY_ISO_FIELD)
     private final String countryCode;
+    @JsonProperty(POSTAL_FIELD)
     private final String postalCode;
+    @JsonProperty(REGION_CODE_FIELD)
     private final String regionCode;
-    private final String timezone;
+    @JsonProperty(TIMEZONE_FIELD)
+    private final String timeZone;
 
-    public LocationData(Map<Fields, Object> fields) {
-        ip = (String) fields.get(Fields.IP);
-        countryName = (String) fields.get(Fields.COUNTRY_NAME);
-        subdivisionName = (String) fields.get(Fields.REGION_NAME);
-        cityName = (String) fields.get(Fields.CITY_NAME);
-        Double[] latlon = (Double[]) fields.get(Fields.LOCATION);
-        continentCode = (String) fields.get(Fields.CONTINENT_CODE);
-        countryCode = (String) fields.get(Fields.COUNTRY_CODE2);
-        postalCode = (String) fields.get(Fields.POSTAL_CODE);
-        regionCode = (String) fields.get(Fields.REGION_CODE);
-        timezone = (String) fields.get(Fields.TIMEZONE);
+    public LocationData(Map<GeoDataField, Object> fields) {
+        ip = (String) fields.get(GeoDataField.IP);
+        countryName = (String) fields.get(GeoDataField.COUNTRY_NAME);
+        regionName = (String) fields.get(GeoDataField.REGION_NAME);
+        cityName = (String) fields.get(GeoDataField.CITY_NAME);
+        Double[] latAndLong = (Double[]) fields.get(GeoDataField.LOCATION);
+        continentCode = (String) fields.get(GeoDataField.CONTINENT_CODE);
+        countryCode = (String) fields.get(GeoDataField.COUNTRY_ISO_CODE);
+        postalCode = (String) fields.get(GeoDataField.POSTAL_CODE);
+        regionCode = (String) fields.get(GeoDataField.REGION_CODE);
+        timeZone = (String) fields.get(GeoDataField.TIMEZONE);
 
-        if (latlon != null && latlon.length == 2) {
-            location = new HashMap<String, Object>() {{
-                put("lat", latlon[0]);
-                put("lon", latlon[1]);
+        if (latAndLong != null && latAndLong.length == 2) {
+            location = new HashMap<String, Double>() {{
+                put("lat", latAndLong[0]);
+                put("lon", latAndLong[1]);
             }};
         } else {
             location = null;
         }
-        latitude = (Double) fields.get(Fields.LATITUDE);
-        longitude = (Double) fields.get(Fields.LONGITUDE);
+        latitude = (Double) fields.get(GeoDataField.LATITUDE);
+        longitude = (Double) fields.get(GeoDataField.LONGITUDE);
     }
-
-    public Map<String, Object> toMap() {
-        final Map<String, Object> mapping = new HashMap<>();
-        if (this.countryName != null)
-            mapping.put(Fields.COUNTRY_NAME.fieldName(), this.countryName);
-        if (this.subdivisionName != null)
-            mapping.put(Fields.REGION_NAME.fieldName(), this.subdivisionName);
-        if (this.cityName != null)
-            mapping.put(Fields.CITY_NAME.fieldName(), this.cityName);
-        if (this.location != null)
-            mapping.put(Fields.LOCATION.fieldName(), this.location);
-        if (this.ip != null)
-            mapping.put(Fields.IP.fieldName(), this.ip);
-        if (this.continentCode != null)
-            mapping.put(Fields.CONTINENT_CODE.fieldName(), this.continentCode);
-        if (this.countryCode != null)
-            mapping.put(Fields.COUNTRY_CODE2.fieldName(), this.countryCode);
-        if (this.postalCode != null)
-            mapping.put(Fields.POSTAL_CODE.fieldName(), this.postalCode);
-        if (this.regionCode != null)
-            mapping.put(Fields.REGION_CODE.fieldName(), this.regionCode);
-        if (this.timezone != null)
-            mapping.put(Fields.TIMEZONE.fieldName(), this.timezone);
-        return mapping;
-    }
-
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         LocationData that = (LocationData) o;
-        return Objects.equals(ip, that.ip) && Objects.equals(countryName, that.countryName) && Objects.equals(subdivisionName, that.subdivisionName) && Objects.equals(cityName, that.cityName) && Objects.equals(location, that.location) && Objects.equals(latitude, that.latitude) && Objects.equals(longitude, that.longitude) && Objects.equals(continentCode, that.continentCode) && Objects.equals(countryCode, that.countryCode) && Objects.equals(postalCode, that.postalCode) && Objects.equals(regionCode, that.regionCode) && Objects.equals(timezone, that.timezone);
+        return Objects.equals(ip, that.ip) && Objects.equals(countryName, that.countryName) && Objects.equals(regionName, that.regionName) && Objects.equals(cityName, that.cityName) && Objects.equals(location, that.location) && Objects.equals(latitude, that.latitude) && Objects.equals(longitude, that.longitude) && Objects.equals(continentCode, that.continentCode) && Objects.equals(countryCode, that.countryCode) && Objects.equals(postalCode, that.postalCode) && Objects.equals(regionCode, that.regionCode) && Objects.equals(timeZone, that.timeZone);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ip, countryName, subdivisionName, cityName, location, latitude, longitude, continentCode, countryCode, postalCode, regionCode, timezone);
+        return Objects.hash(ip, countryName, regionName, cityName, location, latitude, longitude, continentCode, countryCode, postalCode, regionCode, timeZone);
     }
 }

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProvider.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProvider.java
@@ -8,7 +8,10 @@ import com.maxmind.geoip2.exception.AddressNotFoundException;
 import com.maxmind.geoip2.exception.GeoIp2Exception;
 import com.maxmind.geoip2.model.CityResponse;
 import com.maxmind.geoip2.record.City;
+import com.maxmind.geoip2.record.Continent;
 import com.maxmind.geoip2.record.Country;
+import com.maxmind.geoip2.record.Location;
+import com.maxmind.geoip2.record.Postal;
 import com.maxmind.geoip2.record.Subdivision;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +20,11 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -24,11 +32,26 @@ import java.util.Optional;
 public class MaxMindGeoIpProvider implements GeoIpProvider {
     private static final Logger LOG = LoggerFactory.getLogger(MaxMindGeoIpProvider.class);
     private final DatabaseReader databaseReader;
+    private ArrayList<Fields> fieldsToAdd = new ArrayList<>();
 
-    public MaxMindGeoIpProvider(String databasePath) {
-
+    public MaxMindGeoIpProvider(String databasePath, String[] desiredFields) {
         Objects.requireNonNull(databasePath, String.format("Missing '%s' configuration value", GeoIpPrepperConfig.DATABASE_PATH));
         File database = new File(databasePath);
+        if (desiredFields != null && desiredFields.length > 0) {
+            for (String desiredField : desiredFields) {
+                try {
+                    Fields field = Fields.valueOf(desiredField.toUpperCase(Locale.ROOT));
+                    fieldsToAdd.add(field);
+                } catch (Exception e) {
+                    LOG.error("Invalid field in config settings, {}", desiredField);
+                }
+            }
+        } else {
+            fieldsToAdd = new ArrayList<>(Arrays.asList(Fields.IP, Fields.CITY_NAME,
+                    Fields.CONTINENT_CODE, Fields.COUNTRY_NAME, Fields.COUNTRY_CODE2,
+                    Fields.IP, Fields.POSTAL_CODE, Fields.REGION_NAME,
+                    Fields.REGION_CODE, Fields.TIMEZONE, Fields.LOCATION, Fields.LATITUDE, Fields.LONGITUDE));
+        }
         try {
             databaseReader = new DatabaseReader.Builder(database).withCache(new CHMCache()).build();
         } catch (InvalidDatabaseException e) {
@@ -43,11 +66,89 @@ public class MaxMindGeoIpProvider implements GeoIpProvider {
         try {
             final InetAddress ipAddress = InetAddress.getByName(IpAddress);
             final CityResponse response = databaseReader.city(ipAddress);
-            //TODO change what kind of data is returned, allowing users to submit desired fields, etc.
             final Country country = response.getCountry();
             final Subdivision subdivision = response.getMostSpecificSubdivision();
             final City city = response.getCity();
-            final LocationData returnData = new LocationData(country.getName(), subdivision.getName(), city.getName());
+            final Location location = response.getLocation();
+            final Continent continent = response.getContinent();
+            final Postal postal = response.getPostal();
+            Map<Fields, Object> locationDetails = new HashMap<>();
+
+            for (Fields desiredField : this.fieldsToAdd) {
+                switch (desiredField) {
+                    case IP:
+                        locationDetails.put(Fields.IP, ipAddress.getHostAddress());
+                        break;
+                    case CITY_NAME:
+                        String cityName = city.getName();
+                        if (cityName != null) {
+                            locationDetails.put(Fields.CITY_NAME, cityName);
+                        }
+                        break;
+                    case REGION_NAME:
+                        String subdivisionName = subdivision.getName();
+                        if (subdivisionName != null) {
+                            locationDetails.put(Fields.REGION_NAME, subdivisionName);
+                        }
+                        break;
+                    case COUNTRY_NAME:
+                        String countryName = country.getName();
+                        if (countryName != null) {
+                            locationDetails.put(Fields.COUNTRY_NAME, countryName);
+                        }
+                        break;
+                    case CONTINENT_CODE:
+                        String continentCode = continent.getCode();
+                        if (continentCode != null) {
+                            locationDetails.put(Fields.CONTINENT_CODE, continentCode);
+                        }
+                        break;
+                    case COUNTRY_CODE2:
+                        String countryCode2 = country.getIsoCode();
+                        if (countryCode2 != null) {
+                            locationDetails.put(Fields.COUNTRY_CODE2, countryCode2);
+                        }
+                        break;
+                    case REGION_CODE:
+                        String subdivisionCode = subdivision.getIsoCode();
+                        if (subdivisionCode != null) {
+                            locationDetails.put(Fields.REGION_CODE, subdivisionCode);
+                        }
+                        break;
+                    case POSTAL_CODE:
+                        String postalCode = postal.getCode();
+                        if (postalCode != null) {
+                            locationDetails.put(Fields.POSTAL_CODE, postalCode);
+                        }
+                        break;
+                    case TIMEZONE:
+                        String locationTimeZone = location.getTimeZone();
+                        if (locationTimeZone != null) {
+                            locationDetails.put(Fields.TIMEZONE, locationTimeZone);
+                        }
+                        break;
+                    case LOCATION:
+                        Double latitude = location.getLatitude();
+                        Double longitude = location.getLongitude();
+                        if (latitude != null && longitude != null) {
+                            locationDetails.put(Fields.LOCATION, new Double[]{latitude, longitude});
+                        }
+                        break;
+                    case LATITUDE:
+                        Double lat = location.getLatitude();
+                        if (lat != null) {
+                            locationDetails.put(Fields.LATITUDE, lat);
+                        }
+                        break;
+                    case LONGITUDE:
+                        Double lon = location.getLongitude();
+                        if (lon != null) {
+                            locationDetails.put(Fields.LONGITUDE, lon);
+                        }
+                        break;
+                }
+            }
+            final LocationData returnData = new LocationData(locationDetails);
             return Optional.of(returnData);
         } catch (UnknownHostException e) {
             LOG.info("IP Field contained invalid IP address or hostname.", e);

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProvider.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProvider.java
@@ -22,9 +22,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -69,83 +67,82 @@ public class MaxMindGeoIpProvider implements GeoIpProvider {
             final Location location = response.getLocation();
             final Continent continent = response.getContinent();
             final Postal postal = response.getPostal();
-            Map<GeoDataField, Object> locationDetails = new HashMap<>();
-
+            final LocationData.builder builder = new LocationData.builder();
             for (GeoDataField desiredField : this.fieldsToAdd) {
                 switch (desiredField) {
                     case IP:
-                        locationDetails.put(GeoDataField.IP, ipAddress.getHostAddress());
+                        builder.withIp(ipAddress.getHostAddress());
                         break;
                     case CITY_NAME:
                         String cityName = city.getName();
                         if (cityName != null) {
-                            locationDetails.put(GeoDataField.CITY_NAME, cityName);
+                            builder.withCity(cityName);
                         }
                         break;
                     case REGION_NAME:
                         String subdivisionName = subdivision.getName();
                         if (subdivisionName != null) {
-                            locationDetails.put(GeoDataField.REGION_NAME, subdivisionName);
+                            builder.withRegion(subdivisionName);
                         }
                         break;
                     case COUNTRY_NAME:
                         String countryName = country.getName();
                         if (countryName != null) {
-                            locationDetails.put(GeoDataField.COUNTRY_NAME, countryName);
+                            builder.withCountry(countryName);
                         }
                         break;
                     case CONTINENT_CODE:
                         String continentCode = continent.getCode();
                         if (continentCode != null) {
-                            locationDetails.put(GeoDataField.CONTINENT_CODE, continentCode);
+                            builder.withContinent(continentCode);
                         }
                         break;
                     case COUNTRY_ISO_CODE:
-                        String countryCode2 = country.getIsoCode();
-                        if (countryCode2 != null) {
-                            locationDetails.put(GeoDataField.COUNTRY_ISO_CODE, countryCode2);
+                        String countryIso = country.getIsoCode();
+                        if (countryIso != null) {
+                            builder.withCountryCode(countryIso);
                         }
                         break;
                     case REGION_CODE:
-                        String subdivisionCode = subdivision.getIsoCode();
-                        if (subdivisionCode != null) {
-                            locationDetails.put(GeoDataField.REGION_CODE, subdivisionCode);
+                        String regionCode = subdivision.getIsoCode();
+                        if (regionCode != null) {
+                            builder.withRegionCode(regionCode);
                         }
                         break;
                     case POSTAL_CODE:
                         String postalCode = postal.getCode();
                         if (postalCode != null) {
-                            locationDetails.put(GeoDataField.POSTAL_CODE, postalCode);
+                            builder.withPostal(postalCode);
                         }
                         break;
                     case TIMEZONE:
                         String locationTimeZone = location.getTimeZone();
                         if (locationTimeZone != null) {
-                            locationDetails.put(GeoDataField.TIMEZONE, locationTimeZone);
+                            builder.withTimeZone(locationTimeZone);
                         }
                         break;
                     case LOCATION:
                         Double latitude = location.getLatitude();
                         Double longitude = location.getLongitude();
                         if (latitude != null && longitude != null) {
-                            locationDetails.put(GeoDataField.LOCATION, new Double[]{latitude, longitude});
+                            builder.withLocation(new Double[]{latitude, longitude});
                         }
                         break;
                     case LATITUDE:
                         Double lat = location.getLatitude();
                         if (lat != null) {
-                            locationDetails.put(GeoDataField.LATITUDE, lat);
+                            builder.withLatitude(lat);
                         }
                         break;
                     case LONGITUDE:
                         Double lon = location.getLongitude();
                         if (lon != null) {
-                            locationDetails.put(GeoDataField.LONGITUDE, lon);
+                            builder.withLongitude(lon);
                         }
                         break;
                 }
             }
-            final LocationData returnData = new LocationData(locationDetails);
+            final LocationData returnData = builder.build();
             return Optional.of(returnData);
         } catch (UnknownHostException e) {
             LOG.info("IP Field contained invalid IP address or hostname.", e);

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProvider.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProvider.java
@@ -68,77 +68,43 @@ public class MaxMindGeoIpProvider implements GeoIpProvider {
             final Continent continent = response.getContinent();
             final Postal postal = response.getPostal();
             final LocationData.Builder builder = new LocationData.Builder();
-            for (GeoDataField desiredField : this.fieldsToAdd) {
+            for (GeoDataField desiredField : fieldsToAdd) {
                 switch (desiredField) {
                     case IP:
                         builder.withIp(ipAddress.getHostAddress());
                         break;
                     case CITY_NAME:
-                        String cityName = city.getName();
-                        if (cityName != null) {
-                            builder.withCity(cityName);
-                        }
+                        builder.withCityName(city.getName());
                         break;
                     case REGION_NAME:
-                        String subdivisionName = subdivision.getName();
-                        if (subdivisionName != null) {
-                            builder.withRegion(subdivisionName);
-                        }
+                        builder.withRegion(subdivision.getName());
                         break;
                     case COUNTRY_NAME:
-                        String countryName = country.getName();
-                        if (countryName != null) {
-                            builder.withCountry(countryName);
-                        }
+                        builder.withCountry(country.getName());
                         break;
                     case CONTINENT_CODE:
-                        String continentCode = continent.getCode();
-                        if (continentCode != null) {
-                            builder.withContinent(continentCode);
-                        }
+                        builder.withContinent(continent.getCode());
                         break;
                     case COUNTRY_ISO_CODE:
-                        String countryIso = country.getIsoCode();
-                        if (countryIso != null) {
-                            builder.withCountryCode(countryIso);
-                        }
+                        builder.withCountryCode(country.getIsoCode());
                         break;
                     case REGION_CODE:
-                        String regionCode = subdivision.getIsoCode();
-                        if (regionCode != null) {
-                            builder.withRegionCode(regionCode);
-                        }
+                        builder.withRegionCode(subdivision.getIsoCode());
                         break;
                     case POSTAL_CODE:
-                        String postalCode = postal.getCode();
-                        if (postalCode != null) {
-                            builder.withPostal(postalCode);
-                        }
+                        builder.withPostal(postal.getCode());
                         break;
                     case TIMEZONE:
-                        String locationTimeZone = location.getTimeZone();
-                        if (locationTimeZone != null) {
-                            builder.withTimeZone(locationTimeZone);
-                        }
+                        builder.withTimeZone(location.getTimeZone());
                         break;
                     case LOCATION:
-                        Double latitude = location.getLatitude();
-                        Double longitude = location.getLongitude();
-                        if (latitude != null && longitude != null) {
-                            builder.withLocation(new Double[]{latitude, longitude});
-                        }
+                        builder.withLocation(new Double[]{location.getLatitude(), location.getLongitude()});
                         break;
                     case LATITUDE:
-                        Double lat = location.getLatitude();
-                        if (lat != null) {
-                            builder.withLatitude(lat);
-                        }
+                        builder.withLatitude(location.getLatitude());
                         break;
                     case LONGITUDE:
-                        Double lon = location.getLongitude();
-                        if (lon != null) {
-                            builder.withLongitude(lon);
-                        }
+                        builder.withLongitude(location.getLongitude());
                         break;
                 }
             }

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProvider.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProvider.java
@@ -67,7 +67,7 @@ public class MaxMindGeoIpProvider implements GeoIpProvider {
             final Location location = response.getLocation();
             final Continent continent = response.getContinent();
             final Postal postal = response.getPostal();
-            final LocationData.builder builder = new LocationData.builder();
+            final LocationData.Builder builder = new LocationData.Builder();
             for (GeoDataField desiredField : this.fieldsToAdd) {
                 switch (desiredField) {
                     case IP:

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProvider.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProvider.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 public class MaxMindGeoIpProvider implements GeoIpProvider {
     private static final Logger LOG = LoggerFactory.getLogger(MaxMindGeoIpProvider.class);
     private final DatabaseReader databaseReader;
-    private ArrayList<Fields> fieldsToAdd = new ArrayList<>();
+    private ArrayList<GeoDataField> fieldsToAdd = new ArrayList<>();
 
     public MaxMindGeoIpProvider(String databasePath, String[] desiredFields) {
         Objects.requireNonNull(databasePath, String.format("Missing '%s' configuration value", GeoIpPrepperConfig.DATABASE_PATH));
@@ -40,17 +40,14 @@ public class MaxMindGeoIpProvider implements GeoIpProvider {
         if (desiredFields != null && desiredFields.length > 0) {
             for (String desiredField : desiredFields) {
                 try {
-                    Fields field = Fields.valueOf(desiredField.toUpperCase(Locale.ROOT));
+                    GeoDataField field = GeoDataField.valueOf(desiredField.toUpperCase(Locale.ROOT));
                     fieldsToAdd.add(field);
                 } catch (Exception e) {
                     LOG.error("Invalid field in config settings, {}", desiredField);
                 }
             }
         } else {
-            fieldsToAdd = new ArrayList<>(Arrays.asList(Fields.IP, Fields.CITY_NAME,
-                    Fields.CONTINENT_CODE, Fields.COUNTRY_NAME, Fields.COUNTRY_CODE2,
-                    Fields.IP, Fields.POSTAL_CODE, Fields.REGION_NAME,
-                    Fields.REGION_CODE, Fields.TIMEZONE, Fields.LOCATION, Fields.LATITUDE, Fields.LONGITUDE));
+            fieldsToAdd = new ArrayList<>(Arrays.asList(GeoDataField.values()));
         }
         try {
             databaseReader = new DatabaseReader.Builder(database).withCache(new CHMCache()).build();
@@ -72,78 +69,78 @@ public class MaxMindGeoIpProvider implements GeoIpProvider {
             final Location location = response.getLocation();
             final Continent continent = response.getContinent();
             final Postal postal = response.getPostal();
-            Map<Fields, Object> locationDetails = new HashMap<>();
+            Map<GeoDataField, Object> locationDetails = new HashMap<>();
 
-            for (Fields desiredField : this.fieldsToAdd) {
+            for (GeoDataField desiredField : this.fieldsToAdd) {
                 switch (desiredField) {
                     case IP:
-                        locationDetails.put(Fields.IP, ipAddress.getHostAddress());
+                        locationDetails.put(GeoDataField.IP, ipAddress.getHostAddress());
                         break;
                     case CITY_NAME:
                         String cityName = city.getName();
                         if (cityName != null) {
-                            locationDetails.put(Fields.CITY_NAME, cityName);
+                            locationDetails.put(GeoDataField.CITY_NAME, cityName);
                         }
                         break;
                     case REGION_NAME:
                         String subdivisionName = subdivision.getName();
                         if (subdivisionName != null) {
-                            locationDetails.put(Fields.REGION_NAME, subdivisionName);
+                            locationDetails.put(GeoDataField.REGION_NAME, subdivisionName);
                         }
                         break;
                     case COUNTRY_NAME:
                         String countryName = country.getName();
                         if (countryName != null) {
-                            locationDetails.put(Fields.COUNTRY_NAME, countryName);
+                            locationDetails.put(GeoDataField.COUNTRY_NAME, countryName);
                         }
                         break;
                     case CONTINENT_CODE:
                         String continentCode = continent.getCode();
                         if (continentCode != null) {
-                            locationDetails.put(Fields.CONTINENT_CODE, continentCode);
+                            locationDetails.put(GeoDataField.CONTINENT_CODE, continentCode);
                         }
                         break;
-                    case COUNTRY_CODE2:
+                    case COUNTRY_ISO_CODE:
                         String countryCode2 = country.getIsoCode();
                         if (countryCode2 != null) {
-                            locationDetails.put(Fields.COUNTRY_CODE2, countryCode2);
+                            locationDetails.put(GeoDataField.COUNTRY_ISO_CODE, countryCode2);
                         }
                         break;
                     case REGION_CODE:
                         String subdivisionCode = subdivision.getIsoCode();
                         if (subdivisionCode != null) {
-                            locationDetails.put(Fields.REGION_CODE, subdivisionCode);
+                            locationDetails.put(GeoDataField.REGION_CODE, subdivisionCode);
                         }
                         break;
                     case POSTAL_CODE:
                         String postalCode = postal.getCode();
                         if (postalCode != null) {
-                            locationDetails.put(Fields.POSTAL_CODE, postalCode);
+                            locationDetails.put(GeoDataField.POSTAL_CODE, postalCode);
                         }
                         break;
                     case TIMEZONE:
                         String locationTimeZone = location.getTimeZone();
                         if (locationTimeZone != null) {
-                            locationDetails.put(Fields.TIMEZONE, locationTimeZone);
+                            locationDetails.put(GeoDataField.TIMEZONE, locationTimeZone);
                         }
                         break;
                     case LOCATION:
                         Double latitude = location.getLatitude();
                         Double longitude = location.getLongitude();
                         if (latitude != null && longitude != null) {
-                            locationDetails.put(Fields.LOCATION, new Double[]{latitude, longitude});
+                            locationDetails.put(GeoDataField.LOCATION, new Double[]{latitude, longitude});
                         }
                         break;
                     case LATITUDE:
                         Double lat = location.getLatitude();
                         if (lat != null) {
-                            locationDetails.put(Fields.LATITUDE, lat);
+                            locationDetails.put(GeoDataField.LATITUDE, lat);
                         }
                         break;
                     case LONGITUDE:
                         Double lon = location.getLongitude();
                         if (lon != null) {
-                            locationDetails.put(Fields.LONGITUDE, lon);
+                            locationDetails.put(GeoDataField.LONGITUDE, lon);
                         }
                         break;
                 }

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepperTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepperTest.java
@@ -2,6 +2,7 @@ package com.amazon.dataprepper.plugins.prepper.geoip;
 
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
+import com.amazon.dataprepper.plugins.prepper.geoip.provider.Fields;
 import com.amazon.dataprepper.plugins.prepper.geoip.provider.GeoIpProvider;
 import com.amazon.dataprepper.plugins.prepper.geoip.provider.LocationData;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -40,13 +41,21 @@ public class GeoIpPrepperTest {
     private static final String TEST_SPAN_TARGET_FIELD = "resource.attributes.client@ip";
     private static final String TEST_SPAN_BAD_TARGET_FIELD = "doesnt.exist.client@ip";
     private static final String TEST_LOCATION_FIELD_NAME = "locationData";
-    private static final LocationData TEST_LOCATION_DATA = new LocationData("United Kingdom", "West Berkshire", "Boxford");
+    private static final String[] TEST_DESIRED_FIELDS = {"city_name", "country_name", "region_name"};
+
+
+    private static final LocationData TEST_LOCATION_DATA = new LocationData(new HashMap<Fields, Object>() {{
+        put(Fields.COUNTRY_NAME, "United Kingdom");
+        put(Fields.REGION_NAME, "West Berkshire");
+        put(Fields.CITY_NAME, "Boxford");
+    }});
     final PluginSetting testPluginSetting = new PluginSetting(
             PLUGIN_NAME,
             new HashMap<String, Object>() {{
                 put(GeoIpPrepperConfig.DATABASE_PATH, TEST_DATABASE_PATH);
                 put(GeoIpPrepperConfig.TARGET_FIELD, TEST_SPAN_TARGET_FIELD);
                 put(GeoIpPrepperConfig.DATA_SOURCE, PROVIDER_TYPE);
+                put(GeoIpPrepperConfig.DESIRED_FIELDS, TEST_DESIRED_FIELDS);
 
             }}
     ) {{
@@ -85,7 +94,9 @@ public class GeoIpPrepperTest {
         Record<String> recordOut = recordsOut.get(0);
         Map<String, Object> rawSpanMap = OBJECT_MAPPER.readValue(recordOut.getData(), new TypeReference<Map<String, Object>>() {
         });
-        Assertions.assertEquals(TEST_LOCATION_DATA.toString(), rawSpanMap.get(TEST_LOCATION_FIELD_NAME));
+        Assertions.assertEquals(TEST_LOCATION_DATA.toMap().get(Fields.CITY_NAME.fieldName()), rawSpanMap.get(Fields.CITY_NAME.fieldName()));
+        Assertions.assertEquals(TEST_LOCATION_DATA.toMap().get(Fields.REGION_NAME.fieldName()), rawSpanMap.get(Fields.REGION_NAME.fieldName()));
+        Assertions.assertEquals(TEST_LOCATION_DATA.toMap().get(Fields.COUNTRY_NAME.fieldName()), rawSpanMap.get(Fields.COUNTRY_NAME.fieldName()));
     }
 
     @Test

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepperTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepperTest.java
@@ -47,7 +47,7 @@ public class GeoIpPrepperTest {
 
     private static final String[] TEST_DESIRED_FIELDS = {CITY_NAME_FIELD, COUNTRY_NAME_FIELD, REGION_NAME_FIELD};
     private static final LocationData TEST_LOCATION_DATA = new LocationData.Builder().withCountry("United Kingdom")
-            .withRegion("West Berkshire").withCityName("Boxford").build();
+            .withRegionName("West Berkshire").withCityName("Boxford").build();
     final PluginSetting testPluginSetting = new PluginSetting(
             PLUGIN_NAME,
             new HashMap<String, Object>() {{

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepperTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepperTest.java
@@ -32,8 +32,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class GeoIpPrepperTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {
-    };
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {};
     private static final String TEST_PIPELINE_NAME = "testPipelineName";
     private static final String PLUGIN_NAME = "geoip_prepper";
     private static final String PROVIDER_TYPE = "MaxMindGeolite2CityDatabase";
@@ -44,10 +43,8 @@ public class GeoIpPrepperTest {
     private static final String TEST_SPAN_BAD_TARGET_FIELD = "doesnt.exist.client@ip";
     private static final String TEST_LOCATION_FIELD_NAME = "locationData";
     private static final String[] TEST_DESIRED_FIELDS = {"city_name", "country_name", "region_name"};
-
-    private static final LocationData TEST_LOCATION_DATA = new LocationData.builder().withCountry("United Kingdom")
+    private static final LocationData TEST_LOCATION_DATA = new LocationData.Builder().withCountry("United Kingdom")
             .withRegion("West Berkshire").withCity("Boxford").build();
-
     final PluginSetting testPluginSetting = new PluginSetting(
             PLUGIN_NAME,
             new HashMap<String, Object>() {{
@@ -55,7 +52,6 @@ public class GeoIpPrepperTest {
                 put(GeoIpPrepperConfig.TARGET_FIELD, TEST_SPAN_TARGET_FIELD);
                 put(GeoIpPrepperConfig.DATA_SOURCE, PROVIDER_TYPE);
                 put(GeoIpPrepperConfig.DESIRED_FIELDS, TEST_DESIRED_FIELDS);
-
             }}
     ) {{
         setPipelineName(TEST_PIPELINE_NAME);

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepperTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepperTest.java
@@ -2,7 +2,7 @@ package com.amazon.dataprepper.plugins.prepper.geoip;
 
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
-import com.amazon.dataprepper.plugins.prepper.geoip.provider.Fields;
+import com.amazon.dataprepper.plugins.prepper.geoip.provider.GeoDataField;
 import com.amazon.dataprepper.plugins.prepper.geoip.provider.GeoIpProvider;
 import com.amazon.dataprepper.plugins.prepper.geoip.provider.LocationData;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class GeoIpPrepperTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {};
     private static final String TEST_PIPELINE_NAME = "testPipelineName";
     private static final String PLUGIN_NAME = "geoip_prepper";
     private static final String PROVIDER_TYPE = "MaxMindGeolite2CityDatabase";
@@ -44,10 +45,10 @@ public class GeoIpPrepperTest {
     private static final String[] TEST_DESIRED_FIELDS = {"city_name", "country_name", "region_name"};
 
 
-    private static final LocationData TEST_LOCATION_DATA = new LocationData(new HashMap<Fields, Object>() {{
-        put(Fields.COUNTRY_NAME, "United Kingdom");
-        put(Fields.REGION_NAME, "West Berkshire");
-        put(Fields.CITY_NAME, "Boxford");
+    private static final LocationData TEST_LOCATION_DATA = new LocationData(new HashMap<GeoDataField, Object>() {{
+        put(GeoDataField.COUNTRY_NAME, "United Kingdom");
+        put(GeoDataField.REGION_NAME, "West Berkshire");
+        put(GeoDataField.CITY_NAME, "Boxford");
     }});
     final PluginSetting testPluginSetting = new PluginSetting(
             PLUGIN_NAME,
@@ -94,9 +95,10 @@ public class GeoIpPrepperTest {
         Record<String> recordOut = recordsOut.get(0);
         Map<String, Object> rawSpanMap = OBJECT_MAPPER.readValue(recordOut.getData(), new TypeReference<Map<String, Object>>() {
         });
-        Assertions.assertEquals(TEST_LOCATION_DATA.toMap().get(Fields.CITY_NAME.fieldName()), rawSpanMap.get(Fields.CITY_NAME.fieldName()));
-        Assertions.assertEquals(TEST_LOCATION_DATA.toMap().get(Fields.REGION_NAME.fieldName()), rawSpanMap.get(Fields.REGION_NAME.fieldName()));
-        Assertions.assertEquals(TEST_LOCATION_DATA.toMap().get(Fields.COUNTRY_NAME.fieldName()), rawSpanMap.get(Fields.COUNTRY_NAME.fieldName()));
+        Map<String, Object> testLocationDataMap = OBJECT_MAPPER.convertValue(TEST_LOCATION_DATA, MAP_TYPE_REFERENCE);
+        Assertions.assertEquals(testLocationDataMap.get(GeoDataField.CITY_NAME.fieldName()), rawSpanMap.get(GeoDataField.CITY_NAME.fieldName()));
+        Assertions.assertEquals(testLocationDataMap.get(GeoDataField.REGION_NAME.fieldName()), rawSpanMap.get(GeoDataField.REGION_NAME.fieldName()));
+        Assertions.assertEquals(testLocationDataMap.get(GeoDataField.COUNTRY_NAME.fieldName()), rawSpanMap.get(GeoDataField.COUNTRY_NAME.fieldName()));
     }
 
     @Test

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepperTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepperTest.java
@@ -2,7 +2,6 @@ package com.amazon.dataprepper.plugins.prepper.geoip;
 
 import com.amazon.dataprepper.model.configuration.PluginSetting;
 import com.amazon.dataprepper.model.record.Record;
-import com.amazon.dataprepper.plugins.prepper.geoip.provider.GeoDataField;
 import com.amazon.dataprepper.plugins.prepper.geoip.provider.GeoIpProvider;
 import com.amazon.dataprepper.plugins.prepper.geoip.provider.LocationData;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -42,9 +41,13 @@ public class GeoIpPrepperTest {
     private static final String TEST_SPAN_TARGET_FIELD = "resource.attributes.client@ip";
     private static final String TEST_SPAN_BAD_TARGET_FIELD = "doesnt.exist.client@ip";
     private static final String TEST_LOCATION_FIELD_NAME = "locationData";
-    private static final String[] TEST_DESIRED_FIELDS = {"city_name", "country_name", "region_name"};
+    private static final String CITY_NAME_FIELD = "city_name";
+    private static final String COUNTRY_NAME_FIELD = "country_name";
+    private static final String REGION_NAME_FIELD = "region_name";
+
+    private static final String[] TEST_DESIRED_FIELDS = {CITY_NAME_FIELD, COUNTRY_NAME_FIELD, REGION_NAME_FIELD};
     private static final LocationData TEST_LOCATION_DATA = new LocationData.Builder().withCountry("United Kingdom")
-            .withRegion("West Berkshire").withCity("Boxford").build();
+            .withRegion("West Berkshire").withCityName("Boxford").build();
     final PluginSetting testPluginSetting = new PluginSetting(
             PLUGIN_NAME,
             new HashMap<String, Object>() {{
@@ -90,9 +93,9 @@ public class GeoIpPrepperTest {
         Map<String, Object> rawSpanMap = OBJECT_MAPPER.readValue(recordOut.getData(), new TypeReference<Map<String, Object>>() {
         });
         Map<String, Object> testLocationDataMap = OBJECT_MAPPER.convertValue(TEST_LOCATION_DATA, MAP_TYPE_REFERENCE);
-        Assertions.assertEquals(testLocationDataMap.get(GeoDataField.CITY_NAME.fieldName()), rawSpanMap.get(GeoDataField.CITY_NAME.fieldName()));
-        Assertions.assertEquals(testLocationDataMap.get(GeoDataField.REGION_NAME.fieldName()), rawSpanMap.get(GeoDataField.REGION_NAME.fieldName()));
-        Assertions.assertEquals(testLocationDataMap.get(GeoDataField.COUNTRY_NAME.fieldName()), rawSpanMap.get(GeoDataField.COUNTRY_NAME.fieldName()));
+        Assertions.assertEquals(testLocationDataMap.get(CITY_NAME_FIELD), rawSpanMap.get(CITY_NAME_FIELD));
+        Assertions.assertEquals(testLocationDataMap.get(REGION_NAME_FIELD), rawSpanMap.get(REGION_NAME_FIELD));
+        Assertions.assertEquals(testLocationDataMap.get(COUNTRY_NAME_FIELD), rawSpanMap.get(REGION_NAME_FIELD));
     }
 
     @Test

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepperTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/GeoIpPrepperTest.java
@@ -32,7 +32,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class GeoIpPrepperTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {};
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {
+    };
     private static final String TEST_PIPELINE_NAME = "testPipelineName";
     private static final String PLUGIN_NAME = "geoip_prepper";
     private static final String PROVIDER_TYPE = "MaxMindGeolite2CityDatabase";
@@ -44,12 +45,9 @@ public class GeoIpPrepperTest {
     private static final String TEST_LOCATION_FIELD_NAME = "locationData";
     private static final String[] TEST_DESIRED_FIELDS = {"city_name", "country_name", "region_name"};
 
+    private static final LocationData TEST_LOCATION_DATA = new LocationData.builder().withCountry("United Kingdom")
+            .withRegion("West Berkshire").withCity("Boxford").build();
 
-    private static final LocationData TEST_LOCATION_DATA = new LocationData(new HashMap<GeoDataField, Object>() {{
-        put(GeoDataField.COUNTRY_NAME, "United Kingdom");
-        put(GeoDataField.REGION_NAME, "West Berkshire");
-        put(GeoDataField.CITY_NAME, "Boxford");
-    }});
     final PluginSetting testPluginSetting = new PluginSetting(
             PLUGIN_NAME,
             new HashMap<String, Object>() {{

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoIpProviderFactoryTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoIpProviderFactoryTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class GeoIpProviderFactoryTest {
 
     private static final String TEST_DATABASE_PATH = "./src/test/resources/GeoLite2-City-Test.mmdb";
+    private static final String[] TEST_DESIRED_FIELDS = {"city_name", "country_name", "location"};
 
     private PluginSetting pluginSetting;
 
@@ -25,6 +26,7 @@ public class GeoIpProviderFactoryTest {
                 "geoip",
                 new HashMap<String, Object>() {{
                     put(GeoIpPrepperConfig.DATABASE_PATH, TEST_DATABASE_PATH);
+                    put(GeoIpPrepperConfig.DESIRED_FIELDS, TEST_DESIRED_FIELDS);
                 }}
         );
     }

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationDataTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationDataTest.java
@@ -3,26 +3,34 @@ package com.amazon.dataprepper.plugins.prepper.geoip.provider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import java.util.HashMap;
 
 public class LocationDataTest {
-    private static final String TEST_TOSTRING_OUTPUT = "LocationData{countryName='a', subdivisionName='b', cityName='c'}";
     private static LocationData expectedLocation;
 
     @BeforeEach
     public void setup() {
-        expectedLocation = new LocationData("a", "b", "c");
+        expectedLocation = new LocationData(new HashMap<Fields, Object>() {{
+            put(Fields.COUNTRY_NAME, "a");
+            put(Fields.REGION_NAME, "b");
+            put(Fields.CITY_NAME, "c");
+        }});
 
     }
 
-    @Test
-    public void testToString() {
-        Assertions.assertEquals(TEST_TOSTRING_OUTPUT, expectedLocation.toString());
-    }
 
     @Test
     public void testEquals() {
-        LocationData equalLocation = new LocationData("a", "b", "c");
-        LocationData unequalLocation = new LocationData("a", "b", "f");
+        LocationData equalLocation = new LocationData(new HashMap<Fields, Object>() {{
+            put(Fields.COUNTRY_NAME, "a");
+            put(Fields.REGION_NAME, "b");
+            put(Fields.CITY_NAME, "c");
+        }});
+        LocationData unequalLocation = new LocationData(new HashMap<Fields, Object>() {{
+            put(Fields.COUNTRY_NAME, "d");
+            put(Fields.REGION_NAME, "e");
+            put(Fields.CITY_NAME, "f");
+        }});
 
         Assertions.assertEquals(expectedLocation, expectedLocation);
         Assertions.assertNotEquals(expectedLocation, null);

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationDataTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationDataTest.java
@@ -9,15 +9,15 @@ public class LocationDataTest {
 
     @BeforeEach
     public void setup() {
-        expectedLocation = new LocationData.Builder().withCountry("a").withRegion("b").withCity("c").build();
+        expectedLocation = new LocationData.Builder().withCountry("a").withRegion("b").withCityName("c").build();
 
 
     }
 
     @Test
     public void testEquals() {
-        LocationData equalLocation = new LocationData.Builder().withCountry("a").withRegion("b").withCity("c").build();
-        LocationData unequalLocation = new LocationData.Builder().withCountry("d").withRegion("e").withCity("f").build();
+        LocationData equalLocation = new LocationData.Builder().withCountry("a").withRegion("b").withCityName("c").build();
+        LocationData unequalLocation = new LocationData.Builder().withCountry("d").withRegion("e").withCityName("f").build();
 
         Assertions.assertEquals(expectedLocation, expectedLocation);
         Assertions.assertNotEquals(expectedLocation, null);

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationDataTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationDataTest.java
@@ -9,16 +9,15 @@ public class LocationDataTest {
 
     @BeforeEach
     public void setup() {
-        expectedLocation = new LocationData.builder().withCountry("a").withRegion("b").withCity("c").build();
+        expectedLocation = new LocationData.Builder().withCountry("a").withRegion("b").withCity("c").build();
 
 
     }
 
     @Test
     public void testEquals() {
-        LocationData equalLocation = new LocationData.builder().withCountry("a").withRegion("b").withCity("c").build();
-        LocationData unequalLocation = new LocationData.builder().withCountry("d").withRegion("e").withCity("f").build();
-
+        LocationData equalLocation = new LocationData.Builder().withCountry("a").withRegion("b").withCity("c").build();
+        LocationData unequalLocation = new LocationData.Builder().withCountry("d").withRegion("e").withCity("f").build();
 
         Assertions.assertEquals(expectedLocation, expectedLocation);
         Assertions.assertNotEquals(expectedLocation, null);

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationDataTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationDataTest.java
@@ -3,34 +3,22 @@ package com.amazon.dataprepper.plugins.prepper.geoip.provider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import java.util.HashMap;
 
 public class LocationDataTest {
     private static LocationData expectedLocation;
 
     @BeforeEach
     public void setup() {
-        expectedLocation = new LocationData(new HashMap<GeoDataField, Object>() {{
-            put(GeoDataField.COUNTRY_NAME, "a");
-            put(GeoDataField.REGION_NAME, "b");
-            put(GeoDataField.CITY_NAME, "c");
-        }});
+        expectedLocation = new LocationData.builder().withCountry("a").withRegion("b").withCity("c").build();
+
 
     }
 
-
     @Test
     public void testEquals() {
-        LocationData equalLocation = new LocationData(new HashMap<GeoDataField, Object>() {{
-            put(GeoDataField.COUNTRY_NAME, "a");
-            put(GeoDataField.REGION_NAME, "b");
-            put(GeoDataField.CITY_NAME, "c");
-        }});
-        LocationData unequalLocation = new LocationData(new HashMap<GeoDataField, Object>() {{
-            put(GeoDataField.COUNTRY_NAME, "d");
-            put(GeoDataField.REGION_NAME, "e");
-            put(GeoDataField.CITY_NAME, "f");
-        }});
+        LocationData equalLocation = new LocationData.builder().withCountry("a").withRegion("b").withCity("c").build();
+        LocationData unequalLocation = new LocationData.builder().withCountry("d").withRegion("e").withCity("f").build();
+
 
         Assertions.assertEquals(expectedLocation, expectedLocation);
         Assertions.assertNotEquals(expectedLocation, null);

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationDataTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationDataTest.java
@@ -9,15 +9,15 @@ public class LocationDataTest {
 
     @BeforeEach
     public void setup() {
-        expectedLocation = new LocationData.Builder().withCountry("a").withRegion("b").withCityName("c").build();
+        expectedLocation = new LocationData.Builder().withCountry("a").withRegionName("b").withCityName("c").build();
 
 
     }
 
     @Test
     public void testEquals() {
-        LocationData equalLocation = new LocationData.Builder().withCountry("a").withRegion("b").withCityName("c").build();
-        LocationData unequalLocation = new LocationData.Builder().withCountry("d").withRegion("e").withCityName("f").build();
+        LocationData equalLocation = new LocationData.Builder().withCountry("a").withRegionName("b").withCityName("c").build();
+        LocationData unequalLocation = new LocationData.Builder().withCountry("d").withRegionName("e").withCityName("f").build();
 
         Assertions.assertEquals(expectedLocation, expectedLocation);
         Assertions.assertNotEquals(expectedLocation, null);

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationDataTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/LocationDataTest.java
@@ -10,10 +10,10 @@ public class LocationDataTest {
 
     @BeforeEach
     public void setup() {
-        expectedLocation = new LocationData(new HashMap<Fields, Object>() {{
-            put(Fields.COUNTRY_NAME, "a");
-            put(Fields.REGION_NAME, "b");
-            put(Fields.CITY_NAME, "c");
+        expectedLocation = new LocationData(new HashMap<GeoDataField, Object>() {{
+            put(GeoDataField.COUNTRY_NAME, "a");
+            put(GeoDataField.REGION_NAME, "b");
+            put(GeoDataField.CITY_NAME, "c");
         }});
 
     }
@@ -21,15 +21,15 @@ public class LocationDataTest {
 
     @Test
     public void testEquals() {
-        LocationData equalLocation = new LocationData(new HashMap<Fields, Object>() {{
-            put(Fields.COUNTRY_NAME, "a");
-            put(Fields.REGION_NAME, "b");
-            put(Fields.CITY_NAME, "c");
+        LocationData equalLocation = new LocationData(new HashMap<GeoDataField, Object>() {{
+            put(GeoDataField.COUNTRY_NAME, "a");
+            put(GeoDataField.REGION_NAME, "b");
+            put(GeoDataField.CITY_NAME, "c");
         }});
-        LocationData unequalLocation = new LocationData(new HashMap<Fields, Object>() {{
-            put(Fields.COUNTRY_NAME, "d");
-            put(Fields.REGION_NAME, "e");
-            put(Fields.CITY_NAME, "f");
+        LocationData unequalLocation = new LocationData(new HashMap<GeoDataField, Object>() {{
+            put(GeoDataField.COUNTRY_NAME, "d");
+            put(GeoDataField.REGION_NAME, "e");
+            put(GeoDataField.CITY_NAME, "f");
         }});
 
         Assertions.assertEquals(expectedLocation, expectedLocation);

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import java.util.HashMap;
 
 public class MaxMindGeoIpProviderTest {
     private static final String TEST_DATABASE_PATH = "./src/test/resources/GeoLite2-City-Test.mmdb";
@@ -13,12 +14,25 @@ public class MaxMindGeoIpProviderTest {
 
     @BeforeAll
     public static void setup() {
-        maxMindGeoIpProvider = new MaxMindGeoIpProvider(TEST_DATABASE_PATH);
+        maxMindGeoIpProvider = new MaxMindGeoIpProvider(TEST_DATABASE_PATH, null);
     }
 
     @Test
     public void testIpLookup() {
-        LocationData locationData = new LocationData("United Kingdom", "West Berkshire", "Boxford");
+        LocationData locationData = new LocationData(new HashMap<Fields, Object>() {{
+            put(Fields.COUNTRY_NAME, "United Kingdom");
+            put(Fields.REGION_NAME, "West Berkshire");
+            put(Fields.CITY_NAME, "Boxford");
+            put(Fields.LOCATION, new Double[]{51.75, -1.25});
+            put(Fields.LATITUDE, 51.75);
+            put(Fields.LONGITUDE, -1.25);
+            put(Fields.IP, "2.125.160.216");
+            put(Fields.CONTINENT_CODE, "EU");
+            put(Fields.COUNTRY_CODE2, "GB");
+            put(Fields.REGION_CODE, "WBK");
+            put(Fields.POSTAL_CODE, "OX1");
+            put(Fields.TIMEZONE, "Europe/London");
+        }});
         Assertions.assertEquals(locationData, maxMindGeoIpProvider.getDataFromIp("2.125.160.216").orElse(null));
     }
 
@@ -34,11 +48,17 @@ public class MaxMindGeoIpProviderTest {
 
     @Test
     public void badDatabase() {
-        Assert.assertThrows(IllegalArgumentException.class, () -> new MaxMindGeoIpProvider(TEST_BAD_DATABASE_PATH));
+        Assert.assertThrows(IllegalArgumentException.class, () -> new MaxMindGeoIpProvider(TEST_BAD_DATABASE_PATH, null));
     }
 
     @Test
     public void wrongDatabase() {
-        Assert.assertThrows(IllegalArgumentException.class, () -> new MaxMindGeoIpProvider(TEST_WRONG_DATABASE_PATH));
+        Assert.assertThrows(IllegalArgumentException.class, () -> new MaxMindGeoIpProvider(TEST_WRONG_DATABASE_PATH, null));
+    }
+
+    @Test
+    public void wrongFields() {
+        MaxMindGeoIpProvider provider = new MaxMindGeoIpProvider(TEST_DATABASE_PATH, new String[]{"bad field"});
+        Assertions.assertFalse(provider.getDataFromIp("43.34.246.154").isPresent());
     }
 }

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
@@ -21,7 +21,7 @@ public class MaxMindGeoIpProviderTest {
     public void testIpLookup() throws JsonProcessingException {
         LocationData.Builder builder = new LocationData.Builder();
         builder.withCountry("United Kingdom").withRegion("West Berkshire")
-                .withCity("Boxford").withLocation(new Double[]{51.75, -1.25}).withLatitude(51.75).withLongitude(-1.25)
+                .withCityName("Boxford").withLocation(new Double[]{51.75, -1.25}).withLatitude(51.75).withLongitude(-1.25)
                 .withIp("2.125.160.216").withContinent("EU").withCountryCode("GB").withRegionCode("WBK")
                 .withPostal("OX1").withTimeZone("Europe/London");
         LocationData locationData = builder.build();

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
@@ -20,14 +20,12 @@ public class MaxMindGeoIpProviderTest {
 
     @Test
     public void testIpLookup() throws JsonProcessingException {
-        LocationData.builder builder = new LocationData.builder();
+        LocationData.Builder builder = new LocationData.Builder();
         builder.withCountry("United Kingdom").withRegion("West Berkshire")
                 .withCity("Boxford").withLocation(new Double[]{51.75, -1.25}).withLatitude(51.75).withLongitude(-1.25)
                 .withIp("2.125.160.216").withContinent("EU").withCountryCode("GB").withRegionCode("WBK")
                 .withPostal("OX1").withTimeZone("Europe/London");
         LocationData locationData = builder.build();
-        System.out.println(new ObjectMapper().writeValueAsString(locationData));
-        System.out.println(new ObjectMapper().writeValueAsString(maxMindGeoIpProvider.getDataFromIp("2.125.160.216").orElse(null)));
         Assertions.assertEquals(locationData, maxMindGeoIpProvider.getDataFromIp("2.125.160.216").orElse(null));
     }
 

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
@@ -19,19 +19,19 @@ public class MaxMindGeoIpProviderTest {
 
     @Test
     public void testIpLookup() {
-        LocationData locationData = new LocationData(new HashMap<Fields, Object>() {{
-            put(Fields.COUNTRY_NAME, "United Kingdom");
-            put(Fields.REGION_NAME, "West Berkshire");
-            put(Fields.CITY_NAME, "Boxford");
-            put(Fields.LOCATION, new Double[]{51.75, -1.25});
-            put(Fields.LATITUDE, 51.75);
-            put(Fields.LONGITUDE, -1.25);
-            put(Fields.IP, "2.125.160.216");
-            put(Fields.CONTINENT_CODE, "EU");
-            put(Fields.COUNTRY_CODE2, "GB");
-            put(Fields.REGION_CODE, "WBK");
-            put(Fields.POSTAL_CODE, "OX1");
-            put(Fields.TIMEZONE, "Europe/London");
+        LocationData locationData = new LocationData(new HashMap<GeoDataField, Object>() {{
+            put(GeoDataField.COUNTRY_NAME, "United Kingdom");
+            put(GeoDataField.REGION_NAME, "West Berkshire");
+            put(GeoDataField.CITY_NAME, "Boxford");
+            put(GeoDataField.LOCATION, new Double[]{51.75, -1.25});
+            put(GeoDataField.LATITUDE, 51.75);
+            put(GeoDataField.LONGITUDE, -1.25);
+            put(GeoDataField.IP, "2.125.160.216");
+            put(GeoDataField.CONTINENT_CODE, "EU");
+            put(GeoDataField.COUNTRY_ISO_CODE, "GB");
+            put(GeoDataField.REGION_CODE, "WBK");
+            put(GeoDataField.POSTAL_CODE, "OX1");
+            put(GeoDataField.TIMEZONE, "Europe/London");
         }});
         Assertions.assertEquals(locationData, maxMindGeoIpProvider.getDataFromIp("2.125.160.216").orElse(null));
     }

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
@@ -1,6 +1,5 @@
 package com.amazon.dataprepper.plugins.prepper.geoip.provider;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
@@ -1,10 +1,11 @@
 package com.amazon.dataprepper.plugins.prepper.geoip.provider;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import java.util.HashMap;
 
 public class MaxMindGeoIpProviderTest {
     private static final String TEST_DATABASE_PATH = "./src/test/resources/GeoLite2-City-Test.mmdb";
@@ -18,21 +19,15 @@ public class MaxMindGeoIpProviderTest {
     }
 
     @Test
-    public void testIpLookup() {
-        LocationData locationData = new LocationData(new HashMap<GeoDataField, Object>() {{
-            put(GeoDataField.COUNTRY_NAME, "United Kingdom");
-            put(GeoDataField.REGION_NAME, "West Berkshire");
-            put(GeoDataField.CITY_NAME, "Boxford");
-            put(GeoDataField.LOCATION, new Double[]{51.75, -1.25});
-            put(GeoDataField.LATITUDE, 51.75);
-            put(GeoDataField.LONGITUDE, -1.25);
-            put(GeoDataField.IP, "2.125.160.216");
-            put(GeoDataField.CONTINENT_CODE, "EU");
-            put(GeoDataField.COUNTRY_ISO_CODE, "GB");
-            put(GeoDataField.REGION_CODE, "WBK");
-            put(GeoDataField.POSTAL_CODE, "OX1");
-            put(GeoDataField.TIMEZONE, "Europe/London");
-        }});
+    public void testIpLookup() throws JsonProcessingException {
+        LocationData.builder builder = new LocationData.builder();
+        builder.withCountry("United Kingdom").withRegion("West Berkshire")
+                .withCity("Boxford").withLocation(new Double[]{51.75, -1.25}).withLatitude(51.75).withLongitude(-1.25)
+                .withIp("2.125.160.216").withContinent("EU").withCountryCode("GB").withRegionCode("WBK")
+                .withPostal("OX1").withTimeZone("Europe/London");
+        LocationData locationData = builder.build();
+        System.out.println(new ObjectMapper().writeValueAsString(locationData));
+        System.out.println(new ObjectMapper().writeValueAsString(maxMindGeoIpProvider.getDataFromIp("2.125.160.216").orElse(null)));
         Assertions.assertEquals(locationData, maxMindGeoIpProvider.getDataFromIp("2.125.160.216").orElse(null));
     }
 

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
@@ -1,7 +1,6 @@
 package com.amazon.dataprepper.plugins.prepper.geoip.provider;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;

--- a/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
+++ b/data-prepper-plugins/geoip-prepper/src/test/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/MaxMindGeoIpProviderTest.java
@@ -18,12 +18,12 @@ public class MaxMindGeoIpProviderTest {
     }
 
     @Test
-    public void testIpLookup() throws JsonProcessingException {
+    public void testIpLookup() {
         LocationData.Builder builder = new LocationData.Builder();
-        builder.withCountry("United Kingdom").withRegion("West Berkshire")
+        builder.withCountry("United Kingdom").withRegionName("West Berkshire")
                 .withCityName("Boxford").withLocation(new Double[]{51.75, -1.25}).withLatitude(51.75).withLongitude(-1.25)
                 .withIp("2.125.160.216").withContinent("EU").withCountryCode("GB").withRegionCode("WBK")
-                .withPostal("OX1").withTimeZone("Europe/London");
+                .withPostalCode("OX1").withTimeZone("Europe/London");
         LocationData locationData = builder.build();
         Assertions.assertEquals(locationData, maxMindGeoIpProvider.getDataFromIp("2.125.160.216").orElse(null));
     }


### PR DESCRIPTION
…friendly way. Also added support for users to choose what location fields they want.

Signed-off-by: Jonah Calvo <caljonah@amazon.com>

*Issue #, if available:*

- LocationData now utilizes a Fields enum to keep track of all possible fields
- A map of <Fields, Object> is passed to LocationData in the constructor, and fields are parsed from the map
- LocationData now has a toMap function that maps the fields to their proper names, which is used to apply the data to the document.
- GeoIpPrepperConfig has a new config variable, desired_fields, where an array of strings can be passed that contain the fields desired.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
