### PR TITLE
Updated hash ring vnode count to more evenly distribute load.

### DIFF
--- a/data-prepper-core/integrationTest.gradle
+++ b/data-prepper-core/integrationTest.gradle
@@ -170,9 +170,9 @@ task rawSpanEndToEndTest(type: Test) {
     dependsOn build
     dependsOn startOdfeDockerContainer
     def createDataPrepper1Task = createDataPrepperDockerContainer(
-            "rawSpanDataPrepper1", "data-prepper1", 21890, 4900, "/app/${RAW_SPAN_PIPELINE_YAML}")
+            "rawSpanDataPrepper1", "dataprepper1", 21890, 4900, "/app/${RAW_SPAN_PIPELINE_YAML}")
     def createDataPrepper2Task = createDataPrepperDockerContainer(
-            "rawSpanDataPrepper2", "data-prepper2", 21891, 4901, "/app/${RAW_SPAN_PIPELINE_YAML}")
+            "rawSpanDataPrepper2", "dataprepper2", 21891, 4901, "/app/${RAW_SPAN_PIPELINE_YAML}")
     def startDataPrepper1Task = startDataPrepperDockerContainer(createDataPrepper1Task as DockerCreateContainer)
     def startDataPrepper2Task = startDataPrepperDockerContainer(createDataPrepper2Task as DockerCreateContainer)
     dependsOn startDataPrepper1Task
@@ -207,9 +207,9 @@ task rawSpanCompatibilityEndToEndTest(type: Test) {
     dependsOn build
     dependsOn startOdfeDockerContainer
     def createDataPrepper1Task = createDataPrepperDockerContainer(
-            "rawSpanDataPrepperFromBuild", "data-prepper1", 21890, 4900, "/app/${RAW_SPAN_PIPELINE_LATEST_RELEASE_YAML}")
+            "rawSpanDataPrepperFromBuild", "dataprepper1", 21890, 4900, "/app/${RAW_SPAN_PIPELINE_LATEST_RELEASE_YAML}")
     def createDataPrepper2Task = createDataPrepperDockerContainerFromPullImage(
-            "rawSpanDataPrepperFromPull", "data-prepper2", 21891, 4901, "src/integrationTest/resources/${RAW_SPAN_PIPELINE_LATEST_RELEASE_YAML}")
+            "rawSpanDataPrepperFromPull", "dataprepper2", 21891, 4901, "src/integrationTest/resources/${RAW_SPAN_PIPELINE_LATEST_RELEASE_YAML}")
     def startDataPrepper1Task = startDataPrepperDockerContainer(createDataPrepper1Task as DockerCreateContainer)
     def startDataPrepper2Task = startDataPrepperDockerContainer(createDataPrepper2Task as DockerCreateContainer)
     dependsOn startDataPrepper1Task
@@ -244,9 +244,9 @@ task serviceMapEndToEndTest(type: Test) {
     dependsOn build
     dependsOn startOdfeDockerContainer
     def createDataPrepper1Task = createDataPrepperDockerContainer(
-            "serviceMapDataPrepper1", "data-prepper1", 21890, 4900, "/app/${SERVICE_MAP_PIPELINE_YAML}")
+            "serviceMapDataPrepper1", "dataprepper1", 21890, 4900, "/app/${SERVICE_MAP_PIPELINE_YAML}")
     def createDataPrepper2Task = createDataPrepperDockerContainer(
-            "serviceMapDataPrepper2", "data-prepper2", 21891, 4901, "/app/${SERVICE_MAP_PIPELINE_YAML}")
+            "serviceMapDataPrepper2", "dataprepper2", 21891, 4901, "/app/${SERVICE_MAP_PIPELINE_YAML}")
     def startDataPrepper1Task = startDataPrepperDockerContainer(createDataPrepper1Task as DockerCreateContainer)
     def startDataPrepper2Task = startDataPrepperDockerContainer(createDataPrepper2Task as DockerCreateContainer)
     dependsOn startDataPrepper1Task

--- a/data-prepper-core/src/integrationTest/resources/raw-span-e2e-pipeline-latest-release.yml
+++ b/data-prepper-core/src/integrationTest/resources/raw-span-e2e-pipeline-latest-release.yml
@@ -5,7 +5,7 @@ entry-pipeline:
   prepper:
     - peer_forwarder:
         discovery_mode: "static"
-        static_endpoints: ["data-prepper1", "data-prepper2"]
+        static_endpoints: ["dataprepper1", "dataprepper2"]
         ssl: false
   sink:
     - pipeline:

--- a/data-prepper-core/src/integrationTest/resources/service-map-e2e-pipeline.yml
+++ b/data-prepper-core/src/integrationTest/resources/service-map-e2e-pipeline.yml
@@ -5,7 +5,7 @@ entry-pipeline:
   prepper:
     - peer_forwarder:
         discovery_mode: "static"
-        static_endpoints: ["data-prepper1", "data-prepper2"]
+        static_endpoints: ["dataprepper1", "dataprepper2"]
         ssl: false
   sink:
     - pipeline:

--- a/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderConfig.java
+++ b/data-prepper-plugins/peer-forwarder/src/main/java/com/amazon/dataprepper/plugins/prepper/peerforwarder/PeerForwarderConfig.java
@@ -12,7 +12,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class PeerForwarderConfig {
     public static final String TIME_OUT = "time_out";
     public static final String MAX_NUM_SPANS_PER_REQUEST = "span_agg_count";
-    public static final int NUM_VIRTUAL_NODES = 10;
+    public static final int NUM_VIRTUAL_NODES = 128;
     public static final String TARGET_PORT = "target_port";
     public static final String DISCOVERY_MODE = "discovery_mode";
     public static final String DOMAIN_NAME = "domain_name";
@@ -23,6 +23,7 @@ public class PeerForwarderConfig {
     private static final String USE_ACM_CERT_FOR_SSL = "useAcmCertForSSL";
     private static final boolean DEFAULT_USE_ACM_CERT_FOR_SSL = false;
     private static final int DEFAULT_TARGET_PORT = 21890;
+    private static final int DEFAULT_TIMEOUT_SECONDS = 2;
     private static final String ACM_CERT_ISSUE_TIME_OUT_MILLIS = "acmCertIssueTimeOutMillis";
     private static final int DEFAULT_ACM_CERT_ISSUE_TIME_OUT_MILLIS = 120000;
     private static final String ACM_CERT_ARN = "acmCertificateArn";
@@ -84,7 +85,7 @@ public class PeerForwarderConfig {
         return new PeerForwarderConfig(
                 peerClientPool,
                 hashRing,
-                pluginSetting.getIntegerOrDefault(TIME_OUT, 3),
+                pluginSetting.getIntegerOrDefault(TIME_OUT, DEFAULT_TIMEOUT_SECONDS),
                 pluginSetting.getIntegerOrDefault(MAX_NUM_SPANS_PER_REQUEST, 48));
     }
 


### PR DESCRIPTION
Signed-off-by: Jeff Wright <74204404+wrijeff@users.noreply.github.com>

*Issue #, if available:*

*Description of changes:*
* Found previous vnode count (10) did not distribute load very evenly while load testing. Increasing the vnode count.

**Note:** This is a dangerous change in that clusters running old and new versions of Data Prepper will have inconsistent hash values due to the vnode change. This is why I had to slightly adjust the hostnames in the integration tests, so that the hash values would coincidentally line up between old and new DP versions (only in the test env). 

The alternative is to allow users to configure the vnode count and default it to 10, however in the long term I think providing yet another knob to configure is worse for usability.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
