### PR TITLE
Geoip prepper- Updated README, fixed bug when using default fields.

### DIFF
--- a/data-prepper-plugins/geoip-prepper/README.md
+++ b/data-prepper-plugins/geoip-prepper/README.md
@@ -1,5 +1,8 @@
 # GeoIP Prepper
+The GeoIP prepper can be included in pipelines to add geolocation data to documents based off an IP address. 
 
+## Supported Databases
+Currently, the prepper only supports MaxMind City databases. To reduce the size of the project, users should supply their own database file. A free version of the database can be found [here.](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data)
 
 ## Usages
 Example `.yaml` configuration
@@ -15,20 +18,14 @@ prepper:
 ## Configuration
 - target_field(required): A string representing the field on the documents in which IP should be read from.
 - database_path (required): A string representing the path to the database file. Currently, .mmdb files are supported. The Geolite2 City Database can be downloaded via [the MaxMind website](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data).
-- data_source (optional): A string representing the type of lookup to be performed. Currently, only [MaxMind City Databases](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data) are supported.
-- desired_fields (optional): An array of strings representing the fields to be appeneded to documents. Available fields are
+- data_source (optional): A string representing the type of lookup to be performed. Currently, the only valid option is MaxMindGeolite2CityDatabase. More lookup services could be added in the future.
+- desired_fields (optional): An array of strings representing the fields to be appended to the documents. Available fields are:
   - ip, city_name, country_name, continent_code, country_iso_code, postal_code, region_name, region_code, timezone, location, latitude, longitude
     
-  This value defaults to include all available fields.  
-## Metrics
-Apart from common metrics in [AbstractPrepper](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/AbstractPrepper.java), geoip-prepper introduces the following custom metrics.
-- Currently, the prepper tracks no additional metrics.
+  This value defaults to include all available fields.
 
-<!-- TODO add metrics -->
-
-### Counter
-
-
+## Location Details
+The "location" field is an object containing a latitude and longitude. The default index template provided with Data Prepper maps this field to a [geo_point type](https://www.elastic.co/guide/en/elasticsearch/reference/7.14/geo-point.html), which enables geospatial queries in Elasticsearch as well as fancy map visualizations in Kibana. 
 ## Developer Guide
 This plugin is compatible with Java 8. See
 - [CONTRIBUTING](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md)

--- a/data-prepper-plugins/geoip-prepper/README.md
+++ b/data-prepper-plugins/geoip-prepper/README.md
@@ -8,12 +8,18 @@ prepper:
     - geoip_prepper:
         target_field: "span.attributes.net@peer@ip"
         database_path: "path/to/database.mmdb
+        data_source: "MaxMindGeolite2CityDatabase"
+        desired_fields: ["location", "city_name", "country_name"]
 ```
 
 ## Configuration
 - target_field(required): A string representing the field on the documents in which IP should be read from.
 - database_path (required): A string representing the path to the database file. Currently, .mmdb files are supported. The Geolite2 City Database can be downloaded via [the MaxMind website](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data).
 - data_source (optional): A string representing the type of lookup to be performed. Currently, only [MaxMind City Databases](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data) are supported.
+- desired_fields (optional): An array of strings representing the fields to be appeneded to documents. Available fields are
+  - ip, city_name, country_name, continent_code, country_iso_code, postal_code, region_name, region_code, timezone, location, latitude, longitude
+    
+  This value defaults to include all available fields.  
 ## Metrics
 Apart from common metrics in [AbstractPrepper](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/data-prepper-api/src/main/java/com/amazon/dataprepper/model/prepper/AbstractPrepper.java), geoip-prepper introduces the following custom metrics.
 - Currently, the prepper tracks no additional metrics.

--- a/data-prepper-plugins/geoip-prepper/README.md
+++ b/data-prepper-plugins/geoip-prepper/README.md
@@ -1,5 +1,5 @@
 # GeoIP Prepper
-The GeoIP prepper can be included in pipelines to add geolocation data to documents based off an IP address. 
+The GeoIP prepper is a prepper plugin to add geolocation data to documents based off an IP address. 
 
 ## Supported Databases
 Currently, the prepper only supports MaxMind City databases. To reduce the size of the project, users should supply their own database file. A free version of the database can be found [here.](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data)
@@ -11,18 +11,18 @@ prepper:
     - geoip_prepper:
         target_field: "span.attributes.net@peer@ip"
         database_path: "path/to/database.mmdb
-        data_source: "MaxMindGeolite2CityDatabase"
         desired_fields: ["location", "city_name", "country_name"]
 ```
 
 ## Configuration
 - target_field(required): A string representing the field on the documents in which IP should be read from.
 - database_path (required): A string representing the path to the database file. Currently, .mmdb files are supported. The Geolite2 City Database can be downloaded via [the MaxMind website](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data).
-- data_source (optional): A string representing the type of lookup to be performed. Currently, the only valid option is MaxMindGeolite2CityDatabase. More lookup services could be added in the future.
 - desired_fields (optional): An array of strings representing the fields to be appended to the documents. Available fields are:
   - ip, city_name, country_name, continent_code, country_iso_code, postal_code, region_name, region_code, timezone, location, latitude, longitude
     
   This value defaults to include all available fields.
+
+<!TODO: Update when new data_sources are added>
 
 ## Location Details
 The "location" field is an object containing a latitude and longitude. The default index template provided with Data Prepper maps this field to a [geo_point type](https://www.elastic.co/guide/en/elasticsearch/reference/7.14/geo-point.html), which enables geospatial queries in Elasticsearch as well as fancy map visualizations in Kibana. 

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoIpProviderFactory.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoIpProviderFactory.java
@@ -24,7 +24,7 @@ public class GeoIpProviderFactory {
                 if (fields != null) {
                       desiredFields = fields.toArray(new String[0]);
                 } else {
-                    desiredFields = null;
+                    desiredFields = new String[]{};
                 }
                 Objects.requireNonNull(dbPath, "database_path must not be null when provider is MaxMind database");
                 return new MaxMindGeoIpProvider(dbPath, desiredFields);

--- a/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoIpProviderFactory.java
+++ b/data-prepper-plugins/geoip-prepper/src/main/java/com/amazon/dataprepper/plugins/prepper/geoip/provider/GeoIpProviderFactory.java
@@ -20,7 +20,12 @@ public class GeoIpProviderFactory {
                 String dbPath = pluginSetting.getStringOrDefault(GeoIpPrepperConfig.DATABASE_PATH, null);
                 @SuppressWarnings("unchecked")
                 final List<String> fields = (List<String>) pluginSetting.getAttributeFromSettings(GeoIpPrepperConfig.DESIRED_FIELDS);
-                String[] desiredFields = fields.toArray(new String[0]);
+                String[] desiredFields;
+                if (fields != null) {
+                      desiredFields = fields.toArray(new String[0]);
+                } else {
+                    desiredFields = null;
+                }
                 Objects.requireNonNull(dbPath, "database_path must not be null when provider is MaxMind database");
                 return new MaxMindGeoIpProvider(dbPath, desiredFields);
             default:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
README was updated for geoip-prepper.
Fixed a bug that caused the data-prepper to fail to start when no desired_fields were passed to the prepper.
-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
