### PR TITLE
Log4j 2.15 constraint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,15 @@ subprojects {
         testImplementation("junit:junit:4.13") {
             exclude group: 'org.hamcrest' // workaround for jarHell
         }
+        constraints {
+            implementation('org.apache.logging.log4j:log4j-core') {
+                version {
+                    require '2.15.0'
+                }
+                because 'Log4j 2.15.0 fixes CVE-2021-44228'
+            }
+        }
+
     }
     build.dependsOn test
     jacocoTestReport {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Ensures CVE-2021-44228 is applied everywhere.

Uses a Gradle constraint to ensure log4j-core is 2.15.0 minimum.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
