### PR TITLE
Updated log4j to 2.17.0 to fix CVE-2021-45105.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,25 +14,25 @@ subprojects {
     sourceCompatibility = '1.8'
     dependencies {
         implementation "com.google.guava:guava:29.0-jre"
-        implementation 'org.apache.logging.log4j:log4j-core:2.16.0'
+        implementation 'org.apache.logging.log4j:log4j-core:2.17.0'
         implementation "org.slf4j:slf4j-api:1.7.30"
-        implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.16.0'
+        implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
         testImplementation("junit:junit:4.13") {
             exclude group: 'org.hamcrest' // workaround for jarHell
         }
         constraints {
             implementation('org.apache.logging.log4j:log4j-core') {
                 version {
-                    require '2.16.0'
+                    require '2.17.0'
                 }
-                because 'Log4j 2.16.0 fixes CVE-2021-44228 and CVE-2021-45046'
+                because 'Log4j 2.17.0 fixes CVE-2021-44228, CVE-2021-45046, and CVE-2021-45105'
             }
-        }
-        implementation('org.apache.logging.log4j:log4j-api') {
-            version {
-                require '2.16.0'
+            implementation('org.apache.logging.log4j:log4j-api') {
+                version {
+                    require '2.17.0'
+                }
+                because 'the build fails if the Log4j API is not update along with log4j-core'
             }
-            because 'the build fails if the Log4j API is not update along with log4j-core'
         }
     }
     build.dependsOn test

--- a/data-prepper-plugins/elasticsearch/build.gradle
+++ b/data-prepper-plugins/elasticsearch/build.gradle
@@ -67,8 +67,8 @@ configurations.all {
         force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.12.3'
         force 'junit:junit:4.13'
         force "org.slf4j:slf4j-api:1.7.30"
-        force 'org.apache.logging.log4j:log4j-api:2.16.0'
-        force 'org.apache.logging.log4j:log4j-core:2.16.0'
+        force 'org.apache.logging.log4j:log4j-api:2.17.0'
+        force 'org.apache.logging.log4j:log4j-core:2.17.0'
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Updated log4j to 2.17.0 to fix CVE-2021-45105.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opendistro-for-elasticsearch/data-prepper/blob/main/CONTRIBUTING.md).
